### PR TITLE
Add some notes about IntelliJ setup that weren't documented

### DIFF
--- a/docs/md/README.md
+++ b/docs/md/README.md
@@ -297,6 +297,15 @@ Find a local Cursive user for guidance if you like IntelliJ.
 [Saman Ehsan](mailto:sehsan@broadinstitute.org) know how to use it.
 Cursive licences are available
 [here](https://broadinstitute.atlassian.net/wiki/spaces/DSDE/pages/48234557/Software%2BLicenses%2B-%2BCursive).
+The steps for getting this project set up with very recent versions of IntelliJ 
+differ from Cursive's docs:
+1. *Outside of IntelliJ*, `clone` the repo and run `boot` at the top-level to 
+generate the `project.clj` (see below)
+2. *Now inside of IntelliJ*, import the project by specifically targeting the 
+`project.clj` file (it should offer to import the entire project, and targeting 
+the `project.clj` will make use of Leiningen to work with Cursive)
+3. Use the Project Structure window (Help -> Find Action -> Project Structure) to set a JDK as the Project SDK
+
 There is also a
 [Calva](https://marketplace.visualstudio.com/items?itemName=betterthantomorrow.calva)
 plugin for [Visual Studio Code](https://code.visualstudio.com/).


### PR DESCRIPTION
(Cursive's docs online only apply to slightly older versions
of IntelliJ and this project has an extra step of needing to
use `boot` to generate the `project.clj` file)

### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- No ticket is linked to this PR.

IntelliJ's old import project workflow was two steps, selecting the location and selecting how to import the project. Super recent versions of IntelliJ seem to be just inferring that last step, which makes it non-obvious that the project gets imported without using Leiningen by default.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Update README.md to specifically state that cloning and `project.clj` generation must happen before IntelliJ import
- Update README.md to make note of selecting `project.clj` as the project to prompt a Leiningen import

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- This seems to mainly apply to new installs of IntelliJ (or folks who just keep it updated). I used these exact steps to get it working for me, but someone else should be able to do the same if this meets the bar for that sort of review