### PR TITLE
[GH-860] Fix the nil return issue with db transaction context macro

### DIFF
--- a/src/zero/jdbc.clj
+++ b/src/zero/jdbc.clj
@@ -77,8 +77,9 @@
   [binding & body]
   `(let [id# (rand-int 10000)]
      (log/info "JDBC SQL transaction" id# "started to" (clean-db ~(second binding)))
-     (jdbc/with-db-transaction ~binding ~@body)
-     (log/info "JDBC SQL transaction" id# "ended")))
+     (let [~'exe (jdbc/with-db-transaction ~binding ~@body)]
+       (log/info "JDBC SQL transaction" id# "ended")
+       ~'exe)))
 
 (defmacro prepare-statement
   "Alias for [[clojure.java.jdbc/prepare-statement]], does not log since the statement would be used later"

--- a/src/zero/jdbc.clj
+++ b/src/zero/jdbc.clj
@@ -4,94 +4,124 @@
             [clojure.tools.logging.readable :as log]))
 
 (defn clean-db
-  "Make the db not contain the password"
+  "Remove password from DB."
   [db]
   (dissoc db :password))
 
 (defmacro query
   "Logged alias for [[clojure.java.jdbc/query]]"
-  ([db sql-params] `(do
-                      (log/info "JDBC SQL query (without opts):" (clean-db ~db) ~sql-params)
-                      (jdbc/query ~db ~sql-params)))
-  ([db sql-params opts] `(do
-                          (log/info "JDBC SQL query:" (clean-db ~db) ~sql-params ~opts)
-                          (jdbc/query ~db ~sql-params ~opts))))
+  ([db sql-params]
+   `(do
+      (log/info "JDBC SQL query (without opts):" (clean-db ~db) ~sql-params)
+      (jdbc/query ~db ~sql-params)))
+  ([db sql-params opts]
+   `(do
+      (log/info "JDBC SQL query:" (clean-db ~db) ~sql-params ~opts)
+      (jdbc/query ~db ~sql-params ~opts))))
 
 (defmacro update!
   "Logged alias for [[clojure.java.jdbc/update!]]"
-  ([db table set-map where-clause] `(do
-                                      (log/info "JDBC SQL update! (without opts):" (clean-db ~db) ~table ~set-map ~where-clause)
-                                      (jdbc/update! ~db ~table ~set-map ~where-clause)))
-  ([db table set-map where-clause opts] `(do
-                                      (log/info "JDBC SQL update!:" (clean-db ~db) ~table ~set-map ~where-clause ~opts)
-                                      (jdbc/update! ~db ~table ~set-map ~where-clause ~opts))))
+  ([db table set-map where-clause]
+   `(do
+      (log/info "JDBC SQL update! (without opts):"
+        (clean-db ~db) ~table ~set-map ~where-clause)
+      (jdbc/update! ~db ~table ~set-map ~where-clause)))
+  ([db table set-map where-clause opts]
+   `(do
+      (log/info "JDBC SQL update!:"
+        (clean-db ~db) ~table ~set-map ~where-clause ~opts)
+      (jdbc/update! ~db ~table ~set-map ~where-clause ~opts))))
 
 (defmacro insert-multi!
   "Logged alias for [[clojure.java.jdbc/insert-multi!]]"
-  ([db table rows] `(do
-                      (log/info "JDBC SQL insert-rows! (without opts):" (clean-db ~db) ~table ~rows)
-                      (jdbc/insert-multi! ~db ~table ~rows)))
-  ([db table cols-or-rows values-or-opts] `(do
-                                             (if (map? values-or-opts)
-                                               (log/info "JDBC SQL insert-rows!:" (clean-db ~db) ~table ~cols-or-rows ~values-or-opts)
-                                               (log/info "JDBC SQL insert-cols! (without opts):" (clean-db ~db) ~table ~cols-or-rows ~values-or-opts))
-                                             (jdbc/insert-multi! ~db ~table ~cols-or-rows ~values-or-opts)))
-  ([db table cols values opts] `(do
-                                  (log/info "JDBC SQL insert-cols!:" (clean-db ~db) ~table ~cols ~values ~opts)
-                                  (jdbc/insert-multi! ~db ~table ~cols ~values ~opts))))
+  ([db table rows]
+   `(do
+      (log/info "JDBC SQL insert-rows! (without opts):"
+        (clean-db ~db) ~table ~rows)
+      (jdbc/insert-multi! ~db ~table ~rows)))
+  ([db table cols-or-rows values-or-opts]
+   `(do
+      (if (map? values-or-opts)
+        (log/info "JDBC SQL insert-rows!:"
+          (clean-db ~db) ~table ~cols-or-rows ~values-or-opts)
+        (log/info "JDBC SQL insert-cols! (without opts):"
+          (clean-db ~db) ~table ~cols-or-rows ~values-or-opts))
+      (jdbc/insert-multi! ~db ~table ~cols-or-rows ~values-or-opts)))
+  ([db table cols values opts]
+   `(do
+      (log/info "JDBC SQL insert-cols!:"
+        (clean-db ~db) ~table ~cols ~values ~opts)
+      (jdbc/insert-multi! ~db ~table ~cols ~values ~opts))))
 
 (defmacro execute!
   "Logged alias for [[clojure.java.jdbc/execute!]]"
-  ([db sql-params] `(do
-                      (log/info "JDBC SQL execute! (without opts):" (clean-db ~db) ~sql-params)
-                      (jdbc/execute! ~db ~sql-params)))
-  ([db sql-params opts] `(do
-                           (log/info "JDBC SQL execute!:" (clean-db ~db) ~sql-params ~opts)
-                           (jdbc/execute! ~db ~sql-params ~opts))))
+  ([db sql-params]
+   `(do
+      (log/info "JDBC SQL execute! (without opts):" (clean-db ~db) ~sql-params)
+      (jdbc/execute! ~db ~sql-params)))
+  ([db sql-params opts]
+   `(do
+      (log/info "JDBC SQL execute!:" (clean-db ~db) ~sql-params ~opts)
+      (jdbc/execute! ~db ~sql-params ~opts))))
 
 (defmacro db-do-commands
   "Logged alias for [[clojure.java.jdbc/db-do-commands]]"
-  ([db sql-commands] `(do
-                        (log/info "JDBC SQL db-do-commands:" (clean-db ~db) ~sql-commands)
-                        (jdbc/db-do-commands ~db ~sql-commands)))
-  ([db transaction? sql-commands] `(do
-                                     (log/info "JDBC SQL db-do-commands:" (clean-db ~db) ~transaction? ~sql-commands)
-                                     (jdbc/db-do-commands ~db ~transaction? ~sql-commands))))
+  ([db sql-commands]
+   `(do
+      (log/info "JDBC SQL db-do-commands:" (clean-db ~db) ~sql-commands)
+      (jdbc/db-do-commands ~db ~sql-commands)))
+  ([db transaction? sql-commands]
+   `(do
+      (log/info "JDBC SQL db-do-commands:"
+        (clean-db ~db) ~transaction? ~sql-commands)
+      (jdbc/db-do-commands ~db ~transaction? ~sql-commands))))
 
 (defmacro insert!
   "Logged alias for [[clojure.java.jdbc/insert!]]"
-  ([db table row] `(do
-                      (log/info "JDBC SQL insert-rows! (without opts):" (clean-db ~db) ~table [~row])
-                      (jdbc/insert! ~db ~table ~row)))
-  ([db table cols-or-row values-or-opts] `(do
-                                             (if (map? values-or-opts)
-                                               (log/info "JDBC SQL insert-rows!:" (clean-db ~db) ~table [~cols-or-row] ~values-or-opts)
-                                               (log/info "JDBC SQL insert-cols! (without opts):" (clean-db ~db) ~table ~cols-or-row [~values-or-opts]))
-                                             (jdbc/insert! ~db ~table ~cols-or-row ~values-or-opts)))
-  ([db table cols values opts] `(do
-                                  (log/info "JDBC SQL insert-cols!:" (clean-db ~db) ~table ~cols [~values] ~opts)
-                                  (jdbc/insert! ~db ~table ~cols ~values ~opts))))
+  ([db table row]
+   `(do
+      (log/info "JDBC SQL insert-rows! (without opts):"
+        (clean-db ~db) ~table [~row])
+      (jdbc/insert! ~db ~table ~row)))
+  ([db table cols-or-row values-or-opts]
+   `(do
+      (if (map? values-or-opts)
+        (log/info "JDBC SQL insert-rows!:"
+          (clean-db ~db) ~table [~cols-or-row] ~values-or-opts)
+        (log/info "JDBC SQL insert-cols! (without opts):"
+          (clean-db ~db) ~table ~cols-or-row [~values-or-opts]))
+      (jdbc/insert! ~db ~table ~cols-or-row ~values-or-opts)))
+  ([db table cols values opts]
+   `(do
+      (log/info "JDBC SQL insert-cols!:"
+        (clean-db ~db) ~table ~cols [~values] ~opts)
+      (jdbc/insert! ~db ~table ~cols ~values ~opts))))
 
 (defmacro with-db-transaction
   "Logged alias for [[clojure.java.jdbc/with-db-transaction]]"
   [binding & body]
   `(let [id# (rand-int 10000)]
-     (log/info "JDBC SQL transaction" id# "started to" (clean-db ~(second binding)))
-     (let [~'exe (jdbc/with-db-transaction ~binding ~@body)]
+     (log/info "JDBC SQL transaction" id# "started to"
+       (clean-db ~(second binding)))
+     (let [exe# (jdbc/with-db-transaction ~binding ~@body)]
        (log/info "JDBC SQL transaction" id# "ended")
-       ~'exe)))
+       exe#)))
 
 (defmacro prepare-statement
-  "Alias for [[clojure.java.jdbc/prepare-statement]], does not log since the statement would be used later"
-  ([con sql] `(jdbc/prepare-statement ~con ~sql))
-  ([^java.sql.Connection con ^String sql opts] `(jdbc/prepare-statement ~con ~sql ~opts)))
+  "Alias for [[clojure.java.jdbc/prepare-statement]].
+  Does not log since the statement would be used later."
+  ([con sql]
+   `(jdbc/prepare-statement ~con ~sql))
+  ([^java.sql.Connection con ^String sql opts]
+   `(jdbc/prepare-statement ~con ~sql ~opts)))
 
 (defmacro get-connection
   "Logged alias for [[clojure.java.jdbc/prepare-statement]]"
-  ([db-spec] `(do
-               (log/info "JBDC SQL connection made (no opts):" (clean-db ~db-spec))
-               (jdbc/get-connection ~db-spec)))
-  ([db-spec opts] `(do
-                     (log/info "JBDC SQL connection made:" (clean-db ~db-spec) ~opts)
-                     (jdbc/get-connection ~db-spec ~opts))))
-
+  ([db-spec]
+   `(do
+      (log/info "JBDC SQL connection made (no opts):" (clean-db ~db-spec))
+      (jdbc/get-connection ~db-spec)))
+  ([db-spec opts]
+   `(do
+      (log/info "JBDC SQL connection made:" (clean-db ~db-spec) ~opts)
+      (jdbc/get-connection ~db-spec ~opts))))


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-860

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Bind values within macro and re-return it after side-effect.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

With:
```clojure
(macroexpand `(jdbc/with-db-transaction [tx (postgres/zero-db-config)]
                                         (jdbc/query tx ["SELECT uuid FROM workload"])))
```
The changes are more obvious:

#### Before
```clojure
(let*
 [id__12689__auto__ (clojure.core/rand-int 10000)]
 (clojure.tools.logging.readable/info
  "JDBC SQL transaction"
  id__12689__auto__
  "started to"
  (zero.jdbc/clean-db (zero.service.postgres/zero-db-config)))
 (clojure.java.jdbc/with-db-transaction
  [zero.api.handlers/tx (zero.service.postgres/zero-db-config)]
  (zero.jdbc/query zero.api.handlers/tx ["SELECT uuid FROM workload"]))
 (clojure.tools.logging.readable/info "JDBC SQL transaction" id__12689__auto__ "ended"))
```


#### After

```clojure
(let*
 [id__13169__auto__ (clojure.core/rand-int 10000)]
 (clojure.tools.logging.readable/info
  "JDBC SQL transaction"
  id__13169__auto__
  "started to"
  (zero.jdbc/clean-db (zero.service.postgres/zero-db-config)))
 (clojure.core/let
  [exe
   (clojure.java.jdbc/with-db-transaction
    [zero.api.handlers/tx (zero.service.postgres/zero-db-config)]
    (zero.jdbc/query zero.api.handlers/tx ["SELECT uuid FROM workload"]))]
  (clojure.tools.logging.readable/info "JDBC SQL transaction" id__13169__auto__ "ended")
  exe))
``` 
