### PR TITLE
Remove old "workloads" endpoint

### DIFF
--- a/src/zero/api/handlers.clj
+++ b/src/zero/api/handlers.clj
@@ -43,14 +43,6 @@
         query {:includeSubworkflows false :start start :end end}]
     (succeed {:results (cromwell/query env query)})))
 
-(defn list-workloads
-  "List workloads for environment in REQUEST."
-  [{:keys [parameters] :as _request}]
-  (succeed {:results (-> parameters
-                         :query :environment
-                         zero/throw-or-environment-keyword!
-                         (postgres/query :zero-db "SELECT * FROM workload"))}))
-
 (defn submit-wgs
   "Submit the WGS workload described in REQUEST."
   [{:keys [parameters] :as _request}]

--- a/src/zero/api/routes.clj
+++ b/src/zero/api/routes.clj
@@ -143,11 +143,6 @@
             :parameters {:query {:environment string?}}
             :responses {200 {:body {:total pos-int?}}}
             :handler handlers/status-counts}}]
-   ["/api/v1/workloads"
-    {:get {:summary "Get all workloads for a given environment"
-           :parameters {:query {:environment string?}}
-           :responses {200 {:body {:results seq?}}}
-           :handler handlers/list-workloads}}]
    ["/api/v1/wgs"
     {:post {:summary    "Submit WGS Reprocessing workflows"
             :parameters {:body ::wgs-request}


### PR DESCRIPTION
### Purpose
The newer `/api/v1/workload` endpoint has the same purpose.

### Changes
Remove the `api/v1/workloads` endpoint

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
