### PR TITLE
Update auth headers

### DIFF
--- a/ui/src/store/modules/auth.js
+++ b/ui/src/store/modules/auth.js
@@ -13,11 +13,11 @@ const getters = {
 const actions = {
   login({ commit }, user) {
     const token = user.getAuthResponse(true).access_token
-    axios.defaults.headers.common.authentication = `Bearer ${token}`
+    axios.defaults.headers.common.Authorization = `Bearer ${token}`
     commit('updateUser', user)
   },
   logout({ commit }, user) {
-    axios.defaults.headers.common.authentication = ""
+    axios.defaults.headers.common.Authorization = ""
     commit('updateUser', user)
     sessionStorage.clear()
   }


### PR DESCRIPTION
### Purpose
Fix an error with the UI sending authenticated requests in the deployed WFL: `www-authenticate: Bearer error="invalid_request", error_description="No bearer token found in the request"`


### Changes
Set the "Authorization" headers for the auth proxy instead of "authentication" 🤔 

### Review Instructions
- No instructions.
