### PR TITLE
[GH-856] Update cloud fn deploy script

### DIFF
--- a/cloud_function/deploy.sh
+++ b/cloud_function/deploy.sh
@@ -8,8 +8,11 @@ REGION=${4:-"us-central1"}
 
 if [ "${GCLOUD_PROJECT}" == "broad-gotc-dev" ]; then
   # This service account must have access to the WFL API
-  SA_EMAIL="wfl-non-prod@broad-gotc-dev.iam.gserviceaccount.com"
+  SA_EMAIL="aou-cloud-fn-non-prod@broad-gotc-dev.iam.gserviceaccount.com"
   _WFL_URL="https://workflow-launcher.gotc-dev.broadinstitute.org"
+elif [ "${GCLOUD_PROJECT}" == "broad-aou" ]; then
+  SA_EMAIL="aou-cloud-fn@broad-aou.iam.gserviceaccount.com"
+  _WFL_URL=""
 else
   printf "Unrecognized google project\n"
   exit 1


### PR DESCRIPTION
### Purpose
- Change the service account that the cloud function uses in the broad-gotc-dev project 
- Support deploying to the broad-aou project (the _WFL_URL is intentionally left blank here because that WFL instance hasn't been deployed yet).

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

See above :) 

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
