### PR TITLE
Use cljfmt for linting

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -44,24 +44,13 @@
 
  :aliases
 
- ;; HACK: 0.1.7 fails on any namespace with a docstring.
- ;; HACK: Use ,s to create a single shell argument.
- ;;
- {:clint
-  {:extra-deps  {jonase/eastwood {:mvn/version "0.3.6"}
-                 venantius/yagni {:mvn/version "0.1.7"}}
-   :extra-paths ["test"]
-   :main-opts   ["-m" "eastwood.lint"
-                 {:add-linters  #{#_:keyword-typos
-                                  :non-clojure-file
-                                  :non-dynamic-earmuffs
-                                  :unused-fn-args
-                                  :unused-locals
-                                  :unused-namespaces
-                                  :unused-private-vars}
-                  :cwd          "."
-                  :source-paths #{"src"}
-                  :test-paths   #{"test"}}]}
+ {:lint
+  {:extra-deps {cljfmt {:mvn/version "0.6.7"}}
+   :main-opts  ["-m" "cljfmt.main" "check"]}
+
+  :format
+  {:extra-deps {cljfmt {:mvn/version "0.6.7"}}
+   :main-opts  ["-m" "cljfmt.main" "fix"]}
 
   :kondo
   {:extra-deps {clj-kondo {:mvn/version "2020.02.28-1"}}

--- a/src/zero/api/handlers.clj
+++ b/src/zero/api/handlers.clj
@@ -80,11 +80,11 @@
     (let [{:keys [body]} parameters]
       (jdbc/with-db-transaction [tx (postgres/zero-db-config)]
         (->> body
-          (add-workload! tx)
-          :uuid
-          (conj ["SELECT * FROM workload WHERE uuid = ?"])
-          (jdbc/query tx)
-          first unnilify succeed)))))
+             (add-workload! tx)
+             :uuid
+             (conj ["SELECT * FROM workload WHERE uuid = ?"])
+             (jdbc/query tx)
+             first unnilify succeed)))))
 
 (defn get-workload
   "List all workloads or the workload with UUID in REQUEST."
@@ -103,14 +103,14 @@
     (letfn [(q [[left right]] (fn [it] (str left it right)))]
       (jdbc/with-db-transaction [tx (postgres/zero-db-config)]
         (->> uuids
-          (map :uuid)
-          (map (q "''")) (str/join ",") ((q "()"))
-          (format "SELECT * FROM workload WHERE uuid in %s")
-          (jdbc/query tx)
-          (run! (partial start-workload! tx)))
+             (map :uuid)
+             (map (q "''")) (str/join ",") ((q "()"))
+             (format "SELECT * FROM workload WHERE uuid in %s")
+             (jdbc/query tx)
+             (run! (partial start-workload! tx)))
         (->> uuids
-          (mapv (partial postgres/get-workload-for-uuid tx))
-          succeed)))))
+             (mapv (partial postgres/get-workload-for-uuid tx))
+             succeed)))))
 
 (def post-exec
   "Create and start workload described in BODY of REQUEST"

--- a/src/zero/api/routes.clj
+++ b/src/zero/api/routes.clj
@@ -119,8 +119,8 @@
    ["/version"
     {:get  {:summary "Get the versions of server and supported pipelines"
             :handler (handlers/success (let [versions (zero/get-the-version)
-                                             pipeline-versions-keys (keep (fn [x] (when (and (string? x) 
-                                                                                             (str/ends-with? x ".wdl")) x)) 
+                                             pipeline-versions-keys (keep (fn [x] (when (and (string? x)
+                                                                                             (str/ends-with? x ".wdl")) x))
                                                                           (keys versions))]
                                          {:pipeline-versions (select-keys versions pipeline-versions-keys)
                                           :version (apply dissoc versions pipeline-versions-keys)}))
@@ -178,21 +178,21 @@
 ;;
 (def routes
   (ring/ring-handler
-    (ring/router
-      endpoints
-      {:data {:coercion   reitit.coercion.spec/coercion
-              :muuntaja   muuntaja-core/instance
-              :middleware [parameters/parameters-middleware
-                           muuntaja/format-negotiate-middleware
-                           muuntaja/format-response-middleware
-                           exception/exception-middleware
-                           muuntaja/format-request-middleware
-                           coercion/coerce-response-middleware
-                           coercion/coerce-request-middleware
-                           coercion/coerce-exceptions-middleware
-                           multipart/multipart-middleware]}})
-    (ring/routes
-      (swagger-ui/create-swagger-ui-handler {:path "/swagger"
-                                             :url  "/swagger/swagger.json"
-                                             :root "swagger-ui"
-                                             :config {:jsonEditor false}}))))
+   (ring/router
+    endpoints
+    {:data {:coercion   reitit.coercion.spec/coercion
+            :muuntaja   muuntaja-core/instance
+            :middleware [parameters/parameters-middleware
+                         muuntaja/format-negotiate-middleware
+                         muuntaja/format-response-middleware
+                         exception/exception-middleware
+                         muuntaja/format-request-middleware
+                         coercion/coerce-response-middleware
+                         coercion/coerce-request-middleware
+                         coercion/coerce-exceptions-middleware
+                         multipart/multipart-middleware]}})
+   (ring/routes
+    (swagger-ui/create-swagger-ui-handler {:path "/swagger"
+                                           :url  "/swagger/swagger.json"
+                                           :root "swagger-ui"
+                                           :config {:jsonEditor false}}))))

--- a/src/zero/boot.clj
+++ b/src/zero/boot.clj
@@ -29,7 +29,7 @@
                        (util/shell! "git" "show" "-s" "--format=%cI")
                        OffsetDateTime/parse .toInstant .toString)
         clean?    (util/do-or-nil
-                    (util/shell! "git" "diff-index" "--quiet" "HEAD"))]
+                   (util/shell! "git" "diff-index" "--quiet" "HEAD"))]
     {:version   (-> (if clean? committed built)
                     .toLowerCase
                     (str/replace #"[^-a-z0-9]" "-"))
@@ -69,16 +69,16 @@
   []
   (let [tmp (str "CLONE_" (UUID/randomUUID))]
     (letfn [(clone [url] (util/shell-io! "git" "-C" tmp "clone"
-                           "--config" "advice.detachedHead=false" url))]
+                                         "--config" "advice.detachedHead=false" url))]
       (io/make-parents (io/file tmp "Who cares, really?"))
       (try
         (run! clone (vals zero/the-github-repos))
         (catch Exception _
           (run! clone (vals zero/the-other-github-repos)))))
     (into {:tmp tmp}
-      (for [repo (keys zero/the-github-repos)]
-        (let [dir (str/join "/" [tmp repo])]
-          [repo (util/shell! "git" "-C" dir "rev-parse" "HEAD")])))))
+          (for [repo (keys zero/the-github-repos)]
+            (let [dir (str/join "/" [tmp repo])]
+              [repo (util/shell! "git" "-C" dir "rev-parse" "HEAD")])))))
 
 (defn cromwellify-wdl
   "Cromwellify the WDL from dsde-pipelines in CLONES to RESOURCES."
@@ -105,7 +105,7 @@
     (let [pipeline-config (clone "pipeline-config" "wfl/environments.clj")]
       (stage (clone "dsde-pipelines" "tasks/CopyFilesFromCloudToCloud.wdl"))
       (util/shell-io! "git" "-C" (.getParent pipeline-config)
-        "checkout" "ed8b91ea300bd11473e3ba6e476c26bb38d8582b")
+                      "checkout" "ed8b91ea300bd11473e3ba6e476c26bb38d8582b")
       (stage pipeline-config))))
 
 (defn adapterize-wgs
@@ -143,8 +143,8 @@
           {:keys [tmp] :as clones} (clone-repos)
           directory (io/file resources "zero")
           edn (merge version
-                (dissoc clones :tmp)
-                (into {} (map frob wdls)))]
+                     (dissoc clones :tmp)
+                     (into {} (map frob wdls)))]
       (pprint edn)
       (util/shell-io! "npm" "install" "--prefix" "ui")
       (util/shell-io! "npm" "run" "build" "--prefix" "ui")

--- a/src/zero/dx.clj
+++ b/src/zero/dx.clj
@@ -126,7 +126,7 @@
     (if (and result (nat-int? result))
       result
       (throw (IllegalArgumentException.
-               (format "Error: <max> %s must be a positive integer" max))))))
+              (format "Error: <max> %s must be a positive integer" max))))))
 
 (defn failed-workflows
   "The Failed workflows in ENVIRONMENT between TIME0 and TIME1."

--- a/src/zero/main.clj
+++ b/src/zero/main.clj
@@ -16,9 +16,9 @@
          ""
          "Usage: %1$s <command> [<args> ...]"
          "Where: <command> and <args> are described below."]
-      (concat (util/summarize commands)) vec (conj "")
-      (->> (str/join \newline))
-      (format zero/the-name title))))
+        (concat (util/summarize commands)) vec (conj "")
+        (->> (str/join \newline))
+        (format zero/the-name title))))
 
 (defn version
   "Show version information."
@@ -48,9 +48,9 @@
                        zero.module.xx
                        zero.server]]
       (assoc (zipmap (map namify namespaces) (map varify namespaces))
-        "help"         #'help
-        "version"      #'version
-        "version-json" #'version-json))))
+             "help"         #'help
+             "version"      #'version
+             "version-json" #'version-json))))
 
 (defn trace-stack
   "Filter stack trace in #error X for only this code's frames."

--- a/src/zero/metadata.clj
+++ b/src/zero/metadata.clj
@@ -35,12 +35,11 @@
       (spit metadata-file (json/write-str metadata :escape-slash false))
       (if (:destination_cloud_path inputs)
         (gcs/upload-file
-          metadata-file
-          (str (:destination_cloud_path inputs) "/" metadata-file))
+         metadata-file
+         (str (:destination_cloud_path inputs) "/" metadata-file))
         (gcs/upload-file metadata-file (str output-dir "/" metadata-file))))
     (str "Skipping workflow " (:id metadata)
-      " - no valid output destination\n")))
-
+         " - no valid output destination\n")))
 
 (defn get-workflow-metadata-by-output
   "Record metadata for all successful workflows in a Cromwell ENV given
@@ -54,16 +53,16 @@
 (def description
   "Describe this command."
   (str/join
-    \newline
-    ["Usage: zero metadata <env> <wf-name> <output-key>"
-     ""
-     "Where: <env> is an environment"
-     "       <wf-name> is the name of a workflow run in Cromwell"
-     "       <output-key> is a key in the workflow output metadata"
-     "                    (where the metadata file will be written)"
-     ""
-     (str "Example: zero metadata pharma5 WhiteAlbumExomeReprocessing"
-          "WhiteAlbumExomeReprocessing.output_cram")]))
+   \newline
+   ["Usage: zero metadata <env> <wf-name> <output-key>"
+    ""
+    "Where: <env> is an environment"
+    "       <wf-name> is the name of a workflow run in Cromwell"
+    "       <output-key> is a key in the workflow output metadata"
+    "                    (where the metadata file will be written)"
+    ""
+    (str "Example: zero metadata pharma5 WhiteAlbumExomeReprocessing"
+         "WhiteAlbumExomeReprocessing.output_cram")]))
 
 ;; TODO: Add destination path key as optional parameter?
 ;;
@@ -81,5 +80,4 @@
       (throw x))))
 
 (comment
-  (run :hca-int "TestCopyFiles" :TestCopyFiles.hello.response)
-  )
+  (run :hca-int "TestCopyFiles" :TestCopyFiles.hello.response))

--- a/src/zero/module/all.clj
+++ b/src/zero/module/all.clj
@@ -16,9 +16,9 @@
   (let [[bucket object] (gcs/parse-gs-url gs-output-url)]
     (when (first (gcs/list-objects bucket object))
       (throw
-        (IllegalArgumentException.
-          (format "%s: output already exists: %s"
-                  zero/the-name gs-output-url))))))
+       (IllegalArgumentException.
+        (format "%s: output already exists: %s"
+                zero/the-name gs-output-url))))))
 
 (defn bam-or-cram?
   "Nil or a vector with root of PATH and the matching suffix."
@@ -39,7 +39,7 @@
               (util/do-or-nil (gcs/list-objects bucket prefix)))]
       (when-not (ok? result prefix)
         (throw (IllegalArgumentException.
-                 (format "%s must be readable" gs-url)))))
+                (format "%s must be readable" gs-url)))))
     result))
 
 (defn processed-crams
@@ -103,7 +103,7 @@
                                      "SET pipeline = '%s'::pipeline"
                                      "WHERE id = %s"]) pipeline id)
         work  (format "CREATE TABLE %s OF %s (PRIMARY KEY (id))"
-                table pipeline)]
+                      table pipeline)]
     (jdbc/update! tx :workload {:items table} ["id = ?" id])
     (jdbc/db-do-commands tx [kind work])
     [uuid table]))
@@ -119,8 +119,8 @@
   "Keywords from the set of ENVIRONMENTS with Cromwell URL."
   ([url]
    (->> env/stuff
-     (filter #(-> % second :cromwell :url #{url}))
-     keys))
+        (filter #(-> % second :cromwell :url #{url}))
+        keys))
   ([environments url]
    (->> url cromwell-environments
-     (filter environments))))
+        (filter environments))))

--- a/src/zero/module/copyfile.clj
+++ b/src/zero/module/copyfile.clj
@@ -18,12 +18,12 @@
   "Submit WORKFLOW to Cromwell in ENVIRONMENT."
   [environment workflow]
   (cromwell/submit-workflow
-    environment
-    (io/file (:top workflow-wdl))
-    nil
-    (-> workflow (select-keys [:src :dst]) (util/prefix-keys pipeline))
-    (util/make-options environment)
-    {}))
+   environment
+   (io/file (:top workflow-wdl))
+   nil
+   (-> workflow (select-keys [:src :dst]) (util/prefix-keys pipeline))
+   (util/make-options environment)
+   {}))
 
 (defn add-workload!
   "Use transaction TX to add the workload described by BODY."
@@ -45,7 +45,7 @@
             (update! [tx [id uuid]]
               (when uuid
                 (jdbc/update! tx items
-                  {:updated now :uuid uuid}
-                  ["id = ?" id])))]
+                              {:updated now :uuid uuid}
+                              ["id = ?" id])))]
       (let [workflow (postgres/get-table tx items)]
         (run! (comp (partial update! tx) submit!) workflow)))))

--- a/src/zero/module/ukb.clj
+++ b/src/zero/module/ukb.clj
@@ -156,13 +156,13 @@
               (util/do-or-nil (gcs/list-objects bucket prefix)))]
       (when (= in-bucket out-bucket)
         (throw (IllegalArgumentException.
-                 (format "%s and %s must be in different GCS buckets"
-                         in-gs-url out-gs-url))))
+                (format "%s and %s must be in different GCS buckets"
+                        in-gs-url out-gs-url))))
       (when-not (and (readable? in-bucket  in-prefix)
                      (readable? out-bucket out-prefix))
         (throw (IllegalArgumentException.
-                 (format "%s and %s must be readable"
-                         in-gs-url out-gs-url)))))
+                (format "%s and %s must be readable"
+                        in-gs-url out-gs-url)))))
     [in-bucket out-bucket]))
 
 (defn on-hold-some-crams
@@ -243,7 +243,7 @@
                3 report-status
                2 release-some-crams
                (throw (IllegalArgumentException.
-                        "Must specify 2 to 4 arguments.")))
+                       "Must specify 2 to 4 arguments.")))
              env (rest args)))
     (catch Exception x
       (binding [*out* *err*] (println description))
@@ -251,5 +251,4 @@
 
 (comment
   (cromwell/release-workflows-using-agent
-    (fn [] (cons :gotc-dev (find-some-crams :gotc-dev 1))))
-  )
+   (fn [] (cons :gotc-dev (find-some-crams :gotc-dev 1)))))

--- a/src/zero/module/wgs.clj
+++ b/src/zero/module/wgs.clj
@@ -163,12 +163,12 @@
   [environment in-gs out-gs]
   (let [path (wdl/hack-unpack-resources-hack adapter-workflow-wdl)]
     (cromwell/submit-workflow
-      environment
-      (io/file (:dir path) (path ".wdl"))
-      (io/file (:dir path) (path ".zip"))
-      (make-inputs environment out-gs in-gs)
-      (util/make-options environment)
-      cromwell-label-map)))
+     environment
+     (io/file (:dir path) (path ".wdl"))
+     (io/file (:dir path) (path ".zip"))
+     (make-inputs environment out-gs in-gs)
+     (util/make-options environment)
+     cromwell-label-map)))
 
 (defn submit-workflow
   "Submit OBJECT from IN-BUCKET for reprocessing into OUT-GS in
@@ -217,7 +217,7 @@
                4 submit-some-workflows-or-throw
                3 (partial all/report-status cromwell-label)
                (throw (IllegalArgumentException.
-                        "Must specify 3 or 4 arguments.")))
+                       "Must specify 3 or 4 arguments.")))
              env (rest args)))
     (catch Exception x
       (binding [*out* *err*] (println description))

--- a/src/zero/module/wl.clj
+++ b/src/zero/module/wl.clj
@@ -15,7 +15,7 @@
 (def get-cromwell-wgs-environment
   "Map Cromwell URL to a :wgs environment."
   (comp first (partial all/cromwell-environments
-                #{:wgs-dev :wgs-prod :wgs-staging})))
+                       #{:wgs-dev :wgs-prod :wgs-staging})))
 
 (defn maybe-update-workflow-status!
   "Use TX to update the status of WORKFLOW in ENV."
@@ -25,16 +25,16 @@
       (let [now    (OffsetDateTime/now)
             status (util/do-or-nil (cromwell/status env uuid))]
         (jdbc/update! tx items
-          (maybe {:updated now :uuid uuid} :status status)
-          ["id = ?" id])))))
+                      (maybe {:updated now :uuid uuid} :status status)
+                      ["id = ?" id])))))
 
 (defn update-workload!
   "Use transaction TX to update _WORKLOAD statuses."
   [tx {:keys [cromwell items] :as _workload}]
   (let [env (@get-cromwell-wgs-environment cromwell)]
     (->> items
-      (postgres/get-table tx)
-      (run! (partial maybe-update-workflow-status! tx env items)))))
+         (postgres/get-table tx)
+         (run! (partial maybe-update-workflow-status! tx env items)))))
 
 (defn add-workload!
   "Use transaction TX to add the workload described by BODY."
@@ -65,18 +65,18 @@
   (let [in-gs  (str (all/slashify input)  input_cram)
         out-gs (str (all/slashify output) input_cram)]
     (or (->> out-gs gcs/parse-gs-url
-          (apply gcs/list-objects)
-          util/do-or-nil seq)        ; done?
-      (->> {:label  wgs/cromwell-label
-            :status ["On Hold" "Running" "Submitted"]}
-        (cromwell/query env)
-        (map (comp :ExternalWholeGenomeReprocessing.input_cram
-               (fn [it] (json/read-str it :key-fn keyword))
-               :inputs :submittedFiles
-               (partial cromwell/metadata env)
-               :id))
-        (keep #{in-gs})
-        seq))))                    ; active?
+             (apply gcs/list-objects)
+             util/do-or-nil seq)        ; done?
+        (->> {:label  wgs/cromwell-label
+              :status ["On Hold" "Running" "Submitted"]}
+             (cromwell/query env)
+             (map (comp :ExternalWholeGenomeReprocessing.input_cram
+                        (fn [it] (json/read-str it :key-fn keyword))
+                        :inputs :submittedFiles
+                        (partial cromwell/metadata env)
+                        :id))
+             (keep #{in-gs})
+             seq))))                    ; active?
 
 (defn start-workload!
   "Use transaction TX to start the WORKLOAD."
@@ -92,7 +92,7 @@
                       (if (skip-workflow? env workload workflow)
                         util/uuid-nil
                         (wgs/really-submit-one-workflow
-                          env (str input input_cram) output)))])
+                         env (str input input_cram) output)))])
             (update! [tx [id uuid]]
               (when uuid
                 (jdbc/update! tx items

--- a/src/zero/module/xx.clj
+++ b/src/zero/module/xx.clj
@@ -137,12 +137,12 @@
   (let [path  (wdl/hack-unpack-resources-hack (:top workflow-wdl))
         in-gs (gcs/gs-url in-bucket object)]
     (cromwell/hold-workflow
-      environment
-      (io/file (:dir path) (path ".wdl"))
-      (io/file (:dir path) (path ".zip"))
-      (make-inputs environment out-gs in-gs)
-      (util/make-options environment)
-      cromwell-label-map)
+     environment
+     (io/file (:dir path) (path ".wdl"))
+     (io/file (:dir path) (path ".zip"))
+     (make-inputs environment out-gs in-gs)
+     (util/make-options environment)
+     cromwell-label-map)
     (prn in-gs)))
 
 (defn on-hold-some-workflows
@@ -189,7 +189,7 @@
                3 (partial all/report-status cromwell-label)
                2 release-some-on-hold-workflows
                (throw (IllegalArgumentException.
-                        "Must specify 2 to 4 arguments.")))
+                       "Must specify 2 to 4 arguments.")))
              env (rest args)))
     (catch Exception x
       (binding [*out* *err*] (println description))

--- a/src/zero/once.clj
+++ b/src/zero/once.clj
@@ -27,10 +27,10 @@
     (-> (cond file  (io/file file)
               vault (-> vault util/vault-secrets jsonify .getBytes)
               :else (throw (IllegalArgumentException. (pr-str sa))))
-      io/input-stream GoogleCredentials/fromStream
-      (.createScoped ["https://www.googleapis.com/auth/cloud-platform"
-                      "https://www.googleapis.com/auth/userinfo.email"
-                      "https://www.googleapis.com/auth/userinfo.profile"]))))
+        io/input-stream GoogleCredentials/fromStream
+        (.createScoped ["https://www.googleapis.com/auth/cloud-platform"
+                        "https://www.googleapis.com/auth/userinfo.email"
+                        "https://www.googleapis.com/auth/userinfo.profile"]))))
 
 (defn- service-account-token
   "Throw or return a bearer token for the service account SA."
@@ -41,21 +41,21 @@
   "An Authorization header with a Bearer token."
   []
   (authorization-header-with-bearer-token
-    (if-let [environment (util/getenv "ZERO_DEPLOY_ENVIRONMENT")]
-      (let [env (zero/throw-or-environment-keyword! environment)
-            sa (get-in env/stuff [env :server :service-account])]
-        (service-account-token sa))
-      (util/shell! "gcloud" "auth" "print-access-token"))))
+   (if-let [environment (util/getenv "ZERO_DEPLOY_ENVIRONMENT")]
+     (let [env (zero/throw-or-environment-keyword! environment)
+           sa (get-in env/stuff [env :server :service-account])]
+       (service-account-token sa))
+     (util/shell! "gcloud" "auth" "print-access-token"))))
 
 (defn get-service-account-header
   "An Authorization header with service account Bearer token."
   []
   (authorization-header-with-bearer-token
-    (service-account-token
-      (get-service-account-from-environment))))
+   (service-account-token
+    (get-service-account-from-environment))))
 
 (defn service-account-email
   "The client_email for the ZERO_DEPLOY_ENVIRONMENT service account."
   []
   (-> (get-service-account-from-environment)
-    service-account-credentials .getClientEmail))
+      service-account-credentials .getClientEmail))

--- a/src/zero/server.clj
+++ b/src/zero/server.clj
@@ -27,23 +27,23 @@
          "       <port> is a port number to listen on."
          ""
          (str/join \space ["Example: %1$s server" env port])]
-      (->> (str/join \newline))
-      (format zero/the-name title))))
+        (->> (str/join \newline))
+        (format zero/the-name title))))
 
 (def cookie-store
   "A session store for wrap-defaults."
   (cookie/cookie-store
-    {:key     (util/getenv "COOKIE_SECRET" "must be 16 bytes")
-     :readers (merge *data-readers* tc/data-readers)}))
+   {:key     (util/getenv "COOKIE_SECRET" "must be 16 bytes")
+    :readers (merge *data-readers* tc/data-readers)}))
 
 (defn wrap-defaults
   [handler]
   (defaults/wrap-defaults
-    handler
-    (-> defaults/api-defaults
-        (assoc :proxy true)
-        (assoc-in [:session :cookie-attrs :same-site] :lax)
-        (assoc-in [:session :store] cookie-store))))
+   handler
+   (-> defaults/api-defaults
+       (assoc :proxy true)
+       (assoc-in [:session :cookie-attrs :same-site] :lax)
+       (assoc-in [:session :store] cookie-store))))
 
 (defn wrap-internal-error
   [handler]

--- a/src/zero/service/cromwell.clj
+++ b/src/zero/service/cromwell.clj
@@ -197,11 +197,11 @@
                             (select-keys [:commit :version])
                             (json/write-str :escape-slash false))]
       (merge
-        {(key-for :version)     version-value
-         (key-for :wdl)         wdl-value
-         (key-for :wdl-version) (or (the-version wdl-value) "Unknown")}
-        (select-keys (into {} (map unprefix inputs))
-                     (get-in env/stuff [environment :cromwell :labels]))))))
+       {(key-for :version)     version-value
+        (key-for :wdl)         wdl-value
+        (key-for :wdl-version) (or (the-version wdl-value) "Unknown")}
+       (select-keys (into {} (map unprefix inputs))
+                    (get-in env/stuff [environment :cromwell :labels]))))))
 
 (defn post-workflow
   "Assemble PARTS into a multipart HTML body and post it to the Cromwell

--- a/src/zero/service/datarepo.clj
+++ b/src/zero/service/datarepo.clj
@@ -28,9 +28,9 @@
          :content-type :application/json
          :headers      (once/get-service-account-header)
          :body         body}
-      http/request :body
-      (json/read-str :key-fn keyword)
-      :id)))
+        http/request :body
+        (json/read-str :key-fn keyword)
+        :id)))
 
 (defn file-ingest
   "Ingest SRC file as VDEST in ENVIRONMENT using DATASET-ID and PROFILE-ID."
@@ -40,8 +40,8 @@
        :source_path src
        :target_path vdest
        :mime_type   "text/plain"}
-    (json/write-str :escape-slash false)
-    (->> (thing-ingest environment dataset-id "files"))))
+      (json/write-str :escape-slash false)
+      (->> (thing-ingest environment dataset-id "files"))))
 
 (defn tabular-ingest
   "Ingest TABLE at PATH to DATASET-ID in ENVIRONMENT and return the job ID."
@@ -52,18 +52,18 @@
        :max_bad_records       0
        :path                  path
        :table                 table}
-    (json/write-str :escape-slash false)
-    (->> (thing-ingest environment dataset-id "ingest"))))
+      (json/write-str :escape-slash false)
+      (->> (thing-ingest environment dataset-id "ingest"))))
 
 (defn get-job-result
   "Get result for JOB-ID in ENVIRONMENT."
   [environment job-id]
   (let [{:keys [body status]}
         (http/request
-          {:method :get                 ; :debug true :debug-body true
-           :url (format "%s/jobs/%s/result" (api environment) job-id)
-           :headers (once/get-service-account-header)
-           :throw-exceptions false})]
+         {:method :get                 ; :debug true :debug-body true
+          :url (format "%s/jobs/%s/result" (api environment) job-id)
+          :headers (once/get-service-account-header)
+          :throw-exceptions false})]
     (if (== 200 status)
       (json/read-str body :key-fn keyword)
       (throw (HttpException. body)))))
@@ -75,10 +75,10 @@
             (-> {:method :get ; :debug true :debug-body true
                  :url (format "%s/jobs/%s" (api environment) job-id)
                  :headers (once/get-service-account-header)}
-              http/request :body
-              (json/read-str :key-fn keyword)
-              :job_status
-              #{"running"}))]
+                http/request :body
+                (json/read-str :key-fn keyword)
+                :job_status
+                #{"running"}))]
     (when (running?)
       (Thread/sleep 10000)
       (poll-job environment job-id))

--- a/src/zero/service/gcs.clj
+++ b/src/zero/service/gcs.clj
@@ -36,7 +36,7 @@
   [url]
   (let [[gs-colon nada bucket object] (str/split url #"/" 4)]
     (when-not
-        (and (every? seq [gs-colon bucket])
+     (and (every? seq [gs-colon bucket])
           (= "gs:" gs-colon)
           (= "" nada))
       (throw (IllegalArgumentException. (format "Bad GCS URL: '%s'" url))))
@@ -46,8 +46,8 @@
   "Format BUCKET and OBJECT into a gs://bucket/object URL."
   [bucket object]
   (when-not (and (string?        bucket)
-              (seq            bucket)
-              (not-any? #{\/} bucket))
+                 (seq            bucket)
+                 (not-any? #{\/} bucket))
     (let [fmt "The bucket (%s) must be a non-empty string."
           msg (format fmt bucket)]
       (throw (IllegalArgumentException. msg))))
@@ -62,8 +62,8 @@
          ;; :query-params {:project project :prefix prefix}
          :content-type :application/json
          :headers      (once/get-auth-header)}
-      http/request :body
-      (json/read-str :key-fn keyword))))
+        http/request :body
+        (json/read-str :key-fn keyword))))
 
 (defn list-buckets
   "The buckets in PROJECT named with optional PREFIX."
@@ -73,10 +73,10 @@
         :query-params {:project project :prefix prefix}
         :content-type :application/json
         :headers      (once/get-auth-header)}
-     http/request :body
-     (json/read-str :key-fn keyword)
-     :items
-     (or [])))
+       http/request :body
+       (json/read-str :key-fn keyword)
+       :items
+       (or [])))
   ([project]
    (list-buckets project "")))
 
@@ -92,9 +92,9 @@
                         :query-params {:prefix prefix
                                        :maxResults 999
                                        :pageToken pageToken}}
-                     http/request
-                     :body
-                     (json/read-str :key-fn keyword))]
+                       http/request
+                       :body
+                       (json/read-str :key-fn keyword))]
                (lazy-cat items (when nextPageToken (each nextPageToken)))))]
      (each "")))
   ([bucket]
@@ -106,21 +106,21 @@
 
 (s/def ::bucket-name
   (s/and string?
-    (partial every? (set/union _-? digit? lowercase?))
-    (complement (comp _-? first))
-    (complement (comp _-? last))
-    (comp (partial > 64) count)
-    (comp (partial <  2) count)))
+         (partial every? (set/union _-? digit? lowercase?))
+         (complement (comp _-? first))
+         (complement (comp _-? last))
+         (comp (partial > 64) count)
+         (comp (partial <  2) count)))
 
 (defn valid-bucket-name-or-throw!
   "Throw unless BUCKET is a valid GCS bucket name."
   [bucket]
   (when-not (s/valid? ::bucket-name bucket)
     (throw
-      (IllegalArgumentException.
-        (format "Bad GCS bucket name: %s\nSee %s\n%s" bucket
-          "https://cloud.google.com/storage/docs/naming#requirements"
-          (s/explain-str ::bucket-name bucket))))))
+     (IllegalArgumentException.
+      (format "Bad GCS bucket name: %s\nSee %s\n%s" bucket
+              "https://cloud.google.com/storage/docs/naming#requirements"
+              (s/explain-str ::bucket-name bucket))))))
 
 (defn make-bucket
   "Make a storageClass CLASS bucket in PROJECT named BUCKET at LOCATION."
@@ -134,7 +134,7 @@
        :form-params  {:name         bucket
                       :location     location
                       :storageClass class}}
-    http/request :body (json/read-str :key-fn keyword)))
+      http/request :body (json/read-str :key-fn keyword)))
 
 (defn delete-bucket
   "Throw or delete the bucket in PROJECT named NAME."
@@ -144,15 +144,15 @@
               204 true
               404 false
               (-> 'delete-bucket
-                (list name)
-                pr-str
-                (ex-info response)
-                throw)))]
+                  (list name)
+                  pr-str
+                  (ex-info response)
+                  throw)))]
     (-> {:method            :delete     ; :debug true :debug-body true
          :url               (str bucket-url name)
          :headers           (once/get-auth-header)
          :throw-exceptions? false}
-      http/request deleted-this-time?)))
+        http/request deleted-this-time?)))
 
 (defn upload-file
   "Upload FILE to BUCKET with name OBJECT."
@@ -165,8 +165,8 @@
           :content-type (.detect (new Tika) body)
           :headers      (once/get-auth-header)
           :body         body}
-       http/request :body
-       (json/read-str :key-fn keyword))))
+         http/request :body
+         (json/read-str :key-fn keyword))))
   ([file url]
    (apply upload-file file (parse-gs-url url))))
 
@@ -179,8 +179,8 @@
           :query-params {:alt "media"}
           :headers      (once/get-auth-header)
           :as           :stream}
-       http/request :body
-       (io/copy out))))
+         http/request :body
+         (io/copy out))))
   ([file url]
    (apply download-file file (parse-gs-url url))))
 
@@ -209,9 +209,9 @@
    (-> {:method       :get              ; :debug true :debug-body true
         :url          (str (bucket-object-url bucket object) params)
         :headers      (once/get-auth-header)}
-     http/request
-     :body
-     (json/read-str :key-fn keyword)))
+       http/request
+       :body
+       (json/read-str :key-fn keyword)))
   ([url]
    (let [[bucket object] (parse-gs-url url)]
      (object-meta bucket object ""))))
@@ -224,8 +224,8 @@
         :content-type :application/json
         :headers      (once/get-auth-header)
         :body         (json/write-str metadata :escape-slash false)}
-     http/request :body
-     (json/read-str :key-fn keyword)))
+       http/request :body
+       (json/read-str :key-fn keyword)))
   ([metadata url]
    (apply patch-object! metadata (parse-gs-url url))))
 
@@ -236,8 +236,8 @@
      (-> {:method  :post                ; :debug true :debug-body true
           :url     (str src-url "/rewriteTo/" destination)
           :headers (once/get-auth-header)}
-       http/request :body
-       (json/read-str :key-fn keyword))))
+         http/request :body
+         (json/read-str :key-fn keyword))))
   ([sbucket sobject dbucket dobject]
    (let [src-url  (bucket-object-url sbucket sobject)
          dest-url (bucket-object-url dbucket dobject)]
@@ -263,11 +263,11 @@
     (let [buckets (keep mine? (list-buckets project bucket))]
       (when-not (== 1 (count buckets))
         (throw (IllegalArgumentException.
-                 (format "Found %s buckets named %s in project %s."
-                   (count buckets) bucket project))))
+                (format "Found %s buckets named %s in project %s."
+                        (count buckets) bucket project))))
       (-> {:method       :patch         ; :debug true :debug-body true
            :url          (:selfLink (first buckets))
            :content-type :application/json
            :headers      (once/get-auth-header)
            :body         (json/write-str metadata :escape-slash false)}
-        http/request :body (json/read-str :key-fn keyword)))))
+          http/request :body (json/read-str :key-fn keyword)))))

--- a/src/zero/service/pubsub.clj
+++ b/src/zero/service/pubsub.clj
@@ -122,13 +122,13 @@
   ([request]
    (letfn [(jsonify [edn] (json/write-str edn :escape-slash false))]
      (-> request
-       (update-in [:body] jsonify)
-       http/request :body
-       (json/read-str :key-fn keyword))))
+         (update-in [:body] jsonify)
+         http/request :body
+         (json/read-str :key-fn keyword))))
   ([request pushEndpoint]
    (subscribe (assoc-in request
-                [:body :pushConfig]
-                {:pushEndpoint pushEndpoint})))
+                        [:body :pushConfig]
+                        {:pushEndpoint pushEndpoint})))
   ([project topic subscription]
    (subscribe (subscribe-request project topic subscription)))
   ([project topic subscription pushEndpoint]
@@ -160,18 +160,18 @@
   [project topic & messages]
   (letfn [(jsonify [edn] (json/write-str edn :escape-slash false))
           (encode [data] (->> data
-                           jsonify
-                           .getBytes
-                           (.encodeToString (Base64/getEncoder))))
+                              jsonify
+                              .getBytes
+                              (.encodeToString (Base64/getEncoder))))
           (wrap [message] {:data       (encode message)
                            :attributes attributes})]
     (-> {:method  :post
          :url     (str api-url (topic-name project topic) :publish)
          :headers (once/get-auth-header)
          :body    (jsonify {:messages (map wrap messages)})}
-      http/request :body
-      (json/read-str :key-fn keyword)
-      :messageIds)))
+        http/request :body
+        (json/read-str :key-fn keyword)
+        :messageIds)))
 
 ;; The :returnImmediately and :maxMessages are just illustrative.
 ;;
@@ -181,25 +181,25 @@
   (letfn [(jsonify [edn] (json/write-str edn :escape-slash false))
           (ednify [json] (json/read-str json :key-fn keyword))
           (decode [data] (->> data
-                           (.decode (Base64/getDecoder))
-                           String. ednify))
+                              (.decode (Base64/getDecoder))
+                              String. ednify))
           (unwrap [m] (update-in m [:message :data] decode))]
     (-> {:method  :post
          :url     (str api-url (subscription-name project subscription) :pull)
          :headers (once/get-auth-header)
          :body    (jsonify {:returnImmediately true :maxMessages 23})}
-      http/request :body
-      (json/read-str :key-fn keyword)
-      :receivedMessages
-      (->> (map unwrap)))))
+        http/request :body
+        (json/read-str :key-fn keyword)
+        :receivedMessages
+        (->> (map unwrap)))))
 
 (defn acknowledge
   "Acknowledge messages from SUBSCRIPTION in PROJECT given their ACK-IDS"
   [project subscription ack-ids]
   (letfn [(jsonify [edn] (json/write-str edn :escape-slash false))]
     (-> {:method  :post
-       :url     (str api-url (subscription-name project subscription) :acknowledge)
-       :headers (once/get-auth-header)
-       :body    (jsonify {:ackIds ack-ids})}
-      http/request :body
-      (json/read-str :key-fn keyword))))
+         :url     (str api-url (subscription-name project subscription) :acknowledge)
+         :headers (once/get-auth-header)
+         :body    (jsonify {:ackIds ack-ids})}
+        http/request :body
+        (json/read-str :key-fn keyword))))

--- a/src/zero/util.clj
+++ b/src/zero/util.clj
@@ -35,8 +35,8 @@ vault.client.http/http-client           ; Keep :clint eastwood quiet.
   "Nil or the JSON in FILE."
   [file]
   (do-or-nil
-    (with-open [^java.io.Reader in (io/reader file)]
-      (json/read in :key-fn keyword))))
+   (with-open [^java.io.Reader in (io/reader file)]
+     (json/read in :key-fn keyword))))
 
 (defn spit-json
   "Throw or write EDN CONTENT to FILE as JSON."
@@ -50,9 +50,9 @@ vault.client.http/http-client           ; Keep :clint eastwood quiet.
   [path]
   (let [token-path (str (System/getProperty "user.home") "/.vault-token")]
     (try (vault/read-secret
-           (doto (vault/new-client "https://clotho.broadinstitute.org:8200/")
-             (vault/authenticate! :token (slurp token-path)))
-           path)
+          (doto (vault/new-client "https://clotho.broadinstitute.org:8200/")
+            (vault/authenticate! :token (slurp token-path)))
+          path)
          (catch Throwable e
            (let [error (get-in (Throwable->map e) [:via 0 :message])
                  lines ["%1$s: %2$s" "%1$s: Run 'vault login' and try again."]
@@ -115,9 +115,9 @@ vault.client.http/http-client           ; Keep :clint eastwood quiet.
   sequences for HTTP pagination callbacks and so on."
   [coll]
   (lazy-seq
-    (when (seq coll)
-      (cons (first coll)
-        (lazy-unchunk (rest coll))))))
+   (when (seq coll)
+     (cons (first coll)
+           (lazy-unchunk (rest coll))))))
 
 (defn keys-in
   "Return all keys used in any maps in TREE."
@@ -125,9 +125,9 @@ vault.client.http/http-client           ; Keep :clint eastwood quiet.
   (letfn [(follow? [node]
             (or (map? node) (vector? node) (set? node) (list? node)))]
     (reduce into #{}
-      (remove nil?
-        (map (fn [node] (when (map? node) (keys node)))
-          (tree-seq follow? identity tree))))))
+            (remove nil?
+                    (map (fn [node] (when (map? node) (keys node)))
+                         (tree-seq follow? identity tree))))))
 
 (defn fmap
   "Map the function F over the values in map M."
@@ -138,31 +138,31 @@ vault.client.http/http-client           ; Keep :clint eastwood quiet.
   "The number of minutes from START to END."
   [start end]
   (. ChronoUnit/MINUTES between
-    (OffsetDateTime/parse start)
-    (OffsetDateTime/parse end)))
+     (OffsetDateTime/parse start)
+     (OffsetDateTime/parse end)))
 
 (defn seconds-between
   "The number of seconds from START to END."
   [start end]
   (. ChronoUnit/SECONDS between
-    (OffsetDateTime/parse start)
-    (OffsetDateTime/parse end)))
+     (OffsetDateTime/parse start)
+     (OffsetDateTime/parse end)))
 
 (defn summarize
   "Summarize COMMANDS in a string vector."
   [commands]
   (let [indent (str/join (repeat 4 \space))]
     (apply concat
-      (for [[n f] (sort-by first commands)]
-        (let [{:keys [arglists doc]} (meta f)
-              command (apply pr-str (first arglists))]
-          [(str/join " " [" " n command]) (str indent doc)])))))
+           (for [[n f] (sort-by first commands)]
+             (let [{:keys [arglists doc]} (meta f)
+                   command (apply pr-str (first arglists))]
+               [(str/join " " [" " n command]) (str indent doc)])))))
 
 (defn prefix-keys
   "Prefix all keys in map M with P."
   [m p]
   (zipmap (map (fn [k] (keyword (str (name p) "." (name k)))) (keys m))
-    (vals m)))
+          (vals m)))
 
 (defn exome-inputs
   "Exome inputs for ENVIRONMENT that do not depend on the input file."
@@ -182,12 +182,12 @@ vault.client.http/http-client           ; Keep :clint eastwood quiet.
         br   (prefix-keys gatk :BaseRecalibrator)
         gbr  (prefix-keys gatk :GatherBqsrReports)]
     (-> (merge ab br gbr)
-      (prefix-keys :UnmappedBamToAlignedBam)
-      (prefix-keys :UnmappedBamToAlignedBam)
-      (prefix-keys :ExomeGermlineSingleSample)
-      (prefix-keys :ExomeGermlineSingleSample)
-      (prefix-keys :ExomeReprocessing)
-      (prefix-keys :ExomeReprocessing))))
+        (prefix-keys :UnmappedBamToAlignedBam)
+        (prefix-keys :UnmappedBamToAlignedBam)
+        (prefix-keys :ExomeGermlineSingleSample)
+        (prefix-keys :ExomeGermlineSingleSample)
+        (prefix-keys :ExomeReprocessing)
+        (prefix-keys :ExomeReprocessing))))
 
 (def gc_bias_metrics-inputs
   "This is silly too."
@@ -195,11 +195,11 @@ vault.client.http/http-client           ; Keep :clint eastwood quiet.
         cam  (prefix-keys bias :CollectAggregationMetrics)
         qm   (prefix-keys bias :CollectReadgroupBamQualityMetrics)]
     (-> (merge cam qm)
-      (prefix-keys :AggregatedBamQC.AggregatedBamQC)
-      (prefix-keys :ExomeGermlineSingleSample)
-      (prefix-keys :ExomeGermlineSingleSample)
-      (prefix-keys :ExomeReprocessing)
-      (prefix-keys :ExomeReprocessing))))
+        (prefix-keys :AggregatedBamQC.AggregatedBamQC)
+        (prefix-keys :ExomeGermlineSingleSample)
+        (prefix-keys :ExomeGermlineSingleSample)
+        (prefix-keys :ExomeReprocessing)
+        (prefix-keys :ExomeReprocessing))))
 
 (defn seeded-shuffle
   "Randomize COLL consistently."
@@ -217,10 +217,10 @@ vault.client.http/http-client           ; Keep :clint eastwood quiet.
           "us-east1"    "bcd"
           "us-east4"    "abc"
           "us-west1"    "abc"
-          #_#_ "us-west2"  "abc"}
-      (mapcat spray)
-      seeded-shuffle
-      (str/join " "))))
+          #_#_"us-west2"  "abc"}
+         (mapcat spray)
+         seeded-shuffle
+         (str/join " "))))
 
 (defn make-options
   "Make options to run the workflow in ENVIRONMENT."
@@ -239,8 +239,8 @@ vault.client.http/http-client           ; Keep :clint eastwood quiet.
            :default_runtime_attributes
            {:docker    (str/join "/" [gcr repo image])
             :zones     google-cloud-zones}}
-        (maybe :monitoring_script cromwell)
-        (maybe :noAddress noAddress)))))
+          (maybe :monitoring_script cromwell)
+          (maybe :noAddress noAddress)))))
 
 (defn is-non-negative!
   "Throw unless integer value of INT-STRING is non-negative."
@@ -248,8 +248,8 @@ vault.client.http/http-client           ; Keep :clint eastwood quiet.
   (let [result (parse-int int-string)]
     (when-not (nat-int? result)
       (throw (IllegalArgumentException.
-               (format "%s must be a non-negative integer"
-                 (if (nil? result) "" (format " (%s)" result))))))
+              (format "%s must be a non-negative integer"
+                      (if (nil? result) "" (format " (%s)" result))))))
     result))
 
 (defonce the-system-environment (delay (into {} (System/getenv))))
@@ -269,7 +269,7 @@ vault.client.http/http-client           ; Keep :clint eastwood quiet.
   (let [header (if (empty? comments) ""
                    (str "# " (str/join "\n# " comments) "\n\n"))
         yaml (yaml/generate-string content
-               :dumper-options {:flow-style :block})]
+                                   :dumper-options {:flow-style :block})]
     (spit file (str header yaml))))
 
 (defn shell!
@@ -278,7 +278,7 @@ vault.client.http/http-client           ; Keep :clint eastwood quiet.
   (let [{:keys [exit err out]} (apply shell/sh args)]
     (when-not (zero? exit)
       (throw (Exception. (format "%s: %s exit status from: %s : %s"
-                           zero/the-name exit args err))))
+                                 zero/the-name exit args err))))
     (str/trim out)))
 
 (defn shell-io!
@@ -287,7 +287,7 @@ vault.client.http/http-client           ; Keep :clint eastwood quiet.
   (let [exit (-> args ProcessBuilder. .inheritIO .start .waitFor)]
     (when-not (zero? exit)
       (throw (Exception. (format "%s: %s exit status from: %s"
-                           zero/the-name exit args))))))
+                                 zero/the-name exit args))))))
 
 (defn create-jwt
   "Sign a JSON Web Token with OAuth secrets from environment ENV."
@@ -310,4 +310,4 @@ vault.client.http/http-client           ; Keep :clint eastwood quiet.
   "True when UUID is UUID-NIL or its string representation."
   [uuid]
   (or (= uuid uuid-nil)
-    (= uuid (str uuid-nil))))
+      (= uuid (str uuid-nil))))

--- a/src/zero/wdl.clj
+++ b/src/zero/wdl.clj
@@ -44,8 +44,8 @@
         result (io/file directory (.getName (io/file wdl)))]
     (when (.exists result)
       (throw (IllegalArgumentException.
-               (format "%s: Two WDL files have the same leaf name: %s"
-                 zero/the-name result))))
+              (format "%s: Two WDL files have the same leaf name: %s"
+                      zero/the-name result))))
     (io/make-parents result)
     (with-open [out (io/writer result)
                 in  (io/reader (io/file wdl))]
@@ -75,13 +75,13 @@
       (doseq [wdl imports] (cromwellify-file directory wdl))
       (letfn [(dependency? [f] (let [fname (.getName f)]
                                  (and (not= (.getName root-wf) fname)
-                                   (str/ends-with? fname ".wdl"))))]
+                                      (str/ends-with? fname ".wdl"))))]
         [directory
          (cromwellify-file directory root-wf)
          (when (seq imports) (->> directory
-                               file-seq
-                               (filter dependency?)
-                               (apply util/zip-files zip)))]))
+                                  file-seq
+                                  (filter dependency?)
+                                  (apply util/zip-files zip)))]))
     (catch FileNotFoundException x
       (binding [*out* *err*]
         (println (format "%s: WARNING: %s" zero/the-name (.getMessage x)))))))

--- a/test/zero/integration/v1_endpoint_test.clj
+++ b/test/zero/integration/v1_endpoint_test.clj
@@ -63,8 +63,8 @@
     (let [src (str/join [uri "input.txt"])
           dst (str/join [uri "output.txt"])]
       (->
-        (str/join "/" ["test" "zero" "resources" "copy-me.txt"])
-        (gcs/upload-file src))
+       (str/join "/" ["test" "zero" "resources" "copy-me.txt"])
+       (gcs/upload-file src))
       (let [workload  (workloads/make-copyfile-workload src dst)
             await     (comp (partial wait-for-workflow-complete :gotc-dev) :uuid)
             submitted (endpoints/exec-workload workload)]

--- a/test/zero/tools/endpoints.clj
+++ b/test/zero/tools/endpoints.clj
@@ -19,8 +19,8 @@
   [uuid]
   (let [auth-header (once/get-auth-header)
         response    (client/get (str server "/api/v1/workload")
-                      {:headers      auth-header
-                       :query-params {:uuid uuid}})]
+                                {:headers      auth-header
+                                 :query-params {:uuid uuid}})]
     (first (parse-json-string (:body response)))))
 
 (defn get-workloads
@@ -28,7 +28,7 @@
   []
   (let [auth-header (once/get-auth-header)
         response    (client/get (str server "/api/v1/workload")
-                      {:headers auth-header})]
+                                {:headers auth-header})]
     (parse-json-string (:body response))))
 
 (def get-pending-workloads
@@ -45,10 +45,10 @@
   (let [auth-header (once/get-auth-header)
         payload     (json/write-str workload :escape-slash false)
         response    (client/post (str server "/api/v1/create")
-                      {:headers      auth-header
-                       :content-type :json
-                       :accept       :json
-                       :body         payload})]
+                                 {:headers      auth-header
+                                  :content-type :json
+                                  :accept       :json
+                                  :body         payload})]
     (parse-json-string (:body response))))
 
 (defn start-workload
@@ -57,10 +57,10 @@
   (let [auth-header (once/get-auth-header)
         payload     (json/write-str [workload] :escape-slash false)
         response    (client/post (str server "/api/v1/start")
-                      {:headers      auth-header
-                       :content-type :json
-                       :accept       :json
-                       :body         payload})]
+                                 {:headers      auth-header
+                                  :content-type :json
+                                  :accept       :json
+                                  :body         payload})]
     (first (parse-json-string (:body response)))))
 
 (defn start-wgs-workflow
@@ -69,10 +69,10 @@
   (let [auth-header (once/get-auth-header)
         payload     (json/write-str workflow :escape-slash false)
         response    (client/post (str server "/api/v1/wgs")
-                      {:headers      auth-header
-                       :content-type :json
-                       :accept       :json
-                       :body         payload})]
+                                 {:headers      auth-header
+                                  :content-type :json
+                                  :accept       :json
+                                  :body         payload})]
     (parse-json-string (:body response))))
 
 (defn exec-workload
@@ -81,8 +81,8 @@
   (let [auth-header (once/get-auth-header)
         payload     (json/write-str workload :escape-slash false)
         response    (client/post (str server "/api/v1/exec")
-                      {:headers      auth-header
-                       :content-type :json
-                       :accept       :json
-                       :body         payload})]
+                                 {:headers      auth-header
+                                  :content-type :json
+                                  :accept       :json
+                                  :body         payload})]
     (parse-json-string (:body response))))

--- a/test/zero/tools/fixtures.clj
+++ b/test/zero/tools/fixtures.clj
@@ -30,5 +30,5 @@
      (try ~@body
           (finally
             (->>
-              (gcs/list-objects gcs-test-bucket name#)
-              (run! (comp delete-test-object :name)))))))
+             (gcs/list-objects gcs-test-bucket name#)
+             (run! (comp delete-test-object :name)))))))

--- a/test/zero/unit/all_modules_test.clj
+++ b/test/zero/unit/all_modules_test.clj
@@ -9,6 +9,6 @@
       (is (some #{:gotc-dev} (all/cromwell-environments url))))
     (testing "get a cromwell env from a set of possible envs"
       (is (some #{:wgs-dev} (all/cromwell-environments
-                              #{:wgs-dev :wgs-prod :wgs-staging} url))))
+                             #{:wgs-dev :wgs-prod :wgs-staging} url))))
     (testing "unknown url"
       (is (nil? (all/cromwell-environments "https://no.such.cromwell/"))))))

--- a/test/zero/unit/datarepo_test.clj
+++ b/test/zero/unit/datarepo_test.clj
@@ -59,10 +59,10 @@
         (stage vcf "bogus vcf content")
         (stage (str vcf ".tbi") "bogus index content")
         (stage table (json/write-str
-                       {:id        bucket
-                        :vcf       (ingest vcf-url vcf)
-                        :vcf_index (ingest vcf-url (str vcf ".tbi"))}
-                       :escape-slash false))
+                      {:id        bucket
+                       :vcf       (ingest vcf-url vcf)
+                       :vcf_index (ingest vcf-url (str vcf ".tbi"))}
+                      :escape-slash false))
         (let [table-url (gcs/gs-url bucket table)
               job (datarepo/tabular-ingest :gotc-dev dataset table-url "sample")
               {:keys [bad_row_count row_count]} (datarepo/poll-job :gotc-dev job)]

--- a/test/zero/unit/pubsub_test.clj
+++ b/test/zero/unit/pubsub_test.clj
@@ -101,8 +101,8 @@
             (let [ack-ids (map :ackId result)
                   ack-result (pubsub/acknowledge project notification-subscription ack-ids)
                   pull-result (pubsub/pull project notification-subscription)]
-            (is (= ack-result {}))
-            (is (= (count pull-result) 0))))))
+              (is (= ack-result {}))
+              (is (= (count pull-result) 0))))))
       (finally
         (gcs/delete-object notification-bucket test-file)
         (io/delete-file "test.txt")))))


### PR DESCRIPTION
### Purpose
We should use the same linting tool for both WFL and the PTC service. 

### Changes
- Use `cljfmt` instead of `eastwood`. Cljfmt includes auto-formatting which should make it trivial to fix any linting errors.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
