### PR TITLE
Fix the redundant single quotes for prepared statement.

### DIFF
--- a/src/zero/module/all.clj
+++ b/src/zero/module/all.clj
@@ -102,7 +102,7 @@
         work  (format "CREATE TABLE %s OF %s (PRIMARY KEY (id))"
                       table pipeline)]
     (jdbc/update! tx :workload {:items table} ["id = ?" id])
-    (jdbc/execute! tx ["UPDATE workload SET pipeline = '?'::pipeline WHERE id = ?" pipeline id])
+    (jdbc/execute! tx ["UPDATE workload SET pipeline = ?::pipeline WHERE id = ?" pipeline id])
     (jdbc/db-do-commands tx [work])
     [uuid table]))
 


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- Fixes https://broadinstitute.atlassian.net/browse/GH-845. It seems the prepared statement should not have single quotes, otherwise they will be kept and escaped by the clever jdbc lib.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Removed the redundant single quotes for prepared statement.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
