### PR TITLE
fix deployment after liquibase updated their base image

### DIFF
--- a/ops/cli.py
+++ b/ops/cli.py
@@ -169,7 +169,6 @@ def run_liquibase_migration(db_username, db_password):
     changelog_dir = f"{pwd}/wfl/database"
     command = ' '.join(['docker run --rm --net=host',
                         f'-v {changelog_dir}:/liquibase/changelog liquibase/liquibase',
-                        '/liquibase/liquibase',
                         f'--url="{db_url}" --changeLogFile=/changelog/changelog.xml',
                         f'--username="{db_username}" --password="{db_password}" update'])
     shell(command)


### PR DESCRIPTION
### Purpose
Liquibase changed their base image and have broken @rexwangcc's fix.
Small pr to address this.

### Changes
Undo liquibas workaround: https://github.com/broadinstitute/wfl/pull/71/files#diff-da2a4da0fe1bbdf1dbae6823c2a89d66R175

### Review Instructions
Ensure you're not using any cached docker images.