### PR TITLE
always create a new workload before starting it

### DIFF
--- a/test/zero/integration/v1_endpoint_test.clj
+++ b/test/zero/integration/v1_endpoint_test.clj
@@ -31,7 +31,7 @@
 
 (deftest test-start-workload
   (testing "The `start` endpoint starts an existing workload"
-    (let [unstarted (or (endpoints/first-pending-workload) make-workload)
+    (let [unstarted (make-workload)
           response  (endpoints/start-workload unstarted)
           status    (endpoints/get-workload-status (:uuid response))]
       (is (:uuid unstarted) "Workloads should have been assigned a uuid")


### PR DESCRIPTION
### Purpose
Fix https://broadinstitute.atlassian.net/browse/GH-843
I wrote a bug in the `test-start-workload` test point where I got the first-unstarted workload and tried to start it.
The correct behaviour should be to always create the workload before starting it.

### Changes
Always create a new workload before starting it. Note this is still failing due to https://broadinstitute.atlassian.net/browse/GH-845
