### PR TITLE
[GH-742] Fix showing error message

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -53,7 +53,7 @@ export default {
       const unauthorized = (error.response && error.response.status === 401)
       if(unauthorized && error.config) {
         if(this.$store.getters['sidebar/getSideBar'] === true) {
-          this.toggleSideBar()
+          this.$store.dispatch('sidebar/toggleSideBar')
         }
         this.$router.push('/error')
       }


### PR DESCRIPTION
### Purpose
The previous PR for fixes contained an error that prevented the redirect to the error page. Now if you get a 401 error in the WFL UI, it should redirect you to a page that says "Access Denied"  

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- No changes.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
