### PR TITLE
use one test runner for wfl

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -75,11 +75,9 @@
   {:main-opts   ["-m" "zero.main"]}
 
   :test
-  {:extra-deps  {com.cognitect/test-runner
-                 {:git/url "https://github.com/cognitect-labs/test-runner"
-                  :sha     "cb96e80f6f3d3b307c59cbeb49bb0dcb3a2a780b"}}
-   :extra-paths ["test"]
-   :main-opts   ["-m" "cognitect.test-runner"]}
+  {:extra-deps  {lambdaisland/kaocha {:mvn/version "1.0.629"}}
+   :extra-paths ["resources", "test"]
+   :main-opts   ["-m" "kaocha.runner" "unittest"]}
 
   :uberjar {:extra-deps {uberdeps {:mvn/version "0.1.4"}}
             :main-opts  ["-m" "uberdeps.uberjar"]}
@@ -87,5 +85,5 @@
   :integration
   {:extra-paths ["resources", "integration"]
    :extra-deps  {lambdaisland/kaocha {:mvn/version "1.0.629"}}
-   :main-opts   ["-m" "kaocha.runner"]}
+   :main-opts   ["-m" "kaocha.runner" "integration"]}
   }}

--- a/tests.edn
+++ b/tests.edn
@@ -1,24 +1,16 @@
 #kaocha/v1
-    {:tests [{;; Every suite must have an :id
-              :id :integration
-
-              ;; Directories containing files under test. This is used to
-              ;; watch for changes, and when doing code coverage analysis
-              ;; through Cloverage. These directories are *not* automatically
-              ;; added to the classpath.
-              :source-paths ["src", "resources", "database"]
-
-              ;; Directories containing tests. These will automatically be
-              ;; added to the classpath when running this suite.
-              :test-paths ["integration"]
-
-              ;; Regex strings to determine whether a namespace contains
-              ;; tests. (use strings, not actual regexes, due to a limitation of Aero)
-              :ns-patterns ["-test$"]}]
+    {:tests [{:id           :unittest
+              :source-paths ["src", "resources"]
+              :test-paths   ["test"]
+              :ns-patterns  ["-test$"]}
+             {:id           :integration
+              :source-paths ["src", "resources"]
+              :test-paths   ["integration"]
+              :ns-patterns  ["-test$"]}]
 
      :plugins [
                :kaocha.plugin/print-invocations
-;               :kaocha.plugin/profiling
+;;               :kaocha.plugin/profiling
                ]
 
      ;; Colorize output (use ANSI escape sequences).
@@ -33,12 +25,12 @@
      ;; will make sure are loaded. When providing a vector of symbols, or pointing
      ;; at a var containing a vector, then kaocha will call all referenced functions
      ;; for reporting.
-;     :reporter    kaocha.report/documentation
+;;     :reporter    kaocha.report/documentation
 
      ;; Enable/disable output capturing.
      :capture-output? true
 
      ;; Plugin specific configuration. Show the 10 slowest tests of each type, rather
      ;; than only 3.
-;     :kaocha.plugin.profiling/count 3
+;;     :kaocha.plugin.profiling/count 3
 }


### PR DESCRIPTION
### Purpose
Use the same test runner for unittests and integration tests. There's no need to use two separate ones.

### Changes
1. Replace test runner in deps.edn
2. Add `unittest` identifier to tests.edn

Unit tests can still be run in the usual way:
````
clojure -A:test
````

### Open Questions
Should the integration and unit tests be combined under a common alias for convenience? I wonder if something like this is more useful:
````
clojure -A:test             # run all tests in wfl
clojure -A:unittest       # run all unit tests 
clojure -A:integration  # run all integration tests 
````
