### PR TITLE
remove ino logging in -main as this breaks parsing version-json

### DIFF
--- a/src/zero/main.clj
+++ b/src/zero/main.clj
@@ -73,8 +73,6 @@
   [& the-args]
   (try
     (let [[verb & args] the-args]
-      (log/info "Understood entry point verb to be" verb)
-      (log/info "Understood entry point arguments to be" args)
       (if-let [run (commands verb)]
         (do
           (apply run args)


### PR DESCRIPTION
### Purpose
`info` level logging to `zero.main` broke deployment as the deployment script, `cli.py` reads the stdout of
```bash
$ java -jar target/wfl-*.jar version-json | jq .version
```
Logging in this case made the version-json entry-point no longer print valid json. 

### Changes
Remove info logging in `zero.main/-main`
