### PR TITLE
only print success when the command succeeded + tidy-ups

### DIFF
--- a/ops/cli.py
+++ b/ops/cli.py
@@ -23,7 +23,6 @@ import tempfile
 if sys.platform.lower() == "win32":
     os.system("color")
 
-
 class AvailableColors(Enum):
     GRAY = 90
     RED = 91
@@ -35,16 +34,30 @@ class AvailableColors(Enum):
     BLACK = 30
     DEFAULT = 39
 
-
-def dye_msg_with_color(msg: str, color: str) -> str:
+def _apply_color(color: str, message: str) -> str:
     """Dye message with color, fall back to default if it fails."""
     color_code = AvailableColors["DEFAULT"].value
     try:
         color_code = AvailableColors[color.upper()].value
     except KeyError:
         pass
-    return f"\033[{color_code}m{msg}\033[0m"
+    return f"\033[1;{color_code}m{message}\033[0m"
 
+def info(message: str):
+    """Log the info to stdout"""
+    print(_apply_color("default", message))
+
+def success(message: str):
+    """Log the success to stdout"""
+    print(_apply_color("green", message))
+
+def error(message: str):
+    """Log the error to stderr"""
+    print(_apply_color("red", message), file=sys.stderr)
+
+def warn(message: str):
+    """Log the warning to stdout"""
+    print(_apply_color("yellow", message))
 
 def registerableCLI(cls):
     """Class decorator to register methodss with @register into a set."""
@@ -55,19 +68,93 @@ def registerableCLI(cls):
             cls.registered_commands.add(name)
     return cls
 
-
 def register(func: Callable) -> Callable:
     """Method decorator to register CLI commands."""
     func.registered = True
     return func
 
+def shell(command: str):
+    """Run COMMAND in a subprocess."""
+    info(f"Running: {command}")
+    return subprocess.check_call(command, shell=True)
+
+def shell_unchecked(command: str):
+    """Run COMMAND in a subprocess and who cares whether it fails!"""
+    warn(f"Running unchecked: {command}")
+    return subprocess.call(command, shell=True)
+
+def clone_config_repo(dest: str, branch: str):
+    """Clone the gotc-deploy repo."""
+    info(f"=> Cloning gotc-deploy repo to {dest}, branch: {branch}")
+    git.Repo.clone_from(
+        url="git@github.com:broadinstitute/gotc-deploy.git",
+        to_path=dest,
+        branch=branch
+    )
+    success(f"[✔] Cloned gotc-deploy repo to {dest}")
+
+def render_ctmpl(ctmpl_file: str, **kwargs) -> int:
+    """Render a ctmpl file."""
+    info("=> Rendering ctmpl file {ctmpl_file}")
+    envs = ""
+    if kwargs:
+        for k, v in kwargs.items():
+            envs += f"-e {k}={v}"
+
+    info(f"=> Feeding variables: {envs}")
+    command = " ".join(['docker run -i --rm -v "$(pwd)":/working',
+                        '-v "$HOME"/.vault-token:/root/.vault-token',
+                        f'{envs}',
+                        'broadinstitute/dsde-toolbox:dev',
+                        '/usr/local/bin/render-ctmpls.sh -k',
+                        f'"{ctmpl_file}"'])
+
+    shell_unchecked(command)
+    success(f"[✔] Rendered file {ctmpl_file.split('.ctmpl')[0]}")
+
+def is_available(*commands: list):
+    for cmd in commands:
+        if not shutil.which(cmd):
+            error(f"=> {cmd} is not in PATH. Please install it!")
+
+def set_up_helm():
+    info("=> Setting up Helm charts")
+    ADD = " ".join(["helm repo add gotc-charts",
+                    "https://broadinstitute.github.io/gotc-helm-repo/"])
+    shell(ADD)
+    shell("helm repo update")
+    success("[✔] Set up Helm charts")
+
+def set_up_k8s(environment: str, namespace: str):
+    """Connect to K8S cluster and set up namespace."""
+    info(f"=> Setting up Kubernetes with namespace {namespace}.")
+
+    ZONE = "us-central1-a"
+    GCLOUD = " ".join(["gcloud container clusters get-credentials",
+                       f"gotc-{environment}-shared-{ZONE} --zone {ZONE}",
+                       f"--project broad-gotc-{environment}"])
+    shell(GCLOUD)
+
+    info("=> Setting up Kubernetes cluster context.")
+    context = f"gke_broad-gotc-{environment}_{ZONE}_gotc-{environment}-shared-{ZONE}"
+    shell(f"kubectl config use-context {context} --namespace={namespace}")
+    success(f"[✔] Set context to {context}.")
+    success(f"[✔] Set namespace to {namespace}.")
+
+def helm_deploy_wfl(values: str):
+    """Use Helm to deploy WFL to K8S using VALUES."""
+    info("=> Deploying to K8S cluster with Helm.")
+    info("=> This must run on a non-split VPN.")
+
+    shell(f"helm upgrade wfl-k8s gotc-charts/wfl -f {values} --install")
+    info("[✔] WFL is deployed. Run `kubectl get pods` for details.")
 
 @registerableCLI
 class CLI:
     def __init__(self):
         parser = argparse.ArgumentParser(
             description="Deploy the Workflow Launcher API and UI.",
-            usage=self._usage()
+            usage=self.usage()
         )
         parser.add_argument("command", help="command from above to run")
         if len(sys.argv[1:2]) == 0:
@@ -82,7 +169,7 @@ class CLI:
             return 1
         return getattr(self, args.command)(sys.argv[2:])
 
-    def _usage(self) -> str:
+    def usage(self) -> str:
         max = 0
         for command in sorted(self.registered_commands):
             if len(command) > max:
@@ -92,18 +179,6 @@ class CLI:
             msg += f"  {command}{' ' * (max - len(command))}"
             msg += f" |-> {getattr(self, command).__doc__}\n"
         return msg
-
-    @staticmethod
-    def _subprocess_call(command: str):
-        """Run COMMAND in a subprocess."""
-        print(f"Running: {command}")
-        return subprocess.check_call(command, shell=True)
-
-    @staticmethod
-    def _subprocess_call_unchecked(command: str):
-        """Run COMMAND in a subprocess and who cares whether it fails!"""
-        print(f"Running: {command}")
-        return subprocess.call(command, shell=True)
 
     @register
     def render(self, arguments: list) -> int:
@@ -115,140 +190,11 @@ class CLI:
         args = parser.parse_args(arguments)
         file = Path(args.file)
         assert file.exists() and file.is_file(), f"{file} is not valid!"
-        return CLI._render_ctmpl(ctmpl_file=str(file))
-
-    @staticmethod
-    def _clone_config_repo(dest: str, branch: str = "master"):
-        """Clone the gotc-deploy repo."""
-        print(
-            dye_msg_with_color(
-                msg=f"=> Cloning gotc-deploy repo to {dest}, branch: {branch}",
-                color="blue"
-            )
-        )
-        git.Repo.clone_from(
-            url="git@github.com:broadinstitute/gotc-deploy.git",
-            to_path=dest,
-            branch=branch
-        )
-        print(
-            dye_msg_with_color(
-                msg=f"[✔] Cloned gotc-deploy repo to {dest}", color="green"
-            )
-        )
+        render_ctmpl(ctmpl_file=str(file))
         return 0
 
-    @staticmethod
-    def _render_ctmpl(ctmpl_file: str, **kwargs) -> int:
-        """Render a ctmpl file."""
-        print(
-            dye_msg_with_color(
-                msg=f"=> Rendering ctmpl file {ctmpl_file}", color="blue"
-            )
-        )
-        envs = ""
-        if kwargs:
-            for k, v in kwargs.items():
-                envs += f"-e {k}={v}"
-            print(
-                dye_msg_with_color(
-                    msg=f"=> Feeding variables: {envs}", color="blue"
-                )
-            )
-        command = " ".join(['docker run -i --rm -v "$(pwd)":/working',
-                            '-v "$HOME"/.vault-token:/root/.vault-token',
-                            f'{envs}',
-                            'broadinstitute/dsde-toolbox:dev',
-                            '/usr/local/bin/render-ctmpls.sh -k',
-                            f'"{ctmpl_file}"'])
-        print(
-            dye_msg_with_color(
-                msg=f"[✔] Rendered file {ctmpl_file.split('.ctmpl')[0]}",
-                color="green"
-            )
-        )
-        CLI._subprocess_call_unchecked(command)
-
-    @staticmethod
-    def _is_available(*commands: list):
-        for cmd in commands:
-            if not shutil.which(cmd):
-                print(
-                    dye_msg_with_color(
-                        f"=> {cmd} is not in PATH. Please install it!",
-                        color="red"
-                    )
-                )
-
-    @staticmethod
-    def _set_up_helm() -> int:
-        print(dye_msg_with_color(msg="=> Setting up Helm charts", color="blue"))
-        ADD = " ".join(["helm repo add gotc-charts",
-                        "https://broadinstitute.github.io/gotc-helm-repo/"])
-        REPO = "helm repo update"
-        print(dye_msg_with_color(msg="[✔] Set up Helm charts", color="green"))
-        CLI._subprocess_call(ADD)
-        CLI._subprocess_call(REPO)
-
-    @staticmethod
-    def _set_up_k8s(environment: str = "dev", namespace: str = "") -> int:
-        """Connect to K8S cluster and set up namespace."""
-        nsorna = namespace or 'N/A'
-        print(
-            dye_msg_with_color(
-                msg=f"=> Setting up Kubernetes with namespace {nsorna}.",
-                color="blue",
-            )
-        )
-        ZONE = "us-central1-a"
-        GCLOUD = " ".join(["gcloud container clusters get-credentials",
-                           f"gotc-{environment}-shared-{ZONE} --zone {ZONE}",
-                           f"--project broad-gotc-{environment}"])
-        CLI._subprocess_call(GCLOUD)
-        print(
-            dye_msg_with_color(
-                msg="=> Setting up Kubernetes cluster context.", color="blue"
-            )
-        )
-        CONTEXT = "_".join([f"gke_broad-gotc-{environment}_{ZONE}",
-                            f"gotc-{environment}-shared-{ZONE}"])
-        CLI._subprocess_call(f"kubectl config use-context {CONTEXT}")
-        if namespace:
-            CLI._subprocess_call(
-                f"kubectl config set-context {CONTEXT} --namespace={namespace}"
-            )
-            print(
-                dye_msg_with_color(
-                    msg=f"[✔] Set namespace to {namespace}.", color="green"
-                )
-            )
-
-    @staticmethod
-    def _helm_deploy_wfl(values: str) -> int:
-        """Use Helm to deploy WFL to K8S using VALUES."""
-        print(
-            dye_msg_with_color(
-                msg="=> Deploying to K8S cluster with Helm.",
-                color="blue"
-            )
-        )
-        print(
-            dye_msg_with_color(
-                msg="=> This must run on a non-split VPN.",
-                color="blue"
-            )
-        )
-        UPGRADE = f"helm upgrade wfl-k8s gotc-charts/wfl -f {values} --install"
-        CLI._subprocess_call(UPGRADE)
-        print(
-            dye_msg_with_color(
-                msg="[✔] WFL is deployed. Run `kubectl get pods` for details.",
-                color="green"
-            )
-        )
-
     @register
-    def deploy(self, arguments):
+    def deploy(self, arguments) -> int:
         """Deploy WFL to Cloud GKE (VPN is required)"""
         parser = argparse.ArgumentParser(description=f"{self.deploy.__doc__}")
         parser.add_argument(
@@ -270,7 +216,7 @@ class CLI:
             "-n",
             "--namespace",
             dest="namespace",
-            default="",
+            default="default",
             help="Deploy to this namespace."
         )
         parser.add_argument(
@@ -281,22 +227,20 @@ class CLI:
             help="Deploy image with this tag in DockerHub."
         )
         args = parser.parse_args(arguments)
-        CLI._is_available("helm", "kubectl", "gcloud", "git", "docker")
-        CLI._set_up_helm()
-        CLI._set_up_k8s(namespace=args.namespace)
+        is_available("helm", "kubectl", "gcloud", "git", "docker")
+        set_up_helm()
+        set_up_k8s(environment=args.environment, namespace=args.namespace)
         with tempfile.TemporaryDirectory() as dir:
             pwd = os.getcwd()
             os.chdir(dir)
-            CLI._clone_config_repo(dest="gotc-deploy", branch=args.branch)
+            clone_config_repo(dest="gotc-deploy", branch=args.branch)
             values = "wfl-values.yaml"
             shutil.copy(f"gotc-deploy/deploy/gotc-dev/helm/{values}.ctmpl", dir)
-            CLI._render_ctmpl(
-                ctmpl_file=f"{values}.ctmpl", WFL_VERSION=args.tag
-            )
-            CLI._helm_deploy_wfl(values=values)
+            render_ctmpl(ctmpl_file=f"{values}.ctmpl", WFL_VERSION=args.tag)
+            helm_deploy_wfl(values=values)
             os.chdir(pwd)
-        print(dye_msg_with_color(msg="[✔] Deployment is done!", color="green"))
-
+        success("[✔] Deployment is done!")
+        return 0
 
 if __name__ == "__main__":
     c = CLI()


### PR DESCRIPTION
### Purpose
The logging in CLI doesn't match the state of the program. For example, we can log "success" when the command actually failed because success is printed before that command is evaluated.

Aim of this change is to tidy-up this behaviour. I also took the liberty of
- grouping together functions that are called in succession (e.g. `print` and `dye_message_with_color`).
- ensuring defaults are defined in one place
- removing unnecessary static methods 
