### PR TITLE
Ra master docker build n publish

### DIFF
--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -44,8 +44,12 @@ jobs:
       run: |
         echo "${{ secrets.dsde_pipelines_deploy_key }}" > ~/.ssh/dsde_pipelines_deploy_key
         echo "${{ secrets.pipeline_config_deploy_key }}" > ~/.ssh/pipeline_config_deploy_key
+        echo "${{ secrets.wfl_deploy_key }}" > ~/.ssh/wfl_deploy_key
+
         chmod 600 ~/.ssh/dsde_pipelines_deploy_key
         chmod 600 ~/.ssh/pipeline_config_deploy_key
+        chmod 600 ~/.ssh/wfl_deploy_key
+
         echo """
           Host dsde-pipelines.github.com
           HostName github.com
@@ -60,7 +64,8 @@ jobs:
           Host wfl.github.com
           HostName github.com
           User git
-          IdentityFile ~/.ssh/wfl_deployment_key""" > ~/.ssh/config
+          IdentityFile ~/.ssh/wfl_deploy_key""" > ~/.ssh/config
+        du -h ~/.ssh/dsde_pipelines_deploy_key
         cat ~/.ssh/config
         boot build
 

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -36,7 +36,9 @@ jobs:
     - name: setup-ssh-agent
       uses:  webfactory/ssh-agent@v0.2.0
       with:
-        ssh-private-key: ${{ secrets.dsde_pipelines_deploy_key }}
+        ssh-private-key: |
+          ${{ secrets.dsde_pipelines_deploy_key }}
+          ${{ secrets.pipeline_config_deploy_key }}
 
     - name: Build the WFL
       run: 

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -77,7 +77,7 @@ jobs:
         # build the tag to apply.
         # If this is built from a branch then use the format {BRANCH}-{(short) GITHUB_SHA}
         # else use the format {Build (defined in build.txt)}-{(short) GITHUB_SHA}
-        if [[ ${env.BRANCH_NAME} == "master" ]]
+        if [[ ${{ env.BRANCH_NAME }} == "master" ]]
         then
           TAG="$(cat build.txt)-${GITHUB_SHA::8}"
         else

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -1,4 +1,5 @@
 # This is a basic workflow to help you get started with Actions
+# Deployment keys for this gitaction may be found at secret/dsde/gotc/dev/ci/wfl_deploy_keys
 
 name: Build and Publish Docker
 
@@ -29,7 +30,13 @@ jobs:
     - name: Get Branch Name
       id: get_branch
       shell: bash
-      run: echo "##[set-output name=BRANCH_NAME;]$(echo ${GITHUB_REF#refs/heads/})"
+      run: |
+        BRANCH_NAME=$(echo ${GITHUB_HEAD_REF#refs/heads/})
+        if [ -z "${BRANCH_NAME}" ]
+        then
+          BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})
+        fi
+        echo "##[set-output name=BRANCH_NAME;]$(echo ${BRANCH_NAME})"
 
     - name: Install Clojure tools
       uses: DeLaGuardo/setup-clojure@2.0

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -47,6 +47,14 @@ jobs:
 
     - name: Build the WFL
       run: |
+        if [[ ${{ env.BRANCH_NAME }} == "master" ]]
+        then
+        TAG="$(cat build.txt)-${GITHUB_SHA::8}"
+        else
+        TAG="${{ env.BRANCH_NAME }}-${GITHUB_SHA::8}"
+        fi
+
+        echo "TAG IS = ${TAG}"
 #        mkdir -p ~/.ssh
 #
 #        echo "${{ secrets.dsde_pipelines_deploy_key }}" > ~/.ssh/dsde_pipelines_deploy_key
@@ -78,15 +86,13 @@ jobs:
 #        # build the tag to apply.
 #        # If this is built from a branch then use the format {BRANCH}-{(short) GITHUB_SHA}
 #        # else use the format {Build (defined in build.txt)}-{(short) GITHUB_SHA}
-        if [[ ${{ env.BRANCH_NAME }} == "master" ]]
-        then
-          TAG="$(cat build.txt)-${GITHUB_SHA::8}"
-        else
-          TAG="${{ env.BRANCH_NAME }}-${GITHUB_SHA::8}"
-        fi
-
-        echo "TAG IS = ${TAG}"
-
+#        if [[ ${{ env.BRANCH_NAME }} == "master" ]]
+#        then
+#          TAG="$(cat build.txt)-${GITHUB_SHA::8}"
+#        else
+#          TAG="${{ env.BRANCH_NAME }}-${GITHUB_SHA::8}"
+#        fi
+#
 #        # build the api image
 #        docker build . -t broadinstitute/workflow-launcher-api:${TAG}
 #

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -41,7 +41,7 @@ jobs:
           ${{ secrets.pipeline_config_deploy_key }}
           
     - name: Build the WFL
-      run: 
+      run: |
         ssh-add -l
         boot build
 

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -37,12 +37,12 @@ jobs:
       uses:  webfactory/ssh-agent@v0.2.0
       with:
         ssh-private-key: |
-          ${{ secrets.pipeline_config_deploy_key }}
           ${{ secrets.dsde_pipelines_deploy_key }}
+          ${{ secrets.pipeline_config_deploy_key }}
           
-
     - name: Build the WFL
       run: 
+        ssh-add -l
         boot build
 
 

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -57,7 +57,7 @@ jobs:
           User git
           IdentityFile ~/.ssh/pipeline_config_deploy_key""" > ~/.ssh/config
         cat ~/.ssh/config
-        boot build
+#        boot build
 
 
 

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -9,7 +9,6 @@ on:
   push:
     branches: 
       - master
-      - ra_master_docker_build_n_publish
   pull_request:
     branches: 
       - master

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -25,13 +25,6 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
-        
-    - name: Install Clojure tools
-      uses: DeLaGuardo/setup-clojure@2.0
-      with:
-        leiningen: 2.9.1
-        boot: 2.8.3
-        tools-deps: 1.10.1.469
 
     - name: Get Branch Name
       run: |
@@ -45,39 +38,46 @@ jobs:
         repo=$(jq --raw-output .pull_request.head.repo.name "$GITHUB_EVENT_PATH")
         echo ::set-env name=BRANCH_NAME::${ref}
 
+    - name: Install Clojure tools
+      uses: DeLaGuardo/setup-clojure@2.0
+      with:
+        leiningen: 2.9.1
+        boot: 2.8.3
+        tools-deps: 1.10.1.469
+
     - name: Build the WFL
       run: |
-        mkdir -p ~/.ssh
-
-        echo "${{ secrets.dsde_pipelines_deploy_key }}" > ~/.ssh/dsde_pipelines_deploy_key
-        echo "${{ secrets.pipeline_config_deploy_key }}" > ~/.ssh/pipeline_config_deploy_key
-        echo "${{ secrets.wfl_deploy_key }}" > ~/.ssh/wfl_deploy_key
-
-        chmod 600 ~/.ssh/dsde_pipelines_deploy_key
-        chmod 600 ~/.ssh/pipeline_config_deploy_key
-        chmod 600 ~/.ssh/wfl_deploy_key
-
-        echo """
-          Host dsde-pipelines.github.com
-          HostName github.com
-          User git
-          IdentityFile ~/.ssh/dsde_pipelines_deploy_key
-
-          Host pipeline-config.github.com
-          HostName github.com
-          User git
-          IdentityFile ~/.ssh/pipeline_config_deploy_key
-
-          Host wfl.github.com
-          HostName github.com
-          User git
-          IdentityFile ~/.ssh/wfl_deploy_key""" > ~/.ssh/config
-
-        boot build
-
-        # build the tag to apply.
-        # If this is built from a branch then use the format {BRANCH}-{(short) GITHUB_SHA}
-        # else use the format {Build (defined in build.txt)}-{(short) GITHUB_SHA}
+#        mkdir -p ~/.ssh
+#
+#        echo "${{ secrets.dsde_pipelines_deploy_key }}" > ~/.ssh/dsde_pipelines_deploy_key
+#        echo "${{ secrets.pipeline_config_deploy_key }}" > ~/.ssh/pipeline_config_deploy_key
+#        echo "${{ secrets.wfl_deploy_key }}" > ~/.ssh/wfl_deploy_key
+#
+#        chmod 600 ~/.ssh/dsde_pipelines_deploy_key
+#        chmod 600 ~/.ssh/pipeline_config_deploy_key
+#        chmod 600 ~/.ssh/wfl_deploy_key
+#
+#        echo """
+#          Host dsde-pipelines.github.com
+#          HostName github.com
+#          User git
+#          IdentityFile ~/.ssh/dsde_pipelines_deploy_key
+#
+#          Host pipeline-config.github.com
+#          HostName github.com
+#          User git
+#          IdentityFile ~/.ssh/pipeline_config_deploy_key
+#
+#          Host wfl.github.com
+#          HostName github.com
+#          User git
+#          IdentityFile ~/.ssh/wfl_deploy_key""" > ~/.ssh/config
+#
+#        boot build
+#
+#        # build the tag to apply.
+#        # If this is built from a branch then use the format {BRANCH}-{(short) GITHUB_SHA}
+#        # else use the format {Build (defined in build.txt)}-{(short) GITHUB_SHA}
         if [[ ${{ env.BRANCH_NAME }} == "master" ]]
         then
           TAG="$(cat build.txt)-${GITHUB_SHA::8}"
@@ -85,15 +85,17 @@ jobs:
           TAG="${{ env.BRANCH_NAME }}-${GITHUB_SHA::8}"
         fi
 
-        # build the api image
-        docker build . -t broadinstitute/workflow-launcher-api:${TAG}
+        echo "TAG IS = ${TAG}"
 
-        # build the ui image
-        docker build ui/. -t broadinstitute/workflow-launcher-ui:${TAG}
-
-        docker login --username "${{ secrets.dockerhub_username }}" --password "${{ secrets.dockerhub_password }}"
-
-        docker push broadinstitute/workflow-launcher-api:${TAG}
-
-        docker push broadinstitute/workflow-launcher-ui:${TAG}
+#        # build the api image
+#        docker build . -t broadinstitute/workflow-launcher-api:${TAG}
+#
+#        # build the ui image
+#        docker build ui/. -t broadinstitute/workflow-launcher-ui:${TAG}
+#
+#        docker login --username "${{ secrets.dockerhub_username }}" --password "${{ secrets.dockerhub_password }}"
+#
+#        docker push broadinstitute/workflow-launcher-api:${TAG}
+#
+#        docker push broadinstitute/workflow-launcher-ui:${TAG}
 

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -37,8 +37,9 @@ jobs:
       uses:  webfactory/ssh-agent@v0.2.0
       with:
         ssh-private-key: |
-          ${{ secrets.dsde_pipelines_deploy_key }}
           ${{ secrets.pipeline_config_deploy_key }}
+          ${{ secrets.dsde_pipelines_deploy_key }}
+          
 
     - name: Build the WFL
       run: 

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -8,9 +8,11 @@ on:
   push:
     branches: 
       - master
+      - ra_master_docker_build_n_publish
   pull_request:
     branches: 
       - master
+      - ra_master_docker_build_n_publish
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -38,10 +38,11 @@ jobs:
         action=$(jq --raw-output .action "$GITHUB_EVENT_PATH")
         merged=$(jq --raw-output .pull_request.merged "$GITHUB_EVENT_PATH")
 
+        echo "DEBUG -> action: $action merged: $merged"
+
         ref=$(jq --raw-output .pull_request.head.ref "$GITHUB_EVENT_PATH")
         owner=$(jq --raw-output .pull_request.head.repo.owner.login "$GITHUB_EVENT_PATH")
         repo=$(jq --raw-output .pull_request.head.repo.name "$GITHUB_EVENT_PATH")
-
         echo ::set-env name=BRANCH_NAME::${ref}
 
     - name: Build the WFL

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -43,7 +43,6 @@ jobs:
     - name: Build the WFL
       run: |
         mkdir -p ~/.ssh
-        ssh -T git@github.com
 
         echo "${{ secrets.dsde_pipelines_deploy_key }}" > ~/.ssh/dsde_pipelines_deploy_key
         echo "${{ secrets.pipeline_config_deploy_key }}" > ~/.ssh/pipeline_config_deploy_key

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -32,13 +32,6 @@ jobs:
         leiningen: 2.9.1
         boot: 2.8.3
         tools-deps: 1.10.1.469
-
-#    - name: setup-ssh-agent
-#      uses:  webfactory/ssh-agent@v0.2.0
-#      with:
-#        ssh-private-key: |
-#          ${{ secrets.dsde_pipelines_deploy_key }}
-#          ${{ secrets.pipeline_config_deploy_key }}
           
     - name: Build the WFL
       run: |
@@ -70,12 +63,34 @@ jobs:
 
         boot build
 
-    - name: Publish Docker
-      uses: elgohr/Publish-Docker-Github-Action@2.14
-      with:
-        # The name of the image you would like to push
-        name: broadinstitute/workflow-launcher-api
-        # The login username for the registry
-        username: "${{ secrets.dockerhub_username }}"
-        # The login password for the registry
-        password: "${{ secrets.dockerhub_password }}"
+        # build the api image
+        docker build . -t broadinstitute/workflow-launcher-api:${GITHUB_SHA}
+
+        # build the ui image
+        docker build ui/. -t broadinstitute/workflow-launcher-ui:${GITHUB_SHA}
+
+        docker login --username "${{ secrets.dockerhub_username }}" --password "${{ secrets.dockerhub_password }}"
+
+        docker push broadinstitute/workflow-launcher-api:${GITHUB_SHA}
+
+        docker push broadinstitute/workflow-launcher-ui:${GITHUB_SHA}
+
+#    - name: Publish Docker
+#      uses: elgohr/Publish-Docker-Github-Action@2.14
+#      with:
+#        # The name of the image you would like to push
+#        name: broadinstitute/workflow-launcher-api:${GITHUB_SHA}
+#        # The login username for the registry
+#        username: "${{ secrets.dockerhub_username }}"
+#        # The login password for the registry
+#        password: "${{ secrets.dockerhub_password }}"
+#
+#    - name: Publish Docker
+#      uses: elgohr/Publish-Docker-Github-Action@2.14
+#      with:
+#        # The name of the image you would like to push
+#        name: broadinstitute/workflow-launcher-ui:${GITHUB_SHA}
+#        # The login username for the registry
+#        username: "${{ secrets.dockerhub_username }}"
+#        # The login password for the registry
+#        password: "${{ secrets.dockerhub_password }}"

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -42,19 +42,11 @@ jobs:
           
     - name: Build the WFL
       run: |
-        cat <<EOF > ~/.ssh/config
-          Host dsde-pipelines
-          HostName github.com
-          User git
-          IdentityFile ~/.ssh/dsde_pipelines_deploy_key
-
-          Host pipeline-config
-          HostName github.com
-          User git
-          IdentityFile ~/.ssh/pipeline_config_deploy_key
-          EOF
+        echo "${{ secrets.dsde_pipelines_deploy_key }}" > ~/.ssh/dsde_pipelines_deploy_key
+        echo "${{ secrets.pipeline_config_deploy_key }}" > ~/.ssh/pipeline_config_deploy_key
+        chmod 600 ~/.ssh/dsde_pipelines_deploy_key
+        chmod 600 ~/.ssh/pipeline_config_deploy_key
         ls ~/.ssh
-        boot build
 
 
 #     - name: Publish Docker

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -40,7 +40,6 @@ jobs:
     - name: Install Clojure tools
       uses: DeLaGuardo/setup-clojure@2.0
       with:
-        leiningen: 2.9.1
         boot: 2.8.3
 
     - name: Build the WFL

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -41,8 +41,6 @@ jobs:
     - name: Build the WFL
       run: 
         boot build
-      env:
-        GITHUB_TOKEN: ${{ secrets.wfl_pat }}
 
 
 #     - name: Publish Docker

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -70,13 +70,12 @@ jobs:
 
         boot build
 
-
-     - name: Publish Docker
-       uses: elgohr/Publish-Docker-Github-Action@2.14
-       with:
-         # The name of the image you would like to push
-         name: broadinstitute/workflow-launcher-api
-         # The login username for the registry
-         username: "${{ secrets.dockerhub_username }}"
-         # The login password for the registry
-         password: "${{ secrets.dockerhub_password }}"
+    - name: Publish Docker
+      uses: elgohr/Publish-Docker-Github-Action@2.14
+      with:
+        # The name of the image you would like to push
+        name: broadinstitute/workflow-launcher-api
+        # The login username for the registry
+        username: "${{ secrets.dockerhub_username }}"
+        # The login password for the registry
+        password: "${{ secrets.dockerhub_password }}"

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -33,12 +33,12 @@ jobs:
         boot: 2.8.3
         tools-deps: 1.10.1.469
 
-    - name: setup-ssh-agent
-      uses:  webfactory/ssh-agent@v0.2.0
-      with:
-        ssh-private-key: |
-          ${{ secrets.dsde_pipelines_deploy_key }}
-          ${{ secrets.pipeline_config_deploy_key }}
+#    - name: setup-ssh-agent
+#      uses:  webfactory/ssh-agent@v0.2.0
+#      with:
+#        ssh-private-key: |
+#          ${{ secrets.dsde_pipelines_deploy_key }}
+#          ${{ secrets.pipeline_config_deploy_key }}
           
     - name: Build the WFL
       run: |

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -78,11 +78,17 @@ jobs:
         # build the tag to apply.
         # If this is built from a branch then use the format {BRANCH}-{(short) GITHUB_SHA}
         # else use the format {Build (defined in build.txt)}-{(short) GITHUB_SHA}
+
+        WFL_JAR_PATH="target/wfl-*.jar"
+        WFL_BASE="$(echo $WFL_JAR_PATH | sed 's=.*/==;s/\.[^.]*$//')"
+        WFL_VERSION="${WFL_BASE#*-}"
+        echo $WFL_VERSION
+
         if [[ ${{ steps.get_branch.outputs.BRANCH_NAME }} == "master" ]]
         then
-          TAG="$(cat build.txt)-${GITHUB_SHA::8}"
+          TAG="${WFL_VERSION}-${GITHUB_SHA::8}"
         else
-          TAG="${{ steps.get_branch.outputs.BRANCH_NAME }}-${GITHUB_SHA::8}"
+          TAG="${{ steps.get_branch.outputs.BRANCH_NAME }}-${WFL_VERSION}-${GITHUB_SHA::8}"
         fi
 
         # build the api image

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -1,0 +1,49 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Build and Publish Docker
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: 
+      - master
+  pull_request:
+    branches: 
+      - master
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+        
+    - name: Install Clojure tools
+      uses: DeLaGuardo/setup-clojure@2.0
+      with:
+        leiningen: 2.9.1
+        boot: 2.8.3
+        tools-deps: 1.10.1.469
+      
+    - name: Build the WFL
+      run: 
+        boot build
+      env:
+        GITHUB_TOKEN: ${{ secrets.wfl_pat }}
+
+
+#     - name: Publish Docker
+#       uses: elgohr/Publish-Docker-Github-Action@2.14
+#       with:
+#         # The name of the image you would like to push
+#         name: broadinstitute/workflow-launcher-api
+#         # The login username for the registry
+#         username: "${{ secrets.dockerhub_username }}"
+#         # The login password for the registry
+#         password: "${{ secrets.dockerhub_password }}"

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -46,7 +46,20 @@ jobs:
         echo "${{ secrets.pipeline_config_deploy_key }}" > ~/.ssh/pipeline_config_deploy_key
         chmod 600 ~/.ssh/dsde_pipelines_deploy_key
         chmod 600 ~/.ssh/pipeline_config_deploy_key
+        echo """
+          Host dsde-pipelines
+          HostName github.com
+          User git
+          IdentityFile ~/.ssh/dsde_pipelines_deploy_key
+
+          Host pipeline-config
+          HostName github.com
+          User git
+          IdentityFile ~/.ssh/pipeline_config_deploy_key""" > ~/.ssh/config
         ls ~/.ssh
+        boot build
+
+
 
 
 #     - name: Publish Docker

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -29,8 +29,8 @@ jobs:
     - name: Get Branch Name
       id: get_branch
       shell: bash
-      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-      
+      run: echo "##[set-output name=BRANCH_NAME;]$(echo ${GITHUB_REF#refs/heads/})"
+
 #      |
 #        action=$(jq --raw-output .action "$GITHUB_EVENT_PATH")
 #        merged=$(jq --raw-output .pull_request.merged "$GITHUB_EVENT_PATH")

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -31,17 +31,6 @@ jobs:
       shell: bash
       run: echo "##[set-output name=BRANCH_NAME;]$(echo ${GITHUB_REF#refs/heads/})"
 
-#      |
-#        action=$(jq --raw-output .action "$GITHUB_EVENT_PATH")
-#        merged=$(jq --raw-output .pull_request.merged "$GITHUB_EVENT_PATH")
-#
-#        echo "DEBUG -> action: $action merged: $merged"
-#
-#        ref=$(jq --raw-output .pull_request.head.ref "$GITHUB_EVENT_PATH")
-#        owner=$(jq --raw-output .pull_request.head.repo.owner.login "$GITHUB_EVENT_PATH")
-#        repo=$(jq --raw-output .pull_request.head.repo.name "$GITHUB_EVENT_PATH")
-#        echo ::set-output name=BRANCH_NAME::${ref}
-
     - name: Install Clojure tools
       uses: DeLaGuardo/setup-clojure@2.0
       with:
@@ -51,61 +40,53 @@ jobs:
 
     - name: Build the WFL
       run: |
+        mkdir -p ~/.ssh
+
+        echo "${{ secrets.dsde_pipelines_deploy_key }}" > ~/.ssh/dsde_pipelines_deploy_key
+        echo "${{ secrets.pipeline_config_deploy_key }}" > ~/.ssh/pipeline_config_deploy_key
+        echo "${{ secrets.wfl_deploy_key }}" > ~/.ssh/wfl_deploy_key
+
+        chmod 600 ~/.ssh/dsde_pipelines_deploy_key
+        chmod 600 ~/.ssh/pipeline_config_deploy_key
+        chmod 600 ~/.ssh/wfl_deploy_key
+
+        echo """
+          Host dsde-pipelines.github.com
+          HostName github.com
+          User git
+          IdentityFile ~/.ssh/dsde_pipelines_deploy_key
+
+          Host pipeline-config.github.com
+          HostName github.com
+          User git
+          IdentityFile ~/.ssh/pipeline_config_deploy_key
+
+          Host wfl.github.com
+          HostName github.com
+          User git
+          IdentityFile ~/.ssh/wfl_deploy_key""" > ~/.ssh/config
+
+        boot build
+
+        # build the tag to apply.
+        # If this is built from a branch then use the format {BRANCH}-{(short) GITHUB_SHA}
+        # else use the format {Build (defined in build.txt)}-{(short) GITHUB_SHA}
         if [[ ${{ steps.get_branch.outputs.BRANCH_NAME }} == "master" ]]
         then
-        TAG="$(cat build.txt)-${GITHUB_SHA::8}"
+          TAG="$(cat build.txt)-${GITHUB_SHA::8}"
         else
-        TAG="${{ steps.get_branch.outputs.BRANCH_NAME }}-${GITHUB_SHA::8}"
+          TAG="${{ steps.get_branch.outputs.BRANCH_NAME }}-${GITHUB_SHA::8}"
         fi
 
-        echo "TAG IS = ${TAG}"
-#        mkdir -p ~/.ssh
-#
-#        echo "${{ secrets.dsde_pipelines_deploy_key }}" > ~/.ssh/dsde_pipelines_deploy_key
-#        echo "${{ secrets.pipeline_config_deploy_key }}" > ~/.ssh/pipeline_config_deploy_key
-#        echo "${{ secrets.wfl_deploy_key }}" > ~/.ssh/wfl_deploy_key
-#
-#        chmod 600 ~/.ssh/dsde_pipelines_deploy_key
-#        chmod 600 ~/.ssh/pipeline_config_deploy_key
-#        chmod 600 ~/.ssh/wfl_deploy_key
-#
-#        echo """
-#          Host dsde-pipelines.github.com
-#          HostName github.com
-#          User git
-#          IdentityFile ~/.ssh/dsde_pipelines_deploy_key
-#
-#          Host pipeline-config.github.com
-#          HostName github.com
-#          User git
-#          IdentityFile ~/.ssh/pipeline_config_deploy_key
-#
-#          Host wfl.github.com
-#          HostName github.com
-#          User git
-#          IdentityFile ~/.ssh/wfl_deploy_key""" > ~/.ssh/config
-#
-#        boot build
-#
-#        # build the tag to apply.
-#        # If this is built from a branch then use the format {BRANCH}-{(short) GITHUB_SHA}
-#        # else use the format {Build (defined in build.txt)}-{(short) GITHUB_SHA}
-#        if [[ ${{ env.BRANCH_NAME }} == "master" ]]
-#        then
-#          TAG="$(cat build.txt)-${GITHUB_SHA::8}"
-#        else
-#          TAG="${{ env.BRANCH_NAME }}-${GITHUB_SHA::8}"
-#        fi
-#
-#        # build the api image
-#        docker build . -t broadinstitute/workflow-launcher-api:${TAG}
-#
-#        # build the ui image
-#        docker build ui/. -t broadinstitute/workflow-launcher-ui:${TAG}
-#
-#        docker login --username "${{ secrets.dockerhub_username }}" --password "${{ secrets.dockerhub_password }}"
-#
-#        docker push broadinstitute/workflow-launcher-api:${TAG}
-#
-#        docker push broadinstitute/workflow-launcher-ui:${TAG}
+        # build the api image
+        docker build . -t broadinstitute/workflow-launcher-api:${TAG}
+
+        # build the ui image
+        docker build ui/. -t broadinstitute/workflow-launcher-ui:${TAG}
+
+        docker login --username "${{ secrets.dockerhub_username }}" --password "${{ secrets.dockerhub_password }}"
+
+        docker push broadinstitute/workflow-launcher-api:${TAG}
+
+        docker push broadinstitute/workflow-launcher-ui:${TAG}
 

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -47,15 +47,20 @@ jobs:
         chmod 600 ~/.ssh/dsde_pipelines_deploy_key
         chmod 600 ~/.ssh/pipeline_config_deploy_key
         echo """
-          Host dsde-pipelines
+          Host dsde-pipelines.github.com
           HostName github.com
           User git
           IdentityFile ~/.ssh/dsde_pipelines_deploy_key
 
-          Host pipeline-config
+          Host pipeline-config.github.com
           HostName github.com
           User git
-          IdentityFile ~/.ssh/pipeline_config_deploy_key""" > ~/.ssh/config
+          IdentityFile ~/.ssh/pipeline_config_deploy_key
+
+          Host wfl.github.com
+          HostName github.com
+          User git
+          IdentityFile ~/.ssh/wfl_deployment_key""" > ~/.ssh/config
         cat ~/.ssh/config
         boot build
 

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -43,13 +43,9 @@ jobs:
     - name: Build the WFL
       run: |
         echo "${{ secrets.dsde_pipelines_deploy_key }}" > ~/.ssh/dsde_pipelines_deploy_key
-
         echo "${{ secrets.pipeline_config_deploy_key }}" > ~/.ssh/pipeline_config_deploy_key
-
         chmod 600 ~/.ssh/dsde_pipelines_deploy_key
-
         chmod 600 ~/.ssh/pipeline_config_deploy_key
-
         cat <<EOF > ~/.ssh/config
           Host dsde-pipelines
           HostName github.com
@@ -61,7 +57,7 @@ jobs:
           User git
           IdentityFile ~/.ssh/pipeline_config_deploy_key
           EOF
-
+        ls ~/.ssh
         boot build
 
 

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -42,8 +42,14 @@ jobs:
           
     - name: Build the WFL
       run: |
-        echo ${{ secrets.dsde_pipelines_deploy_key }} >> ~/.ssh/dsde_pipelines_deploy_key
-        echo ${{ secrets.pipeline_config_deploy_key }} >> ~/.ssh/pipeline_config_deploy_key
+        echo "${{ secrets.dsde_pipelines_deploy_key }}" > ~/.ssh/dsde_pipelines_deploy_key
+
+        echo "${{ secrets.pipeline_config_deploy_key }}" > ~/.ssh/pipeline_config_deploy_key
+
+        chmod 600 ~/.ssh/dsde_pipelines_deploy_key
+
+        chmod 600 ~/.ssh/pipeline_config_deploy_key
+
         cat <<EOF > ~/.ssh/config
           Host dsde-pipelines
           HostName github.com
@@ -55,6 +61,7 @@ jobs:
           User git
           IdentityFile ~/.ssh/pipeline_config_deploy_key
           EOF
+
         boot build
 
 

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -32,7 +32,12 @@ jobs:
         leiningen: 2.9.1
         boot: 2.8.3
         tools-deps: 1.10.1.469
-      
+
+    - name: setup-ssh-agent
+      uses:  webfactory/ssh-agent@v0.2.0
+      with:
+        ssh-private-key: ${{ secrets.dsde_pipelines_deploy_key }}
+
     - name: Build the WFL
       run: 
         boot build

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -27,6 +27,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Get Branch Name
+      id: get_branch
       run: |
         action=$(jq --raw-output .action "$GITHUB_EVENT_PATH")
         merged=$(jq --raw-output .pull_request.merged "$GITHUB_EVENT_PATH")
@@ -36,7 +37,7 @@ jobs:
         ref=$(jq --raw-output .pull_request.head.ref "$GITHUB_EVENT_PATH")
         owner=$(jq --raw-output .pull_request.head.repo.owner.login "$GITHUB_EVENT_PATH")
         repo=$(jq --raw-output .pull_request.head.repo.name "$GITHUB_EVENT_PATH")
-        echo ::set-env name=BRANCH_NAME::${ref}
+        echo ::set-output name=BRANCH_NAME::${ref}
 
     - name: Install Clojure tools
       uses: DeLaGuardo/setup-clojure@2.0
@@ -47,11 +48,11 @@ jobs:
 
     - name: Build the WFL
       run: |
-        if [[ ${{ env.BRANCH_NAME }} == "master" ]]
+        if [[ ${{ steps.get_branch.outputs.BRANCH_NAME }} == "master" ]]
         then
         TAG="$(cat build.txt)-${GITHUB_SHA::8}"
         else
-        TAG="${{ env.BRANCH_NAME }}-${GITHUB_SHA::8}"
+        TAG="${{ steps.get_branch.outputs.BRANCH_NAME }}-${GITHUB_SHA::8}"
         fi
 
         echo "TAG IS = ${TAG}"

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -57,9 +57,7 @@ jobs:
           User git
           IdentityFile ~/.ssh/pipeline_config_deploy_key""" > ~/.ssh/config
         cat ~/.ssh/config
-#        boot build
-
-
+        boot build
 
 
 #     - name: Publish Docker

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -56,7 +56,7 @@ jobs:
           HostName github.com
           User git
           IdentityFile ~/.ssh/pipeline_config_deploy_key""" > ~/.ssh/config
-        ls ~/.ssh
+        cat ~/.ssh/config
         boot build
 
 

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -42,7 +42,19 @@ jobs:
           
     - name: Build the WFL
       run: |
-        ssh-add -l
+        echo ${{ secrets.dsde_pipelines_deploy_key }} >> ~/.ssh/dsde_pipelines_deploy_key
+        echo ${{ secrets.pipeline_config_deploy_key }} >> ~/.ssh/pipeline_config_deploy_key
+        cat <<EOF > ~/.ssh/config
+Host dsde-pipelines
+HostName github.com
+User git
+IdentityFile ~/.ssh/dsde_pipelines_deploy_key
+
+Host pipeline-config
+HostName github.com
+User git
+IdentityFile ~/.ssh/pipeline_config_deploy_key
+EOF
         boot build
 
 

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -42,10 +42,6 @@ jobs:
           
     - name: Build the WFL
       run: |
-        echo "${{ secrets.dsde_pipelines_deploy_key }}" > ~/.ssh/dsde_pipelines_deploy_key
-        echo "${{ secrets.pipeline_config_deploy_key }}" > ~/.ssh/pipeline_config_deploy_key
-        chmod 600 ~/.ssh/dsde_pipelines_deploy_key
-        chmod 600 ~/.ssh/pipeline_config_deploy_key
         cat <<EOF > ~/.ssh/config
           Host dsde-pipelines
           HostName github.com

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -45,16 +45,16 @@ jobs:
         echo ${{ secrets.dsde_pipelines_deploy_key }} >> ~/.ssh/dsde_pipelines_deploy_key
         echo ${{ secrets.pipeline_config_deploy_key }} >> ~/.ssh/pipeline_config_deploy_key
         cat <<EOF > ~/.ssh/config
-Host dsde-pipelines
-HostName github.com
-User git
-IdentityFile ~/.ssh/dsde_pipelines_deploy_key
+          Host dsde-pipelines
+          HostName github.com
+          User git
+          IdentityFile ~/.ssh/dsde_pipelines_deploy_key
 
-Host pipeline-config
-HostName github.com
-User git
-IdentityFile ~/.ssh/pipeline_config_deploy_key
-EOF
+          Host pipeline-config
+          HostName github.com
+          User git
+          IdentityFile ~/.ssh/pipeline_config_deploy_key
+          EOF
         boot build
 
 

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -32,7 +32,18 @@ jobs:
         leiningen: 2.9.1
         boot: 2.8.3
         tools-deps: 1.10.1.469
-          
+
+    - name: Get Branch Name
+      run: |
+        action=$(jq --raw-output .action "$GITHUB_EVENT_PATH")
+        merged=$(jq --raw-output .pull_request.merged "$GITHUB_EVENT_PATH")
+
+        ref=$(jq --raw-output .pull_request.head.ref "$GITHUB_EVENT_PATH")
+        owner=$(jq --raw-output .pull_request.head.repo.owner.login "$GITHUB_EVENT_PATH")
+        repo=$(jq --raw-output .pull_request.head.repo.name "$GITHUB_EVENT_PATH")
+
+        echo ::set-env name=BRANCH_NAME::${ref}
+
     - name: Build the WFL
       run: |
         mkdir -p ~/.ssh
@@ -63,34 +74,25 @@ jobs:
 
         boot build
 
+        # build the tag to apply.
+        # If this is built from a branch then use the format {BRANCH}-{(short) GITHUB_SHA}
+        # else use the format {Build (defined in build.txt)}-{(short) GITHUB_SHA}
+        if [[ ${env.BRANCH_NAME} == "master" ]]
+        then
+          TAG="$(cat build.txt)-${GITHUB_SHA::8}"
+        else
+          TAG="${{ env.BRANCH_NAME }}-${GITHUB_SHA::8}"
+        fi
+
         # build the api image
-        docker build . -t broadinstitute/workflow-launcher-api:${GITHUB_SHA}
+        docker build . -t broadinstitute/workflow-launcher-api:${TAG}
 
         # build the ui image
-        docker build ui/. -t broadinstitute/workflow-launcher-ui:${GITHUB_SHA}
+        docker build ui/. -t broadinstitute/workflow-launcher-ui:${TAG}
 
         docker login --username "${{ secrets.dockerhub_username }}" --password "${{ secrets.dockerhub_password }}"
 
-        docker push broadinstitute/workflow-launcher-api:${GITHUB_SHA}
+        docker push broadinstitute/workflow-launcher-api:${TAG}
 
-        docker push broadinstitute/workflow-launcher-ui:${GITHUB_SHA}
+        docker push broadinstitute/workflow-launcher-ui:${TAG}
 
-#    - name: Publish Docker
-#      uses: elgohr/Publish-Docker-Github-Action@2.14
-#      with:
-#        # The name of the image you would like to push
-#        name: broadinstitute/workflow-launcher-api:${GITHUB_SHA}
-#        # The login username for the registry
-#        username: "${{ secrets.dockerhub_username }}"
-#        # The login password for the registry
-#        password: "${{ secrets.dockerhub_password }}"
-#
-#    - name: Publish Docker
-#      uses: elgohr/Publish-Docker-Github-Action@2.14
-#      with:
-#        # The name of the image you would like to push
-#        name: broadinstitute/workflow-launcher-ui:${GITHUB_SHA}
-#        # The login username for the registry
-#        username: "${{ secrets.dockerhub_username }}"
-#        # The login password for the registry
-#        password: "${{ secrets.dockerhub_password }}"

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -42,6 +42,9 @@ jobs:
           
     - name: Build the WFL
       run: |
+        mkdir -p ~/.ssh
+        ssh -T git@github.com
+
         echo "${{ secrets.dsde_pipelines_deploy_key }}" > ~/.ssh/dsde_pipelines_deploy_key
         echo "${{ secrets.pipeline_config_deploy_key }}" > ~/.ssh/pipeline_config_deploy_key
         echo "${{ secrets.wfl_deploy_key }}" > ~/.ssh/wfl_deploy_key

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -67,17 +67,16 @@ jobs:
           HostName github.com
           User git
           IdentityFile ~/.ssh/wfl_deploy_key""" > ~/.ssh/config
-        du -h ~/.ssh/dsde_pipelines_deploy_key
-        cat ~/.ssh/config
+
         boot build
 
 
-#     - name: Publish Docker
-#       uses: elgohr/Publish-Docker-Github-Action@2.14
-#       with:
-#         # The name of the image you would like to push
-#         name: broadinstitute/workflow-launcher-api
-#         # The login username for the registry
-#         username: "${{ secrets.dockerhub_username }}"
-#         # The login password for the registry
-#         password: "${{ secrets.dockerhub_password }}"
+     - name: Publish Docker
+       uses: elgohr/Publish-Docker-Github-Action@2.14
+       with:
+         # The name of the image you would like to push
+         name: broadinstitute/workflow-launcher-api
+         # The login username for the registry
+         username: "${{ secrets.dockerhub_username }}"
+         # The login password for the registry
+         password: "${{ secrets.dockerhub_password }}"

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -28,16 +28,19 @@ jobs:
 
     - name: Get Branch Name
       id: get_branch
-      run: |
-        action=$(jq --raw-output .action "$GITHUB_EVENT_PATH")
-        merged=$(jq --raw-output .pull_request.merged "$GITHUB_EVENT_PATH")
-
-        echo "DEBUG -> action: $action merged: $merged"
-
-        ref=$(jq --raw-output .pull_request.head.ref "$GITHUB_EVENT_PATH")
-        owner=$(jq --raw-output .pull_request.head.repo.owner.login "$GITHUB_EVENT_PATH")
-        repo=$(jq --raw-output .pull_request.head.repo.name "$GITHUB_EVENT_PATH")
-        echo ::set-output name=BRANCH_NAME::${ref}
+      shell: bash
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      
+#      |
+#        action=$(jq --raw-output .action "$GITHUB_EVENT_PATH")
+#        merged=$(jq --raw-output .pull_request.merged "$GITHUB_EVENT_PATH")
+#
+#        echo "DEBUG -> action: $action merged: $merged"
+#
+#        ref=$(jq --raw-output .pull_request.head.ref "$GITHUB_EVENT_PATH")
+#        owner=$(jq --raw-output .pull_request.head.repo.owner.login "$GITHUB_EVENT_PATH")
+#        repo=$(jq --raw-output .pull_request.head.repo.name "$GITHUB_EVENT_PATH")
+#        echo ::set-output name=BRANCH_NAME::${ref}
 
     - name: Install Clojure tools
       uses: DeLaGuardo/setup-clojure@2.0

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -13,7 +13,6 @@ on:
   pull_request:
     branches: 
       - master
-      - ra_master_docker_build_n_publish
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -43,7 +42,6 @@ jobs:
       with:
         leiningen: 2.9.1
         boot: 2.8.3
-        tools-deps: 1.10.1.469
 
     - name: Build the WFL
       run: |

--- a/src/zero/boot.clj
+++ b/src/zero/boot.clj
@@ -78,9 +78,9 @@
       (io/make-parents (io/file tmp "Who cares, really?"))
 
       (try
-        (run! clone (vals zero/the-github-repos))
+        (run! clone (vals zero/the-other-github-repos))
         (catch Exception e
-          (run! clone (vals zero/the-other-github-repos))
+          (run! clone (vals zero/the-github-repos))
           )))
 
     (into {:tmp tmp}

--- a/src/zero/boot.clj
+++ b/src/zero/boot.clj
@@ -76,11 +76,19 @@
               (util/shell-io! "git" "-C" tmp "clone"
                               "--config" "advice.detachedHead=false" url))]
       (io/make-parents (io/file tmp "Who cares, really?"))
-      (run! clone (vals zero/the-github-repos)))
+
+      (try
+        (run! clone (vals zero/the-github-repos))
+        (catch Exception e
+          (run! clone (vals zero/the-other-github-repos))
+          )))
+
     (into {:tmp tmp}
           (for [repo (keys zero/the-github-repos)]
             (let [dir (str/join "/" [tmp repo])]
               [repo (util/shell! "git" "-C" dir "rev-parse" "HEAD")])))))
+(comment
+  (clone-repos))
 
 (defn cromwellify-wdl
   "Cromwellify the WDL from dsde-pipelines in CLONES to RESOURCES."

--- a/src/zero/zero.clj
+++ b/src/zero/zero.clj
@@ -20,6 +20,12 @@
         git   (partial str "git@github.com:broadinstitute/")]
     (zipmap repos (map git repos))))
 
+(def the-other-github-repos
+  "Map Zero source repo names to their URLs with aliases"
+  (let [repos ["wfl" "dsde-pipelines" "pipeline-config"]
+        git (fn [x] (str "git@" x ".github.com:broadinstitute/" x))]
+    (zipmap repos (map git repos))))
+
 (defn error-or-environment-keyword
   "Error string or the keyword for a valid ENVIRONMENT."
   [environment]

--- a/src/zero/zero.clj
+++ b/src/zero/zero.clj
@@ -17,7 +17,7 @@
 (def the-github-repos
   "Map Zero source repo names to their URLs"
   (let [repos ["wfl" "dsde-pipelines" "pipeline-config"]
-        git   (partial str "https://github.com/broadinstitute/")]
+        git   (partial str "git@github.com:broadinstitute/")]
     (zipmap repos (map git repos))))
 
 (defn error-or-environment-keyword


### PR DESCRIPTION
### Purpose
This PR is to create a gitaction that will build and publish the wdfl api and wfl ui docker images

Since deployment keys are unique, and we required all three repos involved to have a deployment key, a change had to be made to the clojure code which generates the URLs that are used to clone repos. This is now wrapped in a try/catch statement, which will first try the aliased URLs and then try the non-aliased URLs. We could have alternatively altered the code to allow the wfl repo to be cloned via the https URL and then use the SSH URL for the remaining repos, but that was a more involved change than this and so was considered less of an ideal solution.

### Review Instructions
Verify that the workflow succeeds and a new image is pushed to the location in dockerhub:
broadinstitute/workflow-launcher-api
broadinstitute/workflow-launcher-ui
