### PR TITLE
[GH-707] Add DNS terraform config

### DIFF
--- a/deploy/gotc-dev/terraform/broad-gotc-dev-provider.tf
+++ b/deploy/gotc-dev/terraform/broad-gotc-dev-provider.tf
@@ -1,0 +1,18 @@
+# Configure the Google Cloud provider
+# Every google project that resources are going ot be created in will have its own
+#  google provider definition using the google project name as its alias so as to be
+#  clear
+
+provider "google" {
+  alias   = "broad-gotc-dev"
+  project = "broad-gotc-dev"
+  region  = var.region
+  version = "~> 3.2"
+}
+
+provider "google-beta" {
+  alias   = "broad-gotc-dev"
+  project = "broad-gotc-dev"
+  region  = var.region
+  version = "~> 3.2"
+}

--- a/deploy/gotc-dev/terraform/broad-gotc-dev-provider.tf
+++ b/deploy/gotc-dev/terraform/broad-gotc-dev-provider.tf
@@ -1,5 +1,5 @@
 # Configure the Google Cloud provider
-# Every google project that resources are going ot be created in will have its own
+# Every google project that resources are going to be created in will have its own
 #  google provider definition using the google project name as its alias so as to be
 #  clear
 

--- a/deploy/gotc-dev/terraform/dns.tf
+++ b/deploy/gotc-dev/terraform/dns.tf
@@ -1,0 +1,12 @@
+module "wfl-dns" {
+
+  source = "github.com/broadinstitute/gotc-deploy.git//terraform/auth_proxy?ref=tf_auth-proxy-0.0.1"
+
+  providers = {
+    google      = google.broad-gotc-dev
+    google-beta = google-beta.broad-gotc-dev
+  }
+  auth_proxy_dns_name    = "workflow-launcher"
+  auth_proxy_dns_zone    = "gotc-dev"
+  auth_proxy_dns_project = "broad-gotc-dev"
+}

--- a/deploy/gotc-dev/terraform/global_vars.tf
+++ b/deploy/gotc-dev/terraform/global_vars.tf
@@ -1,0 +1,5 @@
+variable "region" {
+  type        = string
+  default     = "us-central1"
+  description = "Default region"
+}


### PR DESCRIPTION
### Purpose
https://broadinstitute.atlassian.net/jira/software/projects/GH/boards/530?selectedIssue=GH-707

### Changes
Add terraform config to create a public IP address and DNS record for the WFL UI.

Note: This uses the same shared terraform state file as the auth proxies for the WFL & gotc-cromwell

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

Thoughts on the DNS name `workflow-launcher`? The one for the API is called `wfl-auth` but that can change as well.
