### PR TITLE
[GH-742] Additional UI fixes

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -20,6 +20,7 @@
 </template>
 
 <script>
+import axios from "axios";
 import TopBar from "./components/TopBar.vue";
 import SideBar from "./components/SideBar.vue";
 
@@ -48,6 +49,16 @@ export default {
         })
       });
     }
+    axios.interceptors.response.use(null, (error) => {
+      const unauthorized = (error.response && error.response.status === 401)
+      if(unauthorized && error.config) {
+        if(this.$store.getters['sidebar/getSideBar'] === true) {
+          this.toggleSideBar()
+        }
+        this.$router.push('/error')
+      }
+      return Promise.reject(error);
+    });
   }
 };
 </script>

--- a/ui/src/components/TopBar.vue
+++ b/ui/src/components/TopBar.vue
@@ -27,7 +27,7 @@
           <v-col cols="5">
             <v-row justify="end" align="center">
             <v-btn class="mr-2"  text >Status: {{ status.status }}</v-btn>
-            <v-btn class="mr-2"  outlined v-bind:href="swagger_link">Swagger API</v-btn>
+            <v-btn class="mr-2"  outlined v-if="isAuthenticated" v-bind:href="swagger_link">Swagger API</v-btn>
             <v-btn outlined v-if="isAuthenticated" v-on:click="logout">Logout</v-btn>
             </v-row>
           </v-col>

--- a/ui/src/components/TopBar.vue
+++ b/ui/src/components/TopBar.vue
@@ -62,7 +62,12 @@ export default {
   methods: {
     logout() {
       window.gapi.auth2.getAuthInstance().signOut().then(user => {
-        this.$store.dispatch('auth/logout', user).then(() => this.$router.push('/login'));
+        this.$store.dispatch('auth/logout', user).then(() => {
+          if(this.$store.getters['sidebar/getSideBar'] === true) {
+            this.toggleSideBar()
+          }
+          this.$router.push('/login')
+        });
       });
     },
     getStatus() {

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -43,6 +43,11 @@ const routes = [
     // this generates a separate chunk (modules.[hash].js) for this route
     // which is lazy-loaded when the route is visited.
     component: () => import(/* webpackChunkName: "modules" */ '../views/Modules.vue')
+  },
+  {
+    path: '/error',
+    name: 'error',
+    component: () => import(/* webpackChunkName: "modules" */ '../views/Error.vue')
   }
 ]
 

--- a/ui/src/views/Error.vue
+++ b/ui/src/views/Error.vue
@@ -1,0 +1,15 @@
+<template>
+  <v-container id="main-header" class="errorMessage">
+    <v-container fluid fill-width>
+      <h1>Access Denied</h1>
+      <p>The current user is not authorized to access this page.</p>
+    </v-container>
+  </v-container>
+</template>
+
+<script>
+export default {
+  name: "error",
+  components: {}
+};
+</script>


### PR DESCRIPTION
### Purpose
Fixes for https://broadinstitute.atlassian.net/browse/GH-742

### Changes
- If you click "logout" when the sidebar is toggled open, it should now close (previously it stayed open)
- If you get a 401 error, you will now see an error message:
<img width="1221" alt="Screen Shot 2020-05-06 at 4 08 51 PM" src="https://user-images.githubusercontent.com/6414394/81224135-39cfe580-8fb5-11ea-8bf2-6d2bfc506648.png">


### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

Note the new error page is hard-coded and very bare-bones at the moment, but we can iterate on this later to handle other possible errors!
