### PR TITLE
GH-807 Avoid extra WFL clones

### DIFF
--- a/src/zero/boot.clj
+++ b/src/zero/boot.clj
@@ -64,18 +64,23 @@
 
 (defn clone-repos
   "Return a map of zero/the-github-repos clones in a :tmp directory.
-   Delete the :tmp directory at some point."
+   Delete the :tmp directory at some point.
+
+   Specifically omits [[zero/the-name]]'s repo since it isn't needed
+   for the version."
   []
-  (let [tmp (str "CLONE_" (UUID/randomUUID))]
+  (let [tmp (str "CLONE_" (UUID/randomUUID))
+        the-github-repos-no-wfl (dissoc zero/the-github-repos zero/the-name)
+        the-other-github-repos-no-wfl (dissoc zero/the-other-github-repos zero/the-name)]
     (letfn [(clone [url] (util/shell-io! "git" "-C" tmp "clone"
                                          "--config" "advice.detachedHead=false" url))]
       (io/make-parents (io/file tmp "Who cares, really?"))
       (try
-        (run! clone (vals zero/the-github-repos))
+        (run! clone (vals the-github-repos-no-wfl))
         (catch Exception _
-          (run! clone (vals zero/the-other-github-repos)))))
+          (run! clone (vals the-other-github-repos-no-wfl)))))
     (into {:tmp tmp}
-          (for [repo (keys zero/the-github-repos)]
+          (for [repo (keys the-github-repos-no-wfl)]
             (let [dir (str/join "/" [tmp repo])]
               [repo (util/shell! "git" "-C" dir "rev-parse" "HEAD")])))))
 

--- a/src/zero/boot.clj
+++ b/src/zero/boot.clj
@@ -51,7 +51,7 @@
   [the-version]
   {:description "WFL manages workflows."
    :project     zero/artifactId
-   :url         (zero/the-github-repos zero/the-name)
+   :url         (:primary (zero/the-github-repos zero/the-name))
    :version     (:version the-version)})
 
 (defn make-the-manifest
@@ -70,15 +70,14 @@
    for the version."
   []
   (let [tmp (str "CLONE_" (UUID/randomUUID))
-        the-github-repos-no-wfl (dissoc zero/the-github-repos zero/the-name)
-        the-other-github-repos-no-wfl (dissoc zero/the-other-github-repos zero/the-name)]
+        the-github-repos-no-wfl (dissoc zero/the-github-repos zero/the-name)]
     (letfn [(clone [url] (util/shell-io! "git" "-C" tmp "clone"
                                          "--config" "advice.detachedHead=false" url))]
       (io/make-parents (io/file tmp "Who cares, really?"))
       (try
-        (run! clone (vals the-github-repos-no-wfl))
+        (run! clone (map :primary (vals the-github-repos-no-wfl)))
         (catch Exception _
-          (run! clone (vals the-other-github-repos-no-wfl)))))
+          (run! clone (map :actions-backup (vals the-github-repos-no-wfl))))))
     (into {:tmp tmp}
           (for [repo (keys the-github-repos-no-wfl)]
             (let [dir (str/join "/" [tmp repo])]

--- a/src/zero/boot.clj
+++ b/src/zero/boot.clj
@@ -27,7 +27,7 @@
         committed (->> commit
                        (util/shell! "git" "show" "-s" "--format=%cI")
                        OffsetDateTime/parse .toInstant .toString)
-        clean?    (util/do-or-nil
+        clean?    (util/do-or-nil-silently
                    (util/shell! "git" "diff-index" "--quiet" "HEAD"))]
     {:version   (-> (if clean? committed built)
                     .toLowerCase

--- a/src/zero/boot.clj
+++ b/src/zero/boot.clj
@@ -70,11 +70,15 @@
    for the version."
   []
   (let [tmp (str "CLONE_" (UUID/randomUUID))
-        the-github-repos-no-wfl (dissoc zero/the-github-repos zero/the-name)]
+        the-github-repos-no-wfl (dissoc zero/the-github-repos zero/the-name)
+        the-other-github-repos-no-wfl (dissoc zero/the-other-github-repos zero/the-name)]
     (letfn [(clone [url] (util/shell-io! "git" "-C" tmp "clone"
                                          "--config" "advice.detachedHead=false" url))]
       (io/make-parents (io/file tmp "Who cares, really?"))
-      (run! clone (vals the-github-repos-no-wfl)))
+      (try
+        (run! clone (vals the-github-repos-no-wfl))
+        (catch Exception _
+          (run! clone (vals the-other-github-repos-no-wfl)))))
     (into {:tmp tmp}
           (for [repo (keys the-github-repos-no-wfl)]
             (let [dir (str/join "/" [tmp repo])]

--- a/src/zero/boot.clj
+++ b/src/zero/boot.clj
@@ -70,15 +70,11 @@
    for the version."
   []
   (let [tmp (str "CLONE_" (UUID/randomUUID))
-        the-github-repos-no-wfl (dissoc zero/the-github-repos zero/the-name)
-        the-other-github-repos-no-wfl (dissoc zero/the-other-github-repos zero/the-name)]
+        the-github-repos-no-wfl (dissoc zero/the-github-repos zero/the-name)]
     (letfn [(clone [url] (util/shell-io! "git" "-C" tmp "clone"
                                          "--config" "advice.detachedHead=false" url))]
       (io/make-parents (io/file tmp "Who cares, really?"))
-      (try
-        (run! clone (vals the-github-repos-no-wfl))
-        (catch Exception _
-          (run! clone (vals the-other-github-repos-no-wfl)))))
+      (run! clone (vals the-github-repos-no-wfl)))
     (into {:tmp tmp}
           (for [repo (keys the-github-repos-no-wfl)]
             (let [dir (str/join "/" [tmp repo])]

--- a/src/zero/util.clj
+++ b/src/zero/util.clj
@@ -31,6 +31,14 @@ vault.client.http/http-client           ; Keep :clint eastwood quiet.
 (defn parse-int     [s] (do-or-nil (Integer/parseInt s)))
 (defn parse-boolean [s] (do-or-nil (Boolean/valueOf  s)))
 
+;; `x#` used here since `_` will fail in a macro.
+(defmacro do-or-nil-silently
+  "Value of BODY or nil if it throws, without printing any exceptions.
+  See also [[do-or-nil]]."
+  [& body]
+  `(try (do ~@body)
+        (catch Exception x#)))
+
 (defn slurp-json
   "Nil or the JSON in FILE."
   [file]

--- a/src/zero/zero.clj
+++ b/src/zero/zero.clj
@@ -19,6 +19,12 @@
         git   (partial str "git@github.com:broadinstitute/")]
     (zipmap repos (map git repos))))
 
+(def the-other-github-repos
+  "Map Zero source repo names to their URLs with aliases"
+  (let [repos ["wfl" "dsde-pipelines" "pipeline-config"]
+        git (fn [x] (str "git@" x ".github.com:broadinstitute/" x))]
+    (zipmap repos (map git repos))))
+
 (defn error-or-environment-keyword
   "Error string or the keyword for a valid ENVIRONMENT."
   [environment]

--- a/src/zero/zero.clj
+++ b/src/zero/zero.clj
@@ -19,12 +19,6 @@
         git   (partial str "git@github.com:broadinstitute/")]
     (zipmap repos (map git repos))))
 
-(def the-other-github-repos
-  "Map Zero source repo names to their URLs with aliases"
-  (let [repos ["wfl" "dsde-pipelines" "pipeline-config"]
-        git (fn [x] (str "git@" x ".github.com:broadinstitute/" x))]
-    (zipmap repos (map git repos))))
-
 (defn error-or-environment-keyword
   "Error string or the keyword for a valid ENVIRONMENT."
   [environment]

--- a/src/zero/zero.clj
+++ b/src/zero/zero.clj
@@ -14,16 +14,13 @@
   'org.broadinstitute/wfl)
 
 (def the-github-repos
-  "Map Zero source repo names to their URLs"
+  "Map Zero source repo names to their URLs.
+  Primary URL should be tried first, and there's a second
+  URL that works in GitHub actions to try as a backup."
   (let [repos ["wfl" "dsde-pipelines" "pipeline-config"]
-        git   (partial str "git@github.com:broadinstitute/")]
-    (zipmap repos (map git repos))))
-
-(def the-other-github-repos
-  "Map Zero source repo names to their URLs with aliases"
-  (let [repos ["wfl" "dsde-pipelines" "pipeline-config"]
-        git (fn [x] (str "git@" x ".github.com:broadinstitute/" x))]
-    (zipmap repos (map git repos))))
+        urls (fn [x] {:primary (str "git@github.com:broadinstitute/" x),
+                :actions-backup (str "git@" x ".github.com:broadinstitute/" x)})]
+    (zipmap repos (map urls repos))))
 
 (defn error-or-environment-keyword
   "Error string or the keyword for a valid ENVIRONMENT."


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-807
- WFL cloned itself to put its master HEAD commit hash into `resources/zero/version.edn`. Doing so is not necessary because the current branch's HEAD commit is already in `version.edn` and is more representative of the version of the software anyway.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Modify `util.clj` to have a function that will swallow errors, because...
- `boot.clj` no longer prints out an error message if `git diff-index --quiet` returns -1 (that exit code is the whole point of `--quiet`)
- `boot.clj` modified to exclude its own repo from what it cloned for `version.edn`

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- On this branch, running `boot build` should exclude `"wfl" "<commit hash>"` from `resources/zero/version.edn`
- The testing behavior is unchanged from master (in other words, the tests run here the same as they will on master because removing that entry from `version.edn` is a no-op with regard to functionality)

### Notes

- Tom mentioned in a comment on the ticket that boot could probably be eliminated entirely. I don't disagree but I don't think that's a change to make before a big deadline (plus, this change is on the road to that anyway). Would require discussion, so I haven't attempted that here.
