### PR TITLE
disable workflow on push into master - make manual

### DIFF
--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -6,10 +6,11 @@ name: Build and Publish Docker
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
 on:
-  push:
-    branches:
-      - master
-
+  workflow_dispatch:
+    inputs:
+      version:
+        description: semantic version to build and push.
+        required: true
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
@@ -21,8 +22,9 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.inputs.version }}
 
     - name: Get Branch Name
       id: get_branch

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ include $(MAKE_INCLUDE_DIR)/common.mk
 
 # Enable for `WFL_VERSION` to be overriden
 # Example:
-# $ WFL_VERSION=1.2.3 make
+# $ make WFL_VERSION=1.2.3
 export WFL_VERSION ?= $(shell $(CAT) $(PROJECT_DIR)/version)
 
 MODULES := api cloud_function docs helm ui


### PR DESCRIPTION
### Purpose
Now that `wfl` uses semantic versioning, we should disable this automation as it'll clobber the images in docker hub.
We should instead adopt a release workflow and bump versions accordingly. 

### Changes
Make the `Build and Publish Docker` manually initiated.

### Review Instructions
