### PR TITLE
Docker build only on pushes to master branch

### DIFF
--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -9,9 +9,6 @@ on:
   push:
     branches: 
       - master
-  pull_request:
-    branches: 
-      - master
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- Our branch naming conventions are conflicting with the docker tag constraints.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- No changes.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
