### PR TITLE
Return 401 error when logged out

### DIFF
--- a/src/zero/api/handlers.clj
+++ b/src/zero/api/handlers.clj
@@ -55,7 +55,10 @@
         (if-let [jwt (some-> request :oauth2/access-tokens :google :id-token
                              decode-jwt valid?)]
           (handler (assoc request :jwt jwt))
-          (response/status (response/response "") 401))))))
+          (-> (response/response {:message "Unauthorized"})
+              (response/header "WWW-Authenticate" "Bearer realm=API access")
+              (response/content-type "application/json")
+              (response/status 401)))))))
 
 (defn succeed
   "A successful response with BODY."

--- a/src/zero/api/handlers.clj
+++ b/src/zero/api/handlers.clj
@@ -55,7 +55,7 @@
         (if-let [jwt (some-> request :oauth2/access-tokens :google :id-token
                              decode-jwt valid?)]
           (handler (assoc request :jwt jwt))
-          (response/redirect landing-uri))))))
+          (response/status (response/response "") 401))))))
 
 (defn succeed
   "A successful response with BODY."


### PR DESCRIPTION
### Purpose
Currently, if you are not logged in the WFL API returns a redirect response. However, swagger will return `{"status":"ok"}` in this case, presumably because the redirect was successful. This is confusing behavior because it makes it seem like the request itself was successful.

### Changes
Make the `authorize` function return a 401 error if a user is not logged in.

### Review Instructions
- No instructions.
