### PR TITLE
[GH-761] Use prepared SQL statements

### DIFF
--- a/src/zero/api/handlers.clj
+++ b/src/zero/api/handlers.clj
@@ -110,15 +110,12 @@
             ps (jdbc/prepare-statement db-conn query)]
         (doseq [[i uuid] (map-indexed vector uuids)] (.setString ps (+ i 1) (:uuid uuid)))
         (jdbc/with-db-transaction [tx db-config]
-          (try
-            (->> ps
+          (->> ps
                (jdbc/query tx)
                (run! (partial start-workload! tx)))
             (->> uuids
                (mapv (partial postgres/get-workload-for-uuid tx))
-               succeed)
-            (catch Exception e
-              (fail {:message (.getMessage e)}))))))))
+               succeed))))))
 
 (def post-exec
   "Create and start workload described in BODY of REQUEST"

--- a/src/zero/api/handlers.clj
+++ b/src/zero/api/handlers.clj
@@ -101,16 +101,20 @@
   [request]
   (let [uuids (-> request :parameters :body distinct)]
     (letfn [(q [[left right]] (fn [it] (str left it right)))]
-      (jdbc/with-db-transaction [tx (postgres/zero-db-config)]
-        (->> uuids
-             (map :uuid)
-             (map (q "''")) (str/join ",") ((q "()"))
-             (format "SELECT * FROM workload WHERE uuid in %s")
-             (jdbc/query tx)
-             (run! (partial start-workload! tx)))
-        (->> uuids
-             (mapv (partial postgres/get-workload-for-uuid tx))
-             succeed)))))
+      (let [db-config (postgres/zero-db-config)
+            db-conn (jdbc/get-connection db-config)
+            query (->> (repeat (count uuids) "?")
+                       (str/join ",") ((q "()"))
+                       (format "SELECT * FROM workload WHERE uuid in %s"))
+            ps (jdbc/prepare-statement db-conn query)]
+        (doseq [[i uuid] (map-indexed vector uuids)] (.setString ps (+ i 1) (:uuid uuid)))
+        (jdbc/with-db-transaction [tx db-config]
+          (->> ps
+               (jdbc/query tx)
+               (run! (partial start-workload! tx)))
+          (->> uuids
+               (mapv (partial postgres/get-workload-for-uuid tx))
+               succeed))))))
 
 (def post-exec
   "Create and start workload described in BODY of REQUEST"

--- a/src/zero/module/all.clj
+++ b/src/zero/module/all.clj
@@ -99,13 +99,11 @@
                                     :version  version
                                     :wdl      top})
         table (format "%s_%09d" pipeline id)
-        kind  (format (str/join " " ["UPDATE workload"
-                                     "SET pipeline = '%s'::pipeline"
-                                     "WHERE id = %s"]) pipeline id)
         work  (format "CREATE TABLE %s OF %s (PRIMARY KEY (id))"
                       table pipeline)]
     (jdbc/update! tx :workload {:items table} ["id = ?" id])
-    (jdbc/db-do-commands tx [kind work])
+    (jdbc/execute! tx ["UPDATE workload SET pipeline = '?'::pipeline WHERE id = ?" pipeline id])
+    (jdbc/db-do-commands tx [work])
     [uuid table]))
 
 (defn slashify

--- a/src/zero/module/copyfile.clj
+++ b/src/zero/module/copyfile.clj
@@ -6,8 +6,7 @@
             [zero.service.cromwell :as cromwell]
             [zero.service.postgres :as postgres]
             [zero.util :as util])
-  (:import [java.time OffsetDateTime]
-           (clojure.lang ExceptionInfo)))
+  (:import [java.time OffsetDateTime]))
 
 (def pipeline "copyfile")
 
@@ -47,8 +46,6 @@
                 (jdbc/update! tx items
                               {:updated now :uuid uuid}
                               ["id = ?" id])))]
-      (try
         (let [workflow (postgres/get-table tx items)]
           (jdbc/update! tx :workload {:started now} ["uuid = ?" uuid])
-          (run! (comp (partial update! tx) submit!) workflow))
-        (catch ExceptionInfo e (throw e))))))
+          (run! (comp (partial update! tx) submit!) workflow)))))

--- a/src/zero/module/copyfile.clj
+++ b/src/zero/module/copyfile.clj
@@ -47,5 +47,5 @@
                 (jdbc/update! tx items
                               {:updated now :uuid uuid}
                               ["id = ?" id])))]
-      (let [workflow (postgres/get-table tx items)]
+      (if-let [workflow (postgres/get-table tx items)]
         (run! (comp (partial update! tx) submit!) workflow)))))

--- a/src/zero/module/wl.clj
+++ b/src/zero/module/wl.clj
@@ -100,6 +100,6 @@
                               {:updated now :uuid uuid}
                               ["id = ?" id])))]
       (let [workflows (postgres/get-table tx items)
-              ids-uuids (map submit! workflows)]
+            ids-uuids (map submit! workflows)]
           (jdbc/update! tx :workload {:started now} ["uuid = ?" uuid])
           (run! (partial update! tx) ids-uuids)))))

--- a/src/zero/module/wl.clj
+++ b/src/zero/module/wl.clj
@@ -36,7 +36,8 @@
     (try
       (let [workflows (postgres/get-table tx items)]
         (run! (partial maybe-update-workflow-status! tx env items) workflows))
-      (catch ExceptionInfo (throw (ex-info "Error updating workload status" {:cause "no-workflows-found"}))))))
+      (catch ExceptionInfo e
+        (throw (ex-info "Error updating workload status" {:cause "no-workflows-found"}))))))
 
 (defn add-workload!
   "Use transaction TX to add the workload described by BODY."

--- a/src/zero/service/postgres.clj
+++ b/src/zero/service/postgres.clj
@@ -9,8 +9,7 @@
             [zero.service.cromwell :as cromwell]
             [zero.util :as util])
   (:import [java.time OffsetDateTime]
-           [liquibase.integration.commandline Main]
-           (clojure.lang ExceptionInfo)))
+           [liquibase.integration.commandline Main]))
 
 (defn zero-db-config
   "Get the database configuration."
@@ -103,8 +102,8 @@
           (jdbc/update! tx :workload
                         {:finished (OffsetDateTime/now)}
                         ["id = ?" id]))))
-    (catch ExceptionInfo e
-      (throw (ex-info "Error updating workload status" {:cause "no-workflows-found"})))))
+    (catch Exception cause
+      (throw (ex-info "Error updating workload status" {} cause)))))
 
 (defn get-workload-for-uuid
   "Use transaction TX to return workload with UUID."
@@ -118,9 +117,9 @@
           (-> workload
               (assoc :workflows (mapv unnilify workflows))
               unnilify))
-        (catch ExceptionInfo e
-          (-> workload
-              unnilify))))))
+        (catch Exception e
+          (unnilify workload))))))
+
 
 (comment
   (str/join " " ["liquibase" "--classpath=$(clojure -Spath)"

--- a/src/zero/service/postgres.clj
+++ b/src/zero/service/postgres.clj
@@ -52,7 +52,8 @@
    (run-liquibase-update
     "jdbc:postgresql:wfl" (util/getenv "USER" "postgres") "password")))
 
-(defn table-exists
+(defn table-exists?
+  "Check if TABLE exists using transaction TX."
   [tx table]
   (->> ["SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = ?" (str/lower-case table)]
        (jdbc/query tx)
@@ -62,7 +63,7 @@
 (defn get-table
   "Return TABLE using transaction TX."
   [tx table]
-  (if (table-exists tx table)
+  (if (table-exists? tx table)
     (jdbc/query tx (format "SELECT * FROM %s" table))))
 
 ;; HACK: We don't have the workload environment here.

--- a/src/zero/service/postgres.clj
+++ b/src/zero/service/postgres.clj
@@ -103,7 +103,7 @@
           (jdbc/update! tx :workload
                         {:finished (OffsetDateTime/now)}
                         ["id = ?" id]))))
-    (catch ExceptionInfo
+    (catch ExceptionInfo e
       (throw (ex-info "Error updating workload status" {:cause "no-workflows-found"})))))
 
 (defn get-workload-for-uuid


### PR DESCRIPTION
### Purpose
Address potential security vulnerabilities from concatenating user input with raw SQL statements:
https://broadinstitute.atlassian.net/jira/software/projects/GH/boards/530?selectedIssue=GH-761

### Changes
Here are the files that currently interact with the database along with the changes I made:
- service.postgres: Modify `get-table` to check that the table exists before using that variable in a SQL query.
- api.handlers: Modify `post-start` to use a parameterized statement instead of concatenating the uuids provided by the user. 
- module.all: Modify `add-workload-table!` to use a parameterized statement when updating the workload.
- module.wfl
- module.copyfile

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

Any ideas what to do about this DB operation to create a new typed table? I don't think there's a way for us to use a parameterized statement here:
https://github.com/broadinstitute/wfl/compare/se-sql-ops-updates?expand=1#diff-3c51ca22431fe3b9448ef2882cbd193aR102
