### PR TITLE
[GH-875] Cloud SQL Instance name inference

### DIFF
--- a/ops/cli.py
+++ b/ops/cli.py
@@ -148,21 +148,8 @@ def set_up_k8s(project: str, namespace: str, cluster: str, zone: str):
     success(f"[✔] Set namespace to {namespace}.")
 
 
-def run_cloudsql_proxy(project: str, cloudsql_instance_name: str = None):
+def run_cloudsql_proxy(project: str, cloudsql_instance_name):
     """Connect to a google cloud sql instance using the cloud sql proxy."""
-    if cloudsql_instance_name is None:
-        info("=> Finding cloud_sql_proxy instance")
-        gcloud_command = f"gcloud --format=json --project {project} sql instances list"
-        instances = json.loads(subprocess.check_output(gcloud_command, shell=True, encoding='utf-8').strip())
-        instance_names = instances\
-            .filter(lambda i: i.get("settings", {}).get("labels", {}).get("wfl", False))\
-            .map(lambda i: i["name"])
-        if len(instance_names) == 1:
-            cloudsql_instance_name = instance_names[0]
-            info(f"   Found instance: {cloudsql_instance_name}")
-        else:
-            error(f"   Didn't find one instance: {instance_names}")
-            exit(1)
     info("=> Running cloud_sql_proxy")
     token = subprocess.check_output("gcloud auth print-access-token", shell=True, encoding='utf-8').strip()
     instance_command = " ".join([f"gcloud --format=json sql --project {project}",

--- a/ops/cli.py
+++ b/ops/cli.py
@@ -163,9 +163,10 @@ def run_cloudsql_proxy(project: str, cloudsql_instance_name: str):
 def infer_cloudsql_name(project: str):
     """Try to find a single cloudsql instance with a truthy 'wfl' tag."""
     info("=> Finding cloud_sql_proxy instance")
-    gcloud_command = f"gcloud --format=json --project {project} sql instances list"
+    gcloud_command = ". ".join([f"gcloud --format=json --project {project} sql instances list",
+                                "--filter=\"settings.userLabels.wfl=true\""])
     instances = json.loads(subprocess.check_output(gcloud_command, shell=True, encoding='utf-8').strip())
-    instance_names = [i["name"] for i in instances if i.get("settings", {}).get("labels", {}).get("wfl", False)]
+    instance_names = [i["name"] for i in instances]
     if len(instance_names) == 1:
         info(f"   Found instance: {instance_names[0]}")
         return instance_names[0]

--- a/ops/cli.py
+++ b/ops/cli.py
@@ -148,7 +148,7 @@ def set_up_k8s(project: str, namespace: str, cluster: str, zone: str):
     success(f"[✔] Set namespace to {namespace}.")
 
 
-def run_cloudsql_proxy(project: str, cloudsql_instance_name):
+def run_cloudsql_proxy(project: str, cloudsql_instance_name: str):
     """Connect to a google cloud sql instance using the cloud sql proxy."""
     info("=> Running cloud_sql_proxy")
     token = subprocess.check_output("gcloud auth print-access-token", shell=True, encoding='utf-8').strip()

--- a/ops/cli.py
+++ b/ops/cli.py
@@ -165,9 +165,7 @@ def infer_cloudsql_name(project: str):
     info("=> Finding cloud_sql_proxy instance")
     gcloud_command = f"gcloud --format=json --project {project} sql instances list"
     instances = json.loads(subprocess.check_output(gcloud_command, shell=True, encoding='utf-8').strip())
-    instance_names = instances \
-        .filter(lambda i: i.get("settings", {}).get("labels", {}).get("wfl", False)) \
-        .map(lambda i: i["name"])
+    instance_names = [i["name"] for i in instances if i.get("settings", {}).get("labels", {}).get("wfl", False)]
     if len(instance_names) == 1:
         info(f"   Found instance: {instance_names[0]}")
         return instance_names[0]

--- a/ops/cli.py
+++ b/ops/cli.py
@@ -266,7 +266,7 @@ class CLI:
         """Connect to the Cloud SQL proxy through docker."""
         parser = argparse.ArgumentParser(description=f"{self.connect.__doc__}")
         parser.add_argument("-p", "--project", default="broad-gotc-dev", dest="project", help="The google project that Cloud SQL is running in. e.g. broad-gotc-dev")
-        parser.add_argument("-i", "--instance", default="zero-postgresql", dest="instance", help="The name of the Cloud SQL instance. e.g. zero-postgresql")
+        parser.add_argument("-i", "--instance", dest="instance", help="The name of the Cloud SQL instance, instead of finding one with a 'wfl' label.")
         args = parser.parse_args(arguments)
         container = run_cloudsql_proxy(project=args.project, cloudsql_instance_name=args.instance)
         success(f"[✔] You have connected to Zero's Cloud SQL instance {args.instance} in {args.project}")

--- a/ops/cli.py
+++ b/ops/cli.py
@@ -148,8 +148,21 @@ def set_up_k8s(project: str, namespace: str, cluster: str, zone: str):
     success(f"[✔] Set namespace to {namespace}.")
 
 
-def run_cloudsql_proxy(project: str, cloudsql_instance_name):
+def run_cloudsql_proxy(project: str, cloudsql_instance_name: str = None):
     """Connect to a google cloud sql instance using the cloud sql proxy."""
+    if cloudsql_instance_name is None:
+        info("=> Finding cloud_sql_proxy instance")
+        gcloud_command = f"gcloud --format=json --project {project} sql instances list"
+        instances = json.loads(subprocess.check_output(gcloud_command, shell=True, encoding='utf-8').strip())
+        instance_names = instances\
+            .filter(lambda i: i.get("settings", {}).get("labels", {}).get("wfl", False))\
+            .map(lambda i: i["name"])
+        if len(instance_names) == 1:
+            cloudsql_instance_name = instance_names[0]
+            info(f"   Found instance: {cloudsql_instance_name}")
+        else:
+            error(f"   Didn't find one instance: {instance_names}")
+            exit(1)
     info("=> Running cloud_sql_proxy")
     token = subprocess.check_output("gcloud auth print-access-token", shell=True, encoding='utf-8').strip()
     instance_command = " ".join([f"gcloud --format=json sql --project {project}",

--- a/ops/cli.py
+++ b/ops/cli.py
@@ -327,6 +327,12 @@ class CLI:
             help="Deploy to this namespace."
         )
         parser.add_argument(
+            "-i",
+            "--instance",
+            dest="cloudsql_instance",
+            help="The name of the Cloud SQL instance, instead of finding one with a 'wfl' label."
+        )
+        parser.add_argument(
             "-d",
             "--dry-run",
             dest="dry_run",
@@ -374,7 +380,7 @@ class CLI:
                 helm_values = yaml.safe_load(f)
             db_username = helm_values['api']['env']['ZERO_POSTGRES_USERNAME']
             db_password = helm_values['api']['env']['ZERO_POSTGRES_PASSWORD']
-            container = run_cloudsql_proxy(project=project, cloudsql_instance_name="zero-postgresql")
+            container = run_cloudsql_proxy(project=project, cloudsql_instance_name=args.cloudsql_instance)
             run_liquibase_migration(db_username, db_password)
             info("=> Stopping cloud_sql_proxy")
             shell(f"docker stop {container}")


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-875
- We need cli.py to be smarter about how it finds the name of the Cloud SQL instance (as in, it needs to be not hardcoded)

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Add a parameter to the `deploy` command to specify the instance (there was already one for `connect`)
- Remove the existing default (it references a soon-to-be-deleted orphaned resource)
- If the parameter isn't passed, look for a single Cloud SQL instance in the project with a [present and truthy 'wfl' tag](https://github.com/broadinstitute/terraform-shared/pull/122)
   - Bonus: this inference happens early during `deploy` execution so `deploy --dry-run` will print out the inferred name without doing anything to it

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

-  If you specify the name of the old orphaned Cloud SQL instance ("zero-postgresql") you should be able to deploy right now to gotc-dev.
- Blocked by [this PR](https://github.com/broadinstitute/terraform-shared/pull/122), you can `deploy --dry-run -e aou` to see it infer the AoU DB instance
   - I recommend we use this as the main test before merging, rather than waiting for the below. The below ones are likely to fail for reasons relating to the blocking tickets, not the task at hand.
- Blocked by the above referenced PR and [also this other one](https://github.com/broadinstitute/gotc-deploy/pull/111), you can `deploy --dry-run` to see it infer the gotc-dev DB instance or you can `deploy` to see it deploy to gotc-dev
- Blocked by the above referenced PR and [also this other (different) one](https://github.com/broadinstitute/gotc-deploy/pull/109), you can run `deploy -e aou` to see it deploy to AoU