### PR TITLE
[GH-859] Set jar to multi-release to remove a warning message

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -71,4 +71,4 @@
    :main-opts   ["-m" "kaocha.runner"]}
 
   :uberjar {:extra-deps {uberdeps {:mvn/version "0.1.4"}}
-            :main-opts  ["-m" "uberdeps.uberjar"]}}}
+            :main-opts  ["-m" "uberdeps.uberjar" "--multi-release"]}}}

--- a/src/zero/boot.clj
+++ b/src/zero/boot.clj
@@ -61,7 +61,8 @@
   (let [keywords [:description :url :version]]
     (assoc (zipmap (map (comp str/capitalize name) keywords)
                    ((apply juxt keywords) the-pom))
-           "Application-Name" (str/capitalize zero/the-name))))
+           "Application-Name" (str/capitalize zero/the-name)
+           "Multi-Release" "true")))
 
 (defn clone-repos
   "Return a map of zero/the-github-repos clones in a :tmp directory.


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-859
- We don't like errant warning messages and setting this option removes one.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Set the jar to multi-release so Log4j2 is happier and doesn't print a warning

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- `boot build` followed by `java -jar target/wfl*.jar -h` will no longer print a warning message
 complaining about a reflection issue.