### PR TITLE
Miscellaneous fixes and improvements for WFL

### DIFF
--- a/cloud_function/tests/upload_test_files.py
+++ b/cloud_function/tests/upload_test_files.py
@@ -6,6 +6,7 @@ been run before). """
 import json
 import uuid
 import subprocess
+import tempfile
 
 bucket = "dev-aou-arrays-input"
 uuid = uuid.uuid4()
@@ -38,11 +39,12 @@ ptc_json = {
 }
 
 def main():
-    with open('ptc.json', 'w') as f:
-        json.dump(ptc_json, f)
-    subprocess.run(["gsutil", "cp", "-r", arrays_path, dest_arrays_path])
-    subprocess.run(["gsutil", "cp", "-r", arrays_metadata_path, dest_arrays_metadata_path])
-    subprocess.run(["gsutil", "cp", "ptc.json", dest_ptc_json_path])
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        with open(f'{tmpdirname}/ptc.json', 'w') as f:
+            json.dump(ptc_json, f)
+        subprocess.run(["gsutil", "cp", "-r", arrays_path, dest_arrays_path])
+        subprocess.run(["gsutil", "cp", "-r", arrays_metadata_path, dest_arrays_metadata_path])
+        subprocess.run(["gsutil", "cp", f"{tmpdirname}/ptc.json", dest_ptc_json_path])
 
 
 if __name__ == '__main__':

--- a/deps.edn
+++ b/deps.edn
@@ -66,11 +66,11 @@
   {:main-opts   ["-m" "zero.main"]}
 
   :test
-  {:extra-deps  {lambdaisland/kaocha {:mvn/version "1.0.632"}
-                 org.liquibase/liquibase-cdi {:mvn/version "4.0.0"
-                                              :exclusions [ch.qos.logback/logback-classic]}
-                 org.liquibase/liquibase-core {:mvn/version "4.0.0"
-                                               :exclusions [ch.qos.logback/logback-classic]}}
+  {:extra-deps  {lambdaisland/kaocha           {:mvn/version "1.0.632"}
+                 org.liquibase/liquibase-cdi   {:mvn/version "4.0.0"
+                                                :exclusions [ch.qos.logback/logback-classic]}
+                 org.liquibase/liquibase-core  {:mvn/version "4.0.0"
+                                                :exclusions [ch.qos.logback/logback-classic]}}
    :extra-paths ["resources" "test"]
    :main-opts   ["-m" "kaocha.runner"]}
 

--- a/src/zero/api/handlers.clj
+++ b/src/zero/api/handlers.clj
@@ -75,17 +75,6 @@
            query {:includeSubworkflows false :start start :end end}]
        (succeed {:results (cromwell/query env query)})))))
 
-(defn submit-wgs
-  "Submit the WGS workload described in REQUEST."
-  [{:keys [parameters] :as _request}]
-  (zero.api.handlers/print-handler-error
-   (let [{:keys [environment input_path max output_path]} (:body parameters)]
-     (logr/infof "submit-wgs endpoint called: environment=%s input_path=%s max=%s output_path=%s"
-                 environment input_path max output_path)
-     (let [env     (zero/throw-or-environment-keyword! environment)
-           results (wgs/submit-some-workflows env max input_path output_path)]
-       (succeed {:results results})))))
-
 (defn append-to-aou-workload
   "Append new workflows to an existing started AoU workload describe in BODY of _REQUEST."
   [{:keys [parameters] :as _request}]

--- a/src/zero/api/routes.clj
+++ b/src/zero/api/routes.clj
@@ -52,15 +52,10 @@
             :parameters {:query {:environment string?}}
             :responses {200 {:body {:total pos-int?}}}
             :handler handlers/status-counts}}]
-   ["/api/v1/wgs"
-    {:post {:summary    "Submit WGS Reprocessing workflows"
-            :parameters {:body ::spec/wgs-request}
-            :responses  {200 {:body {:results vector?}}}
-            :handler    handlers/submit-wgs}}]
    ["/api/v1/append_to_aou"
     {:post {:summary    "Append to an existing AOU workload."
-            :parameters {:body ::spec/aou-request}
-            :responses  {200 {:body ::spec/append-to-workload-response}}
+            :parameters {:body ::spec/append-to-aou-request}
+            :responses  {200 {:body ::spec/append-to-aou-response}}
             :handler    handlers/append-to-aou-workload}}]
    ["/api/v1/workload"
     {:get  {:summary    "Get the workloads."

--- a/src/zero/api/spec.clj
+++ b/src/zero/api/spec.clj
@@ -8,29 +8,36 @@
 (defn uuid-string? [s] (uuid? (util/do-or-nil (UUID/fromString s))))
 
 ;; shared
-(s/def ::environment string?)
+(s/def ::commit (s/and string? (comp (partial == 40) count)))
+(s/def ::created inst?)
+(s/def ::creator string?)
 (s/def ::cromwell string?)
+(s/def ::environment string?)
+(s/def ::finished inst?)
+(s/def ::id pos-int?)
+(s/def ::input string?)
+(s/def ::output string?)
 (s/def ::pipeline string?)
 (s/def ::project string?)
+(s/def ::release string?)
+(s/def ::status (set cromwell/statuses))
+(s/def ::started inst?)
+(s/def ::updated inst?)
 (s/def ::uuid (s/and string? uuid-string?))
+(s/def ::uuids (s/* ::uuid))
 (s/def ::uuid-kv (s/keys :req-un [::uuid]))
 (s/def ::uuid-kvs (s/* ::uuid-kv))
 (s/def ::uuid-query (s/or :none empty?
                           :one (s/keys :req-un [::uuid])))
-(s/def ::creator string?)
-(s/def ::input string?)
-(s/def ::output string?)
-(s/def ::finished inst?)
-(s/def ::wdl string?)
-(s/def ::started inst?)
-(s/def ::release string?)
-(s/def ::status (set cromwell/statuses))
-(s/def ::id pos-int?)
-(s/def ::updated inst?)
-(s/def ::commit (s/and string? (comp (partial == 40) count)))
-(s/def ::created inst?)
-(s/def ::uuids (s/* ::uuid))
 (s/def ::version string?)
+(s/def ::wdl string?)
+(s/def ::workload-request (s/keys :req-un [::creator
+                                           ::cromwell
+                                           ::input
+                                           ::items
+                                           ::output
+                                           ::pipeline
+                                           ::project]))
 (s/def ::workload-response (s/keys :opt-un [::finished
                                             ::pipeline
                                             ::started
@@ -48,26 +55,15 @@
                                             ::uuid
                                             ::version]))
 (s/def ::workload-responses (s/* ::workload-response))
-(s/def ::workload-request (s/keys :req-un [::creator
-                                           ::cromwell
-                                           ::input
-                                           ::items
-                                           ::output
-                                           ::pipeline
-                                           ::project]))
 
 ;; compound
-(s/def ::workflows (s/or :aou (s/* ::workflow-aou)
-                         :wgs (s/+ ::workflow-wgs)))
 (s/def ::items (s/or :aou (s/+ ::items-aou)
                      :wgs (s/+ ::items-wgs)))
+(s/def ::workflows (s/or :aou (s/* ::workflow-aou)
+                         :wgs (s/+ ::workflow-wgs)))
 
 ;; aou
-(s/def ::workflow-aou map?)               ; stub
-(s/def ::items-aou (constantly true))     ; stub
-(s/def ::notifications (s/* map?))
 (s/def ::analysis_version_number integer?)
-(s/def ::chip_well_barcode string?)
 (s/def ::append-to-aou-request (s/keys :req-un [::cromwell
                                                 ::environment
                                                 ::notifications
@@ -77,10 +73,12 @@
                                         :more (s/keys :req-un [::uuid
                                                                ::analysis_version_number
                                                                ::chip_well_barcode]))))
+(s/def ::chip_well_barcode string?)
+(s/def ::items-aou (constantly true))     ; stub
+(s/def ::notifications (s/* map?))
+(s/def ::workflow-aou map?)               ; stub
 
 ;; wgs
-(s/def ::sample_name string?)
-(s/def ::unmapped_bam_suffix string?)
 (s/def ::base_file_name string?)
 (s/def ::final_gvcf_base_name string?)
 (s/def ::input_cram string?)
@@ -89,6 +87,8 @@
                                     ::unmapped_bam_suffix]
                            :req-un [::input_cram
                                     ::sample_name]))
+(s/def ::sample_name string?)
+(s/def ::unmapped_bam_suffix string?)
 (s/def ::workflow-wgs (s/keys :opt-un [::base_file_name
                                        ::final_gvcf_base_name
                                        ::status

--- a/src/zero/api/spec.clj
+++ b/src/zero/api/spec.clj
@@ -1,103 +1,107 @@
 (ns zero.api.spec
   "Define specs used in routes"
-  (:require [zero.service.cromwell              :as cromwell]
-            [clojure.spec.alpha                 :as s]
-            [zero.util                          :as util])
+  (:require [zero.service.cromwell :as cromwell]
+            [clojure.spec.alpha :as s]
+            [zero.util :as util])
   (:import [java.util UUID]))
 
 (defn uuid-string? [s] (uuid? (util/do-or-nil (UUID/fromString s))))
 
-(s/def ::base_file_name       string?)
-(s/def ::commit               (s/and string? (comp (partial == 40) count)))
-(s/def ::created              inst?)
-(s/def ::creator              string?)
-(s/def ::cromwell             string?)
-(s/def ::end                  string?)
-(s/def ::environment          string?)
-(s/def ::final_gvcf_base_name string?)
-(s/def ::finished             inst?)
-(s/def ::id                   pos-int?)
-(s/def ::input                string?)
-(s/def ::input_cram           string?)
-(s/def ::input_path           string?)
-(s/def ::items                (s/or :aou (s/+ ::items-aou)
-                                    :wgs (s/+ ::items-wgs)))
-(s/def ::items-aou            (constantly true)) ; stub
-(s/def ::items-wgs            (s/keys :opt-un [::base_file_name
-                                               ::final_gvcf_base_name
-                                               ::unmapped_bam_suffix]
-                                      :req-un [::input_cram
-                                               ::sample_name]))
-(s/def ::max                  pos-int?)
-(s/def ::output               string?)
-(s/def ::output_path          string?)
-(s/def ::pipeline             string?)
-(s/def ::project              string?)
-(s/def ::release              string?)
-(s/def ::sample_name          string?)
-(s/def ::start                string?)
-(s/def ::started              inst?)
-(s/def ::status               (set cromwell/statuses))
-(s/def ::unmapped_bam_suffix  string?)
-(s/def ::updated              inst?)
-(s/def ::uuid                 (s/and string? uuid-string?))
-(s/def ::uuid-kv              (s/keys :req-un [::uuid]))
-(s/def ::uuid-kvs             (s/* ::uuid-kv))
-(s/def ::uuid-query           (s/or :none empty?
-                                    :one  (s/keys :req-un [::uuid])))
-(s/def ::uuids                (s/* ::uuid))
-(s/def ::version              string?)
-(s/def ::wdl                  string?)
-(s/def ::wgs-request          (s/keys :req-un [::environment
-                                               ::max
-                                               ::input_path
-                                               ::output_path]))
-(s/def ::notifications        (s/* map?))
-(s/def ::aou-request          (s/keys :req-un [::cromwell
-                                               ::environment
-                                               ::notifications
-                                               ::uuid]))
-(s/def ::workflow-aou         map?) ; stub
-(s/def ::workflow-wgs         (s/keys :opt-un [::base_file_name
-                                               ::final_gvcf_base_name
-                                               ::status
-                                               ::unmapped_bam_suffix
-                                               ::updated
-                                               ::uuid]
-                                      :req-un [::id
-                                               ::input_cram
-                                               ::sample_name]))
-(s/def ::workflow-request     (s/keys :req-un [::end
-                                               ::environment
-                                               ::start]))
-(s/def ::workflows            (s/or :aou (s/* ::workflow-aou)
-                                    :wgs (s/+ ::workflow-wgs)))
-(s/def ::workload-request     (s/keys :req-un [::creator
-                                               ::cromwell
-                                               ::input
-                                               ::items
-                                               ::output
-                                               ::pipeline
-                                               ::project]))
+;; shared
+(s/def ::environment string?)
+(s/def ::cromwell string?)
+(s/def ::pipeline string?)
+(s/def ::project string?)
+(s/def ::uuid (s/and string? uuid-string?))
+(s/def ::uuid-kv (s/keys :req-un [::uuid]))
+(s/def ::uuid-kvs (s/* ::uuid-kv))
+(s/def ::uuid-query (s/or :none empty?
+                          :one (s/keys :req-un [::uuid])))
+(s/def ::creator string?)
+(s/def ::input string?)
+(s/def ::output string?)
+(s/def ::finished inst?)
+(s/def ::wdl string?)
+(s/def ::started inst?)
+(s/def ::release string?)
+(s/def ::status (set cromwell/statuses))
+(s/def ::id pos-int?)
+(s/def ::updated inst?)
+(s/def ::commit (s/and string? (comp (partial == 40) count)))
+(s/def ::created inst?)
+(s/def ::uuids (s/* ::uuid))
+(s/def ::version string?)
+(s/def ::workload-response (s/keys :opt-un [::finished
+                                            ::pipeline
+                                            ::started
+                                            ::wdl
+                                            ::workflows]
+                                   :req-un [::commit
+                                            ::created
+                                            ::creator
+                                            ::cromwell
+                                            ::id
+                                            ::input
+                                            ::output
+                                            ::project
+                                            ::release
+                                            ::uuid
+                                            ::version]))
+(s/def ::workload-responses (s/* ::workload-response))
+(s/def ::workload-request (s/keys :req-un [::creator
+                                           ::cromwell
+                                           ::input
+                                           ::items
+                                           ::output
+                                           ::pipeline
+                                           ::project]))
 
-(s/def ::append-to-workload-response (s/* (s/or :none empty?
-                                                :more  (s/keys :req-un [::uuid
-                                                                       ::analysis_version_number
-                                                                       ::chip_well_barcode]))))
-(s/def ::workload-response    (s/keys :opt-un [::finished
-                                               ::pipeline
-                                               ::started
-                                               ::wdl
-                                               ::workflows]
-                                      :req-un [::commit
-                                               ::created
-                                               ::creator
-                                               ::cromwell
-                                               ::id
-                                               ::input
-                                               ::output
-                                               ::project
-                                               ::release
-                                               ::uuid
-                                               ::version]))
-(s/def ::workload-responses   (s/* ::workload-response))
+;; compound
+(s/def ::workflows (s/or :aou (s/* ::workflow-aou)
+                         :wgs (s/+ ::workflow-wgs)))
+(s/def ::items (s/or :aou (s/+ ::items-aou)
+                     :wgs (s/+ ::items-wgs)))
+
+;; aou
+(s/def ::workflow-aou map?)               ; stub
+(s/def ::items-aou (constantly true))     ; stub
+(s/def ::notifications (s/* map?))
+(s/def ::analysis_version_number integer?)
+(s/def ::chip_well_barcode string?)
+(s/def ::append-to-aou-request (s/keys :req-un [::cromwell
+                                                ::environment
+                                                ::notifications
+                                                ::uuid]))
+(s/def ::append-to-aou-response (s/*
+                                  (s/or :none empty?
+                                        :more (s/keys :req-un [::uuid
+                                                               ::analysis_version_number
+                                                               ::chip_well_barcode]))))
+
+;; wgs
+(s/def ::sample_name string?)
+(s/def ::unmapped_bam_suffix string?)
+(s/def ::base_file_name string?)
+(s/def ::final_gvcf_base_name string?)
+(s/def ::input_cram string?)
+(s/def ::items-wgs (s/keys :opt-un [::base_file_name
+                                    ::final_gvcf_base_name
+                                    ::unmapped_bam_suffix]
+                           :req-un [::input_cram
+                                    ::sample_name]))
+(s/def ::workflow-wgs (s/keys :opt-un [::base_file_name
+                                       ::final_gvcf_base_name
+                                       ::status
+                                       ::unmapped_bam_suffix
+                                       ::updated
+                                       ::uuid]
+                              :req-un [::id
+                                       ::input_cram
+                                       ::sample_name]))
+
+;; /api/v1/workflows
+(s/def ::start string?)
+(s/def ::end string?)
+(s/def ::workflow-request (s/keys :req-un [::end
+                                           ::environment
+                                           ::start]))

--- a/src/zero/module/aou.clj
+++ b/src/zero/module/aou.clj
@@ -17,7 +17,7 @@
 
 (def workflow-wdl
   "The top-level WDL file and its version."
-  {:release "Arrays_v1.9"
+  {:release "Arrays_v1.9.1"
    :top     "pipelines/arrays/single_sample/Arrays.wdl"})
 
 (def cromwell-label-map

--- a/tests.edn
+++ b/tests.edn
@@ -25,7 +25,8 @@
      ;; will make sure are loaded. When providing a vector of symbols, or pointing
      ;; at a var containing a vector, then kaocha will call all referenced functions
      ;; for reporting.
-     :reporter    [kaocha.report.progress/report]
+     :reporter    [kaocha.report/documentation
+                   #_kaocha.report.progress/report]
 
      ;; Enable/disable output capturing.
      :capture-output? true

--- a/tests.edn
+++ b/tests.edn
@@ -9,8 +9,8 @@
               :ns-patterns  ["zero\\.unit\\..*-test$"]}]
 
      :plugins [
-               :kaocha.plugin/print-invocations
-;;               :kaocha.plugin/profiling
+               :print-invocations
+               :profiling
                ]
 
      ;; Colorize output (use ANSI escape sequences).


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- No ticket is linked to this PR.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Upgrade the version of Arrays pipeline to `v1.9.1`. (see https://broadinstitute.slack.com/archives/CESEYJW9W/p1596465923385200)
- Use tempdir to avoid polluting file system when running cloud function tests locally. 
- Refactor the specs so they are grouped in a reasonable way for future development.
- Remove a wgs workflow test from the endpoint testing, remove that endpoint as well.
- Switch to use the `documentation` reporter as the default progress of kaocha. 

    Before:
    ```
    unit:   100% [==================================================] 13/13
    13 tests, 60 assertions, 0 failures.
    ```

    After:
    ```
    --- integration (clojure.test) ---------------------------
    zero.integration.v1-endpoint-test
      test-exec-wgs-workload
        The `exec` endpoint creates and starts a WGS workload
      test-append-to-aou-workload
        The `append_to_aou` endpoint appends a new workflow to aou workload.
      test-create-aou-workload
        The `create` endpoint creates new AOU workload
      test-create-wgs-workload
        The `create` endpoint creates new WGS workload
      test-start-aou-workload
        The `start` endpoint starts an existing AOU workload
      test-exec-aou-workload
        The `exec` endpoint creates and starts an AOU workload
      test-copyfile-workload
      test-start-wgs-workload
        The `start` endpoint starts an existing WGS workload

    8 tests, 31 assertions, 0 failures.

    Top 1 slowest kaocha.type/clojure.test (233.39679 seconds, 100.0% of total time)
      integration
        233.39679 seconds average (233.39679 seconds / 1 tests)

    Top 1 slowest kaocha.type/ns (233.38548 seconds, 100.0% of total time)
      zero.integration.v1-endpoint-test
        29.17319 seconds average (233.38548 seconds / 8 tests)

    Top 3 slowest kaocha.type/var (210.50641 seconds, 90.2% of total time)
      zero.integration.v1-endpoint-test/test-copyfile-workload
        198.12834 seconds zero/integration/v1_endpoint_test.clj:101
      zero.integration.v1-endpoint-test/test-create-wgs-workload
        6.31759 seconds zero/integration/v1_endpoint_test.clj:22
      zero.integration.v1-endpoint-test/test-exec-aou-workload
        6.06048 seconds zero/integration/v1_endpoint_test.clj:94
    ```

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
