### PR TITLE
GH-640: Add test for wgs endpoint

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -24,6 +24,7 @@
     [org.clojure/data.zip                    "0.1.3"]
     [org.clojure/java.jdbc                   "0.7.8"]
     [amperity/vault-clj                      "0.5.1"]
+    [buddy/buddy-sign                        "3.1.0"]
     [clj-commons/clj-yaml                    "0.7.0"]
     [clj-http                                "3.7.0"]
     [clj-time                                "0.15.1"]

--- a/deps.edn
+++ b/deps.edn
@@ -15,6 +15,7 @@
   org.clojure/data.zip              {:mvn/version "0.1.3"}
   org.clojure/java.jdbc             {:mvn/version "0.7.8"}
   amperity/vault-clj                {:mvn/version "0.5.1"}
+  buddy/buddy-sign                  {:mvn/version "3.1.0"}
   clj-commons/clj-yaml              {:mvn/version "0.7.0"}
   clj-http                          {:mvn/version "3.7.0"}
   clj-time                          {:mvn/version "0.15.1"}
@@ -83,4 +84,8 @@
 
   :uberjar {:extra-deps {uberdeps {:mvn/version "0.1.4"}}
             :main-opts  ["-m" "uberdeps.uberjar"]}
+
+  :integration
+  {:extra-paths ["integration", "resources"]
+   :main-opts ["-m" "zero.wgs-test"]}
   }}

--- a/integration/zero/wgs_test.clj
+++ b/integration/zero/wgs_test.clj
@@ -1,0 +1,52 @@
+(ns zero.wgs-test
+  (:require [clojure.data.json :as json]
+            [clojure.string :as str]
+            [buddy.sign.jwt :as jwt]
+            [zero.service.cromwell :as cromwell]
+            [zero.environments :as env]
+            [zero.util :as util]))
+
+(def wfl-url
+  "http://localhost:3000")
+
+(def test-input-path
+  "gs://broad-gotc-test-storage/single_sample/plumbing/bams/2m/")
+
+(def test-output-path
+  "gs://broad-gotc-dev-zero-test/wgs-test-output/")
+
+(def credentials-path
+  (get-in (env/stuff :gotc-dev) [:server :vault]))
+
+(defn create-jwt
+  []
+  (let [{:keys [oauth2_client_id oauth2_client_secret]}
+        (util/vault-secrets credentials-path)
+        iat (quot (System/currentTimeMillis) 1000)
+        exp (+ iat 3600000)
+        payload {:hd    "broadinstitute.org"
+                 :iss   "https://accounts.google.com"
+                 :aud   oauth2_client_id
+                 :iat   iat
+                 :exp   exp
+                 :scope ["openid" "email"]}]
+    (jwt/sign payload oauth2_client_secret)))
+
+(defn start-wgs-workflow
+  [env max-string input-path output-path]
+  (-> {:method       :post
+       :url          (str wfl-url "/api/v1/wgs")
+       :content-type :application/json
+       :headers      {"Authorization" (str "Bearer " (create-jwt))}
+       :body         (json/write-str {:environment env
+                                      :max         max-string
+                                      :input_path  input-path
+                                      :output_path output-path})}
+      cromwell/request-json :body :results))
+
+(defn -main
+  [& args]
+  (let [workflow-results (start-wgs-workflow "wgs-dev" "1" test-input-path test-output-path)
+        workflow-id (first workflow-results)
+        status (:status (cromwell/wait-for-workflow-complete :wgs-dev workflow-id))]
+    (print (str workflow-id "completed with status: " status))))

--- a/integration/zero/wgs_test.clj
+++ b/integration/zero/wgs_test.clj
@@ -57,7 +57,7 @@
     (let [workflow-results (start-wgs-workflow env max input-path test-output-path)
           workflow-id (first workflow-results)
           status (:status (cromwell/wait-for-workflow-complete (keyword env) workflow-id))]
-      (println {:id workflow-id :status status})
+      (prn {workflow-id status})
       (gcs/delete-object test-output-path)
       (System/exit (if (= status "Succeeded") 0 1)))))
 

--- a/integration/zero/wgs_test.clj
+++ b/integration/zero/wgs_test.clj
@@ -1,6 +1,6 @@
 (ns zero.wgs-test
-  (:require [clojure.data.json :as json]
-            [clojure.string :as str]
+  (:require [clojure.data.json  :as json]
+            [clojure.string     :as str]
             [buddy.sign.jwt :as jwt]
             [zero.service.cromwell :as cromwell]
             [zero.environments :as env]
@@ -49,4 +49,5 @@
   (let [workflow-results (start-wgs-workflow "wgs-dev" "1" test-input-path test-output-path)
         workflow-id (first workflow-results)
         status (:status (cromwell/wait-for-workflow-complete :wgs-dev workflow-id))]
-    (print (str workflow-id "completed with status: " status))))
+    (println (str workflow-id ": " status))
+    (if (= status "Succeeded") (System/exit 0) (System/exit 1))))

--- a/integration/zero/wgs_test.clj
+++ b/integration/zero/wgs_test.clj
@@ -1,10 +1,11 @@
 (ns zero.wgs-test
-  (:require [clojure.data.json  :as json]
-            [clojure.string     :as str]
+  (:require [clojure.data.json :as json]
             [buddy.sign.jwt :as jwt]
             [zero.service.cromwell :as cromwell]
             [zero.environments :as env]
-            [zero.util :as util]))
+            [zero.service.gcs :as gcs]
+            [zero.util :as util])
+  (:import (java.util UUID)))
 
 (def wfl-url
   "http://localhost:3000")
@@ -13,7 +14,7 @@
   "gs://broad-gotc-test-storage/single_sample/plumbing/bams/2m/")
 
 (def test-output-path
-  "gs://broad-gotc-dev-zero-test/wgs-test-output/")
+  (str "gs://broad-gotc-dev-zero-test/wgs-test-output/" (UUID/randomUUID) "/"))
 
 (def credentials-path
   (get-in (env/stuff :gotc-dev) [:server :vault]))
@@ -46,6 +47,7 @@
 
 (defn -main
   [& args]
+  (gcs/create-object test-output-path)
   (let [workflow-results (start-wgs-workflow "wgs-dev" "1" test-input-path test-output-path)
         workflow-id (first workflow-results)
         status (:status (cromwell/wait-for-workflow-complete :wgs-dev workflow-id))]

--- a/integration/zero/wgs_test.clj
+++ b/integration/zero/wgs_test.clj
@@ -51,5 +51,5 @@
   (let [workflow-results (start-wgs-workflow "wgs-dev" "1" test-input-path test-output-path)
         workflow-id (first workflow-results)
         status (:status (cromwell/wait-for-workflow-complete :wgs-dev workflow-id))]
-    (println (str workflow-id ": " status))
-    (if (= status "Succeeded") (System/exit 0) (System/exit 1))))
+    (println {:id workflow-id :status status})
+    (System/exit (if (= status "Succeeded") 0 1))))

--- a/integration/zero/wgs_test.clj
+++ b/integration/zero/wgs_test.clj
@@ -52,4 +52,5 @@
         workflow-id (first workflow-results)
         status (:status (cromwell/wait-for-workflow-complete :wgs-dev workflow-id))]
     (println {:id workflow-id :status status})
+    (gcs/delete-object test-output-path)
     (System/exit (if (= status "Succeeded") 0 1))))

--- a/src/zero/service/cromwell.clj
+++ b/src/zero/service/cromwell.clj
@@ -273,14 +273,14 @@
       (recur (dec n) environment id))))
 
 (defn wait-for-workflow-complete
-  "Return status of workflow named by ID when it completes."
+  "Return metadata of workflow named by ID when it completes."
   [environment id]
   (work-around-cromwell-fail-bug 9 environment id)
   (loop [environment environment id id]
     (let [now (status environment id)]
       (if (and now (#{"Submitted" "Running"} now))
         (do (util/sleep-seconds 15) (recur environment id))
-        {:status (status environment id)}))))
+        (metadata environment id)))))
 
 (defn abort
   "Abort the workflow with ID run on Cromwell in ENVIRONMENT."

--- a/src/zero/service/cromwell.clj
+++ b/src/zero/service/cromwell.clj
@@ -273,14 +273,14 @@
       (recur (dec n) environment id))))
 
 (defn wait-for-workflow-complete
-  "Return metadata of workflow named by ID when it completes."
+  "Return status of workflow named by ID when it completes."
   [environment id]
   (work-around-cromwell-fail-bug 9 environment id)
   (loop [environment environment id id]
     (let [now (status environment id)]
       (if (and now (#{"Submitted" "Running"} now))
         (do (util/sleep-seconds 15) (recur environment id))
-        (metadata environment id)))))
+        {:status (status environment id)}))))
 
 (defn abort
   "Abort the workflow with ID run on Cromwell in ENVIRONMENT."

--- a/src/zero/service/gcs.clj
+++ b/src/zero/service/gcs.clj
@@ -193,6 +193,18 @@
   ([file url]
    (apply download-file file (parse-gs-url url))))
 
+(defn create-object
+  "Create OBJECT in BUCKET"
+  ([bucket object headers]
+   (http/request {:method  :post
+                  :url     (str upload-url bucket "/o")
+                  :query-params {:name object}
+                  :headers headers}))
+  ([bucket object]
+   (create-object bucket object (once/get-local-auth-header)))
+  ([url]
+   (apply create-object (parse-gs-url url))))
+
 (defn delete-object
   "Delete URL or OBJECT from BUCKET"
   ([bucket object headers]


### PR DESCRIPTION
### Purpose
Add an integration test that sends a request to the `wgs` endpoint and checks that the resulting test workflow succeeds: https://broadinstitute.atlassian.net/jira/software/projects/GH/boards/530?selectedIssue=GH-640

### Changes
Add a `wgs_test.clj` file that can be run with the command:
`clojure -A:integration <cromwell-env> <max> <input_path> <output_path>`

Note: `cromwell/wait-for-workflow-complete` gets the cromwell url out of the wfl `env`, which is why I included `resources` in the extra paths instead of just `integration`. There is probably a better way to do this...

To-Do:
- [x] Create temporary output directory and delete it after the test completes, otherwise wfl will see that a result already exists and will not run the test workflow

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
