### PR TITLE
Update WGS endpoint response

### DIFF
--- a/src/zero/api/routes.clj
+++ b/src/zero/api/routes.clj
@@ -86,7 +86,7 @@
    ["/api/v1/wgs"
     {:post {:summary    "Submit WGS Reprocessing workflows"
             :parameters {:body ::wgs-request}
-            :responses  {200 {:body {:results seq?}}}
+            :responses  {200 {:body {:results vector?}}}
             :handler    (handlers/authorize handlers/submit-wgs)}}]
    ["/swagger.json"
     {:get {:no-doc true ;; exclude this endpoint itself from swagger

--- a/src/zero/module/wgs.clj
+++ b/src/zero/module/wgs.clj
@@ -163,13 +163,15 @@
   [environment in-bucket out-gs object]
   (let [path  (wdl/hack-unpack-resources-hack adapter-workflow-wdl)
         in-gs (gcs/gs-url in-bucket object)]
-    (cromwell/submit-workflow
-           environment
-           (io/file (:dir path) (path ".wdl"))
-           (io/file (:dir path) (path ".zip"))
-           (make-inputs environment out-gs in-gs)
-           (util/make-options environment)
-           cromwell-label-map)))
+    (let [workflow-id (cromwell/submit-workflow
+                        environment
+                        (io/file (:dir path) (path ".wdl"))
+                        (io/file (:dir path) (path ".zip"))
+                        (make-inputs environment out-gs in-gs)
+                        (util/make-options environment)
+                        cromwell-label-map)]
+      (prn workflow-id)
+      workflow-id)))
 
 (defn submit-some-workflows
   "Submit up to MAX workflows from IN-GS to OUT-GS in ENVIRONMENT."

--- a/src/zero/module/wgs.clj
+++ b/src/zero/module/wgs.clj
@@ -163,13 +163,13 @@
   [environment in-bucket out-gs object]
   (let [path  (wdl/hack-unpack-resources-hack adapter-workflow-wdl)
         in-gs (gcs/gs-url in-bucket object)]
-    (prn (cromwell/submit-workflow
+    (cromwell/submit-workflow
            environment
            (io/file (:dir path) (path ".wdl"))
            (io/file (:dir path) (path ".zip"))
            (make-inputs environment out-gs in-gs)
            (util/make-options environment)
-           cromwell-label-map))))
+           cromwell-label-map)))
 
 (defn submit-some-workflows
   "Submit up to MAX workflows from IN-GS to OUT-GS in ENVIRONMENT."
@@ -193,7 +193,7 @@
                         (remove done)
                         (take max)
                         (map (fn [base] (str base (suffix base)))))]
-        (run! (partial submit-workflow environment bucket slashified) more)))))
+        (mapv (partial submit-workflow environment bucket slashified) more)))))
 
 (defn run
   "Reprocess the BAM or CRAM files described by ARGS."


### PR DESCRIPTION
### Purpose
The expected response type of the `wgs` endpoint (seq) does not match what is returned by the handler (nil) which causes an error. Also if no information is returned about the workflows/workload that was started, then there is no way to track the progress of that work and test that it was successful.

### Changes
Update this endpoint to return a vector of workflow ids instead of nil. 

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

~Note: This breaks the command line so it's still a WIP~