### PR TITLE
Create new temp directory for WDL hackery

### DIFF
--- a/src/zero/wdl.clj
+++ b/src/zero/wdl.clj
@@ -5,6 +5,8 @@
             [zero.util :as util]
             [zero.zero :as zero])
   (:import [java.io File FileNotFoundException]
+           [java.nio.file Files]
+           [java.nio.file.attribute FileAttribute]
            [java.util UUID]))
 
 (defn workflow-name
@@ -92,8 +94,7 @@
   (let [suffixes [".wdl" ".zip"]
         make     (partial str "zero/" (workflow-name wdl))
         path     (zipmap suffixes (map make suffixes))
-        dir      (io/file (System/getProperty "java.io.tmpdir"))]
-    (util/delete-tree dir)
+        dir      (.toFile (Files/createTempDirectory "wfl" (into-array FileAttribute nil)))]
     (doseq [resource (vals path)]
       (let [destination (io/file dir resource)]
         (io/make-parents destination)


### PR DESCRIPTION
### Purpose
WFL should not attempt to delete _ALL_ files in a users `java.io.tmpdir` directory. This directory is shared with many other applications, and wiping out all files here can be detrimental for users. If the user has a lot of tmp files, then WFL will appear to hang while `util/delete-tree` recursively deletes every file. Additionally, it can create problems for other applications that put their tmp files in this directory.

- No ticket is linked to this PR.

### Changes
Made WFL create a new temporary directory for its WDL hackery instead of using a shared tmp directory and deleting everything in it.

### Review Instructions

- No instructions.
