### PR TITLE
[GH-877] New cli.py for new wfl-instance Terraform module

### DIFF
--- a/ops/cli.py
+++ b/ops/cli.py
@@ -102,7 +102,8 @@ class Config:
         """Look in the cluster list for the cluster's zone."""
         clusters = json.loads(shell(f"gcloud --project {self.project} --format=json "
                                     "container clusters list "
-                                    f"--filter='name={self.cluster_name}'"))
+                                    f"--filter='name={self.cluster_name}'",
+                                    quiet=True))
         if len(clusters) == 1:
             return clusters[0]["zone"]
         else:

--- a/ops/cli.py
+++ b/ops/cli.py
@@ -121,7 +121,7 @@ def configure_kubectl(config: WflInstanceConfig) -> None:
     ctx = f"gke_{config.project}_{config.cluster_zone}_{config.cluster_name}"
     shell(f"kubectl config use-context {ctx}")
     try:
-        namespaces = json.loads(shell("kubectl get namespace -o json", timeout=5))
+        namespaces = json.loads(shell("kubectl get namespace -o json", timeout=10))
         if config.cluster_namespace not in [item["metadata"]["name"] for item in namespaces["items"]]:
             info(f"    Available namespaces in {config.cluster_name}:", plain=True)
             info(shell("kubectl get namespace", quiet=True), plain=True)

--- a/ops/cli.py
+++ b/ops/cli.py
@@ -54,9 +54,9 @@ def validate_cloud_sql_name(config: WflInstanceConfig) -> None:
         instances = json.loads(shell(f"gcloud --project {config.project} --format=json "
                                      "sql instances list"))
         if config.cloud_sql_name not in [i["name"] for i in instances]:
+            error(f"Cloud SQL instance {config.cloud_sql_name} not found")
             info(f"    Available Cloud SQL instances in {config.project}:", plain=True)
             info(shell(f"gcloud --project {config.project} sql instances list", quiet=True), plain=True)
-            raise RuntimeError(f"Cloud SQL instance {config.cloud_sql_name} not found")
         else:
             success(f"Cloud SQL instance {config.cloud_sql_name} exists")
 
@@ -68,9 +68,9 @@ def validate_cluster_name(config: WflInstanceConfig) -> None:
         clusters = json.loads(shell(f"gcloud --project {config.project} --format=json "
                                     f"container clusters list"))
         if config.cluster_name not in [c["name"] for c in clusters]:
+            error(f"GKE cluster {config.cluster_name} not found")
             info(f"    Available clusters in {config.project}:", plain=True)
             info(shell(f"gcloud --project {config.project} container clusters list", quiet=True), plain=True)
-            raise RuntimeError(f"GKE cluster {config.cluster_name} not found")
         else:
             success(f"GKE cluster {config.cluster_name} exists")
 
@@ -123,9 +123,9 @@ def configure_kubectl(config: WflInstanceConfig) -> None:
     try:
         namespaces = json.loads(shell("kubectl get namespace -o json", timeout=10))
         if config.cluster_namespace not in [item["metadata"]["name"] for item in namespaces["items"]]:
+            error(f"Namespace {config.cluster_namespace} not found in {config.cluster_name}")
             info(f"    Available namespaces in {config.cluster_name}:", plain=True)
             info(shell("kubectl get namespace", quiet=True), plain=True)
-            raise RuntimeError(f"Namespace {config.cluster_namespace} not found in {config.cluster_name}")
         else:
             shell(f"kubectl config set-context --current --namespace={config.cluster_namespace}")
             success("Kubernetes configured")

--- a/ops/cli.py
+++ b/ops/cli.py
@@ -282,6 +282,12 @@ class DeployCommand(ConnectCommand):
 
 
 class CLI:
+    command_mapping = {
+        "deploy": DeployCommand,
+        "connect": ConnectCommand,
+        "info": InfoCommand
+    }
+
     def __init__(self):
         """Set up the parser."""
         parser = argparse.ArgumentParser(description="Deploy or connect to WFL infrastructure instances",
@@ -292,9 +298,9 @@ class CLI:
                             help="Force COMMAND to run even if validation fails")
         commands = parser.add_argument_group("COMMAND")
         commands.add_argument("command",
-                              type=lambda s: getattr(sys.modules[__name__], f"{s.title()}Command"),
-                              choices=[DeployCommand, ConnectCommand, InfoCommand],
-                              metavar="{deploy, connect, info}",
+                              type=lambda s: self.command_mapping.get(s),
+                              choices=self.command_mapping.values(),
+                              metavar=f"{{{', '.join(self.command_mapping.keys())}}}",
                               help="Deploy the local build to the instance, "
                                    "connect to the instance's Cloud SQL, "
                                    "or display instance config")

--- a/ops/cli.py
+++ b/ops/cli.py
@@ -177,9 +177,8 @@ class InfoCommand(Config):
     def __init__(self, parsed_args: argparse.Namespace):
         super().__init__(parsed_args)
 
-    # This can't be static if we're to override it in subclasses
-    # noinspection PyMethodMayBeStatic
-    def execute(self) -> int:
+    @staticmethod
+    def execute() -> int:
         return 0
 
 

--- a/ops/cli.py
+++ b/ops/cli.py
@@ -1,26 +1,28 @@
 #!/usr/bin/env python3
-"""WFL Deployment Script
-@rex
+"""
+WFL Deployment Script
 
-requirements: pip3 install gitpython pyyaml
+requirements: pip3 install pyyaml
 
 usage: python3 cli.py -h
 """
-from enum import Enum
-from pathlib import Path
-from typing import Callable
 import argparse
 import json
 import os
 import shutil
 import subprocess
 import sys
-import tempfile
+from enum import Enum
+from typing import Callable, Optional
+
 import yaml
+
+from .render_ctmpl import render_ctmpl
 
 # In case this will need to run on Windows systems
 if sys.platform.lower() == "win32":
     os.system("color")
+
 
 class AvailableColors(Enum):
     GRAY = 90
@@ -44,308 +46,351 @@ def _apply_color(color: str, message: str) -> str:
     return f"\033[1;{color_code}m{message}\033[0m"
 
 
-def info(message: str):
+def info(message: str, plain=False):
     """Log the info to stdout"""
-    print(_apply_color("default", message))
+    print(_apply_color("default", message) if not plain else message)
 
 
 def success(message: str):
     """Log the success to stdout"""
-    print(_apply_color("green", message))
+    print(_apply_color("green", f"[✔] {message}"))
 
 
 def error(message: str):
     """Log the error to stderr"""
-    print(_apply_color("red", message), file=sys.stderr)
+    print(_apply_color("red", f"[✗] {message}"), file=sys.stderr)
 
 
 def warn(message: str):
     """Log the warning to stdout"""
-    print(_apply_color("yellow", message))
+    print(_apply_color("yellow", f"[!] {message}"))
 
 
-def registerableCLI(cls):
-    """Class decorator to register methodss with @register into a set."""
-    cls.registered_commands = set([])
-    for name in dir(cls):
-        method = getattr(cls, name)
-        if hasattr(method, "registered"):
-            cls.registered_commands.add(name)
-    return cls
-
-
-def register(func: Callable) -> Callable:
-    """Method decorator to register CLI commands."""
-    func.registered = True
-    return func
-
-
-def shell(command: str) -> str:
+def shell(command: str, quiet: bool = False, timeout: Optional[float] = None) -> str:
     """Run COMMAND in a subprocess."""
-    info(f"Running: {command}")
-    return subprocess.check_output(command, shell=True, encoding="utf-8").strip()
+    if not quiet:
+        info(f"Running: {command}")
+    try:
+        return subprocess.check_output(command, shell=True, timeout=timeout, encoding="utf-8").strip()
+    except subprocess.CalledProcessError as err:
+        error(f"Error running: {command}")
+        error(err.output)
+        exit(err.returncode)
 
 
-def shell_unchecked(command: str):
-    """Run COMMAND in a subprocess and who cares whether it fails!"""
-    warn(f"Running unchecked: {command}")
-    return subprocess.call(command, shell=True)
+class Config:
+    """Base class for storing/resolving/validating command line input."""
+
+    def __init__(self, parsed_args: argparse.Namespace):
+        """Resolve and store input from parsed arguments."""
+        self.command: str = parsed_args.command
+        self.dry_run: bool = parsed_args.dry_run
+        self.force: bool = parsed_args.force
+        self.environment: str = parsed_args.environment
+        info(f"=>  Resolving {self.command} configuration")
+        self.version: str = \
+            self.__resolve_config_value("Version", parsed_args.version, lambda: self.__read_version())
+        self.gotc_deploy_folder: str = \
+            self.__resolve_config_value("GotC Deploy folder", f"gotc-deploy/deploy/{self.environment}")
+        self.instance_id: str = \
+            self.__resolve_config_value("Instance ID", parsed_args.instance)
+        self.project: str = \
+            self.__resolve_config_value("GCP project", parsed_args.project, lambda: f"broad-{self.environment}")
+        self.cloudsql_name: str = \
+            self.__resolve_config_value("CloudSQL name", parsed_args.cloud_sql, lambda: self.__find_cloudsql_name())
+        self.cluster_name: str = \
+            self.__resolve_config_value("GKE cluster name", parsed_args.cluster, lambda: self.__find_cluster_name())
+        self.cluster_zone: str = \
+            self.__resolve_config_value("GKE cluster zone", parsed_args.zone, lambda: self.__find_cluster_zone())
+        self.cluster_namespace: str = \
+            self.__resolve_config_value("Kubernetes namespace", parsed_args.namespace,
+                                        lambda: f"{self.instance_id}-wfl")
+        success("Resolved configuration")
+
+    @staticmethod
+    def __resolve_config_value(description: str, specific: str, default: Callable[[], str] = lambda: None) -> str:
+        """Either use the specific value if truthy or calculate the default, printing accordingly."""
+        val = specific or default()
+        info(f"    {description.ljust(20, '.')}: {val}{' (specifically supplied)' if specific else ''}")
+        return val
+
+    @staticmethod
+    def __read_version() -> str:
+        with open("version") as version_file:
+            return version_file.read().strip()
+
+    def __find_cloudsql_name(self) -> str:
+        """Use labels to identify the Cloud SQL name."""
+        instances = json.loads(shell(f"gcloud --project {self.project} --format=json "
+                                     "sql instances list "
+                                     f"--filter='labels.app_name=wfl AND labels.instance_id={self.instance_id}'",
+                                     quiet=True))
+        if len(instances) == 1:
+            return instances[0]["name"]
+        else:
+            error("No CloudSQL instance could be inferred")
+            info("    Couldn't find a single match for "
+                 f"`--filter='labels.app_name=wfl AND labels.instance_id={self.instance_id}'`")
+            info(f"    Available instances in {self.project}:", plain=True)
+            info(shell(f"gcloud --project {self.project} sql instances list", quiet=True), plain=True)
+            return "null" if self.force else exit(1)
+
+    def __find_cluster_name(self) -> str:
+        """Look at the Cloud SQL labels to find the cluster name."""
+        instances = json.loads(shell(f"gcloud --project {self.project} --format=json "
+                                     "sql instances list "
+                                     f"--filter='labels.app_name=wfl AND labels.instance_id={self.instance_id}'",
+                                     quiet=True))
+        if len(instances) == 1:
+            return instances[0]["labels"]["app_cluster"]
+        else:
+            error("No cluster name could be inferred")
+            info("    Couldn't find a single match for "
+                 f"`--filter='labels.app_name=wfl AND labels.instance_id={self.instance_id}'`")
+            info("    The `app_cluster` label is used to find cluster name, see wfl-instance documentation.")
+            info(f"    Available clusters in {self.project}:", plain=True)
+            info(shell(f"gcloud --project {self.project} container clusters list", quiet=True), plain=True)
+            return "null" if self.force else exit(1)
+
+    def __find_cluster_zone(self) -> str:
+        """Look in the cluster list for the cluster's zone."""
+        clusters = json.loads(shell(f"gcloud --project {self.project} --format=json "
+                                    "container clusters list "
+                                    f"--filter='name={self.cluster_name}'"))
+        if len(clusters) == 1:
+            return clusters[0]["zone"]
+        else:
+            error(f"No cluster zone could be found for cluster named {self.cluster_name}")
+            info("    Couldn't find a single match for "
+                 f"`--filter='name={self.cluster_name}'`")
+            return "null" if self.force else exit(1)
+
+    def validate(self):
+        """Validate stored configuration, exiting upon failure if not forced."""
+        info(f"=>  Validating {self.command} configuration")
+        issues = 0
+        if self.__cloudsql_exists():
+            success(f"CloudSQL instance {self.cloudsql_name} exists")
+        else:
+            error(f"CloudSQL instance {self.cloudsql_name} not found")
+            info(f"    Available instances in {self.project}:", plain=True)
+            info(shell(f"gcloud --project {self.project} sql instances list", quiet=True), plain=True)
+            issues += 1 if self.force else exit(1)
+        if self.__cluster_exists():
+            success(f"GKE cluster {self.cluster_name} exists")
+        else:
+            error(f"GKE cluster {self.cluster_name} not found")
+            info(f"    Available clusters in {self.project}:", plain=True)
+            info(shell(f"gcloud --project {self.project} container clusters list", quiet=True), plain=True)
+            issues += 1 if self.force else exit(1)
+        if self.__namespace_exists():
+            success(f"Namespace {self.cluster_namespace} exists in cluster")
+            shell(f"gcloud set-context --current --namespace={self.cluster_namespace}")
+            info("    Namespace now set")
+        else:
+            error(f"Namespace {self.cluster_namespace} not found in cluster")
+            info(f"    Available namespaces in {self.cluster_name}:", plain=True)
+            info(shell("kubectl get namespace", quiet=True), plain=True)
+            issues += 1 if self.force else exit(1)
+        if issues != 0:
+            warn(f"{issues} issues but continuing due to '--force'")
+        else:
+            success("Validated configuration")
+
+    def __cluster_exists(self) -> bool:
+        """Check that the cluster exists."""
+        clusters = json.loads(shell(f"gcloud --project {self.project} --format=json "
+                                    f"container clusters list --zone {self.cluster_zone}"))
+        return self.cluster_name in [c["name"] for c in clusters]
+
+    def __cloudsql_exists(self) -> bool:
+        """Check that the Cloud SQL instanc exists."""
+        instances = json.loads(shell(f"gcloud --project {self.project} --format=json "
+                                     f"sql instances list"))
+        return self.cloudsql_name in [i["name"] for i in instances]
+
+    def __namespace_exists(self) -> bool:
+        """Configure K8s context and check that the namespace is present."""
+        info(f"=>  Configuring Kubernetes for {self.cluster_name}")
+        shell(f"gcloud --project {self.project} container clusters get-credentials "
+              f"{self.cluster_name} --zone {self.cluster_zone}")
+        ctx = f"gke_{self.project}_{self.cluster_zone}_{self.cluster_name}"
+        shell(f"kubectl config use-context {ctx}")
+        try:
+            namespaces = json.loads(shell("kubectl get namespace -o json", timeout=5))
+            return self.cluster_namespace in [item["metadata"]["name"] for item in namespaces["items"]]
+        except subprocess.TimeoutExpired:
+            error("Namespace query took too long--maybe you need to be on non-split VPN?")
+            return False
 
 
-def clone(url: str, branch: str):
-    """Clone the BRANCH of git repo at URL."""
-    info(f"=> Cloning {branch} of {url} ...")
-    shell(f"git clone {url} --branch {branch}")
-    success(f"[✔] Cloned {branch} of {url}.")
+class InfoCommand(Config):
+    """Class for info command that doesn't do anything special, just resolves/validates arguments."""
 
+    def __init__(self, parsed_args: argparse.Namespace):
+        super().__init__(parsed_args)
 
-def render_ctmpl(ctmpl_file: str, **kwargs) -> int:
-    """Render a ctmpl file."""
-    info("=> Rendering ctmpl file {ctmpl_file}")
-    envs = ""
-    if kwargs:
-        for k, v in kwargs.items():
-            envs += f"-e {k}={v}"
-    info(f"=> Feeding variables: {envs}")
-    command = " ".join(['docker run -i --rm -v "$(pwd)":/working',
-                        '-v "$HOME"/.vault-token:/root/.vault-token',
-                        f'{envs}',
-                        'broadinstitute/dsde-toolbox:dev',
-                        '/usr/local/bin/render-ctmpls.sh -k',
-                        f'"{ctmpl_file}"'])
-    shell_unchecked(command)
-    success(f"[✔] Rendered file {ctmpl_file.split('.ctmpl')[0]}")
-
-
-def commands_available():
-    commands = ["docker", "gcloud", "git", "helm", "java", "kubectl", "jq"]
-    for cmd in commands:
-        if not shutil.which(cmd):
-            error(f"=> {cmd} is not in PATH. Please install it!")
-
-
-def set_up_helm():
-    info("=> Setting up Helm charts")
-    ADD = " ".join(["helm repo add gotc-charts",
-                    "https://broadinstitute.github.io/gotc-helm-repo/"])
-    shell(ADD)
-    shell("helm repo update")
-    success("[✔] Set up Helm charts")
-
-
-def set_up_k8s(project: str, namespace: str, cluster: str, zone: str):
-    """Connect to K8S cluster and set up namespace."""
-    info(f"=> Setting up Kubernetes with namespace {namespace}.")
-    GCLOUD = " ".join(["gcloud container clusters get-credentials",
-                       f"{cluster} --zone {zone}",
-                       f"--project {project}"])
-    shell(GCLOUD)
-    info("=> Setting up Kubernetes cluster context.")
-    ctx = f"gke_{project}_{zone}_{cluster}"
-    shell(f"kubectl config use-context {ctx} --namespace={namespace}")
-    success(f"[✔] Set context to {ctx}.")
-    success(f"[✔] Set namespace to {namespace}.")
-
-
-def run_cloudsql_proxy(project: str, cloudsql_instance_name):
-    """Connect to a google cloud sql instance using the cloud sql proxy."""
-    info("=> Running cloud_sql_proxy")
-    token = subprocess.check_output("gcloud auth print-access-token", shell=True, encoding='utf-8').strip()
-    instance_command = " ".join([f"gcloud --format=json sql --project {project}",
-                             f"instances describe {cloudsql_instance_name}",
-                             "| jq .connectionName | tr -d '\"'"])
-    instance = subprocess.check_output(instance_command, shell=True, encoding='utf-8').strip()
-    docker_command = " ".join(['docker run --rm -d -p 127.0.0.1:5432:5432 gcr.io/cloudsql-docker/gce-proxy:1.16 /cloud_sql_proxy',
-                        f'-token="{token}" -instances="{instance}=tcp:0.0.0.0:5432"'])
-    return subprocess.check_output(docker_command, shell=True, encoding='utf-8').strip()
-
-
-def run_liquibase_migration(db_username, db_password):
-    """Run liquibase migration on the database that the cloudsql proxy is connected to."""
-    info("=> Running liquibase")
-    db_url = "jdbc:postgresql://localhost:5432/wfl?useSSL=false"
-    changelog_dir = os.path.join(os.getcwd(), "database")
-    command = ' '.join(['docker run --rm --net=host',
-                        f'-v {changelog_dir}:/liquibase/changelog liquibase/liquibase',
-                        f'--url="{db_url}" --changeLogFile=/changelog/changelog.xml',
-                        f'--username="{db_username}" --password="{db_password}" update'])
-    shell(command)
-    success("[✔] Ran liquibase migration")
-
-
-def helm_deploy_wfl(values: str):
-    """Use Helm to deploy WFL to K8S using VALUES."""
-    info("=> Deploying to K8S cluster with Helm.")
-    info("=> This must run on a non-split VPN.")
-    shell(f"helm upgrade wfl-k8s gotc-charts/wfl -f {values} --install")
-    info("[✔] WFL is deployed. Run `kubectl get pods` for details.")
-
-
-def publish_docker_images(version: str):
-    """Push API and UI docker images with TAG in DIRECTORY."""
-    for x in ["api", "ui"]:
-        shell(f"docker push broadinstitute/workflow-launcher-{x}:{version}")
-
-
-@registerableCLI
-class CLI:
-    def __init__(self):
-        parser = argparse.ArgumentParser(
-            description="Deploy the Workflow Launcher API and UI.",
-            usage=self.usage()
-        )
-        parser.add_argument("command", help="command from above to run")
-        if len(sys.argv[1:2]) == 0:
-            parser.print_help()
-            exit(1)
-        self.main_parser = parser
-
-    def __call__(self) -> int:
-        args = self.main_parser.parse_args(sys.argv[1:2])
-        if args.command not in self.registered_commands:
-            self.main_parser.print_help()
-            return 1
-        return getattr(self, args.command)(sys.argv[2:])
-
-    def usage(self) -> str:
-        max = 0
-        for command in sorted(self.registered_commands):
-            if len(command) > max:
-                max = len(command)
-        msg = "\n"
-        for command in sorted(self.registered_commands):
-            msg += f"  {command}{' ' * (max - len(command))}"
-            msg += f" |-> {getattr(self, command).__doc__}\n"
-        return msg
-
-    @register
-    def render(self, arguments: list) -> int:
-        """Render a CTMPL file."""
-        parser = argparse.ArgumentParser(description=f"{self.render.__doc__}")
-        parser.add_argument("file", help="CTMPL file to be rendered")
-        args = parser.parse_args(arguments)
-        file = Path(args.file)
-        assert file.exists() and file.is_file(), f"{file} is not valid!"
-        render_ctmpl(ctmpl_file=str(file))
+    # This can't be static if we're to override it in subclasses
+    # noinspection PyMethodMayBeStatic
+    def execute(self) -> int:
         return 0
 
-    @register
-    def connect(self, arguments: list) -> int:
-        """Connect to the Cloud SQL proxy through docker."""
-        parser = argparse.ArgumentParser(description=f"{self.connect.__doc__}")
-        parser.add_argument("-p", "--project", default="broad-gotc-dev", dest="project", help="The google project that Cloud SQL is running in. e.g. broad-gotc-dev")
-        parser.add_argument("-i", "--instance", default="zero-postgresql", dest="instance", help="The name of the Cloud SQL instance. e.g. zero-postgresql")
-        args = parser.parse_args(arguments)
-        container = run_cloudsql_proxy(project=args.project, cloudsql_instance_name=args.instance)
-        success(f"[✔] You have connected to Zero's Cloud SQL instance {args.instance} in {args.project}")
-        info(f'To use psql, run: \n\t psql "host=127.0.0.1 sslmode=disable dbname=<DB_NAME> user=<USER_NAME>"')
+
+class ConnectCommand(Config):
+    """Class for connect command that enables `psql` to the Cloud SQL instance."""
+
+    def __init__(self, parsed_args: argparse.Namespace):
+        super().__init__(parsed_args)
+
+    def execute(self) -> int:
+        """Run the Cloud SQL proxy and print `psql` instructions."""
+        container = self.run_cloudsql_proxy()
+        success(f"You have connected to WFL's CloudSQL instance {self.cloudsql_name} "
+                f"in {self.environment}'s {self.instance_id} wfl-instance")
+        info(f'To use psql, run: \n\t psql "host=127.0.0.1 sslmode=disable  dbname=<DB_NAME> user=<USER_NAME>"')
         info(f"To disconnect and stop the container, run: \n\t docker stop {container}")
         return 0
 
-    @register
-    def deploy(self, arguments) -> int:
-        """Deploy WFL to Cloud GKE (VPN is required)"""
-        parser = argparse.ArgumentParser(description=f"{self.deploy.__doc__}")
-        parser.add_argument(
-            "-z",
-            "--zone",
-            dest="zone",
-            default="us-central1-a",
-            help="Use this location for the google cloud cluster."
-        )
-        parser.add_argument(
-            "-e",
-            "--environment",
-            dest="environment",
-            default="gotc-dev",
-            choices=["gotc-dev", "gotc-prod", "aou"],
-            help="Deploy to project 'broad-{ENVIRONMENT}' in cluster '{ENVIRONMENT}-shared-{ZONE}' via "
-                 "'gotc-deploy/deploy/{ENVIRONMENT}'."
-        )
-        parser.add_argument(
-            "-c",
-            "--cluster",
-            dest="cluster",
-            help="Overrides ENVIRONMENT; specify cluster name as '{CLUSTER}-{ZONE}'."
-        )
-        parser.add_argument(
-            "-p",
-            "--project",
-            dest="project",
-            help="Overrides ENVIRONMENT; specify exact gcp project name."
-        )
-        parser.add_argument(
-            "-g",
-            "--gotc-folder",
-            dest="gotc_folder",
-            help="Overrides ENVIRONMENT; specify exact 'gotc-deploy/deploy/{GOTC_FOLDER}' path to use."
-        )
-        parser.add_argument(
-            "-n",
-            "--namespace",
-            dest="namespace",
-            default="default",
-            help="Deploy to this namespace."
-        )
-        parser.add_argument(
-            "-d",
-            "--dry-run",
-            dest="dry_run",
-            action="store_true",
-            help="When provided, exit after printing parsed arguments."
-        )
-        parser.add_argument(
-            "--cluster-no-zone-name",
-            dest="cluster_no_zone_name",
-            action="store_true",
-            help="When provided, do not append '-{ZONE}' to the CLUSTER name."
-        )
-        args = parser.parse_args(arguments)
-        project = args.project if args.project is not None else f"broad-{args.environment}"
-        cluster = args.cluster if args.cluster is not None else f"{args.environment}-shared"
-        if not args.cluster_no_zone_name:
-            cluster = f"{cluster}-{args.zone}"
-        gotc_folder = args.gotc_folder if args.gotc_folder is not None else args.environment
-        info("=> Deploy config:")
-        info(f"   GCP project: {project}")
-        info(f"   GCP zone: {args.zone}")
-        info(f"   GCP cluster: {cluster} (namespace: {args.namespace})")
-        info(f"   GOTC deploy folder: gotc-deploy/deploy/{gotc_folder}")
-        if args.dry_run:
-            info("=> Exiting due to --dry-run")
-            return 0
+    def run_cloudsql_proxy(self):
+        """Use docker via gce-proxy to connect to the Cloud SQL instance."""
+        info("=>  Running cloud_sql_proxy")
+        token = shell("gcloud auth print-access-token")
+        connectionName = json.loads(shell(f"gcloud --project {self.project} --format=json sql instances"
+                                          f"describe {self.cloudsql_name}"))["connectionName"]
+        return shell(f"docker run --rm -d -p 127.0.0.1:5432:5432 gcr.io/cloudsql-docker/gce-proxy:1.16 "
+                     f"/cloud_sql_proxy -token='{token}' -instances='{connectionName}=tcp:0.0.0.0:5432'")
 
-        commands_available()
-        set_up_helm()
-        set_up_k8s(project=project, namespace=args.namespace, cluster=cluster, zone=args.zone)
 
-        version = shell("cat version")
-        publish_docker_images(version=version)
+class DeployCommand(ConnectCommand):
+    """Class for deploy command that deploys WFL to infrastructure."""
+
+    def __init__(self, parsed_args: argparse.Namespace):
+        super().__init__(parsed_args)
+
+    def execute(self) -> int:
+        """Set up helm, publish docker, render CTMPL, helm deploy, migrate liquibase."""
+
+        if not input(f"Are you sure you want to deploy version {self.version}? [N/y]").lower().startswith("y"):
+            exit(0)
+
+        self.__set_up_helm()
+
+        self.__publish_docker_images()
 
         deploy = os.path.join("derived", "helm", "deploy")
         if not os.path.exists(deploy):
             os.makedirs(deploy)
 
         values = "wfl-values.yaml"
-        ctmpl = f"derived/2p/gotc-deploy/deploy/{gotc_folder}/helm/{values}.ctmpl"
+        ctmpl = f"derived/2p/{self.gotc_deploy_folder}/helm/{values}.ctmpl"
         shutil.copy(ctmpl, deploy)
 
-        render_ctmpl(ctmpl_file=f"{deploy}/{values}.ctmpl", WFL_VERSION=version)
-        helm_deploy_wfl(values=f"{deploy}/{values}")
+        render_ctmpl(ctmpl_file=f"{deploy}/{values}.ctmpl", WFL_VERSION=self.version)
+        self.__helm_deploy_wfl(values=f"{deploy}/{values}")
 
-        container = run_cloudsql_proxy(project=project, cloudsql_instance_name="zero-postgresql")
-        with open(f"{deploy}/{values}") as f:
-            helm_values = yaml.safe_load(f)
+        container = self.run_cloudsql_proxy()
+        with open(f"{deploy}/{values}") as values_file:
+            helm_values = yaml.safe_load(values_file)
             env = helm_values['api']['env']
-            run_liquibase_migration(env['ZERO_POSTGRES_USERNAME'], env['ZERO_POSTGRES_PASSWORD'])
-            info("=> Stopping cloud_sql_proxy")
-            shell(f"docker stop {container}")
+            self.__run_liquibase_migration(env['ZERO_POSTGRES_USERNAME'], env['ZERO_POSTGRES_PASSWORD'])
+        info("=>  Stopping cloud_sql_proxy")
+        shell(f"docker stop {container}")
 
-        success("[✔] Deployment is done!")
-        shell("kubectl get pods")
+        success("Deployment is done!")
+        info(shell("kubectl get pods"), plain=True)
+
         return 0
+
+    @staticmethod
+    def __set_up_helm():
+        """Add helm repo and update."""
+        info("=>  Setting up Helm charts")
+        shell("helm repo add gotc-charts https://broadinstitute.github.io/gotc-helm-repo/")
+        shell("helm repo update")
+        success("Set up Helm charts")
+
+    def __publish_docker_images(self):
+        """Publish docker build."""
+        info(f"=>  Publishing Docker images for version {self.version}")
+        for module in ["api", "ui"]:
+            shell(f"docker push broadinstitute/workflow-launcher-{module}:{self.version}")
+        success("Published Docker images")
+
+    def __helm_deploy_wfl(self, values: str):
+        """Helm deploy using gotc-charts/wfl."""
+        info(f"=>  Deploying to {self.cluster_name} in {self.cluster_namespace} namespace")
+        info("    This must run on a non-split VPN", plain=True)
+        shell(f"helm upgrade wfl-k8s gotc-charts/wfl -f {values} --install")
+        success("WFL deployed")
+
+    @staticmethod
+    def __run_liquibase_migration(db_username: str, db_password: str):
+        info("=>  Running liquibase migration")
+        db_url = "jdbc:postgresql://localhost:5432/wfl?useSSL=false"
+        changelog_dir = os.path.join(os.getcwd(), "database")
+        shell(f"docker run --rm --net=host "
+              f"-v {changelog_dir}:/liquibase/changelog liquibase/liquibase "
+              f"--url='{db_url}' --changeLogFile=/changelog/changelog.xml "
+              f"--username='{db_username}' --password='{db_password}' update")
+        success("[✔] Ran liquibase migration")
+
+
+class CLI:
+    def __init__(self):
+        """Set up the parser."""
+        parser = argparse.ArgumentParser(description="Deploy or connect to WFL infrastructure instances",
+                                         usage="%(prog)s [-h] [-d] COMMAND [-e ENV] [-i INSTANCE] [...]")
+        parser.add_argument("-d", "--dry-run", action="store_true",
+                            help="Prevent COMMAND from enacting changes")
+        parser.add_argument("-f", "--force", action="store_true",
+                            help="Force COMMAND to run even if validation fails")
+        commands = parser.add_argument_group("COMMAND")
+        commands.add_argument("command", choices=["deploy", "connect", "info"],
+                              help="Deploy the local build to the instance, "
+                                   "connect to the instance's Cloud SQL, "
+                                   "or display instance config")
+        typical = parser.add_argument_group("typical arguments",
+                                            "(usually necessary to target a particular instance)")
+        typical.add_argument("-e", "--environment", default="gotc-dev", metavar="ENV",
+                             choices=["gotc-dev", "gotc-prod", "aou"],
+                             help="Specify 'gotc-deploy/deploy/{ENV}' with one of: %(choices)s")
+        typical.add_argument("-i", "--instance", default="dev",
+                             help="Provide the ID of the target instance in the environment")
+        specific = parser.add_argument_group("specific arguments",
+                                             "(rarely necessary, inferred from typical arguments)")
+        specific.add_argument("-v", "--version",
+                              help="Specify the exact version to use instead of the 'version' file")
+        specific.add_argument("--project",
+                              help="Specify the exact GCP project name instead of 'broad-{ENV}'")
+        specific.add_argument("--cloud-sql",
+                              help="Specify the exact Cloud SQL name instead of inferring from labels")
+        specific.add_argument("--zone",  # don't set default here so Config knows if this was set
+                              help="Specify the exact GCP cluster zone instead of inferring from labels")
+        specific.add_argument("--cluster",
+                              help="Specify the exact GKE cluster name instead of inferring from labels")
+        specific.add_argument("--namespace",
+                              help="Specify the exact K8s namespace instead of '{INSTANCE}-wfl'")
+        self.parser = parser
+
+    def execute(self) -> int:
+        """Run command."""
+        args = self.parser.parse_args()
+        for cmd in ["docker", "gcloud", "git", "helm", "java", "kubectl", "jq"]:
+            if not shutil.which(cmd):
+                error(f"{cmd} is not in PATH. Please install it!")
+        commands = {
+            "info": InfoCommand,
+            "connect": ConnectCommand,
+            "deploy": DeployCommand
+        }
+        config = commands[args.command](args)
+        config.validate()
+        if config.dry_run:
+            success("Exiting due to '--dry-run'")
+            return 0
+        else:
+            return config.execute()
 
 
 if __name__ == "__main__":
-    c = CLI()
-    exit(c())
+    exit(CLI().execute())

--- a/ops/cli.py
+++ b/ops/cli.py
@@ -291,7 +291,7 @@ class CLI:
     def __init__(self):
         """Set up the parser."""
         parser = argparse.ArgumentParser(description="Deploy or connect to WFL infrastructure instances",
-                                         usage="%(prog)s [-h] [-d | -f] COMMAND [-e ENV] [-i INSTANCE] [...]")
+                                         usage="%(prog)s [-h] [-d | -f] COMMAND -e ENV -i INSTANCE [...]")
         parser.add_argument("-d", "--dry-run", action="store_true",
                             help="Prevent COMMAND from enacting changes")
         parser.add_argument("-f", "--force", action="store_true",
@@ -304,15 +304,14 @@ class CLI:
                               help="Deploy the local build to the instance, "
                                    "connect to the instance's Cloud SQL, "
                                    "or display instance config")
-        typical = parser.add_argument_group("typical arguments",
-                                            "(usually necessary to target a particular instance)")
-        typical.add_argument("-e", "--environment", default="gotc-dev", metavar="ENV",
-                             choices=["gotc-dev", "gotc-prod", "aou"],
-                             help="Specify 'gotc-deploy/deploy/{ENV}' with one of: %(choices)s")
-        typical.add_argument("-i", "--instance", default="dev",
-                             help="Provide the ID of the target instance in the environment")
-        specific = parser.add_argument_group("specific arguments",
-                                             "(rarely necessary, inferred from typical arguments)")
+        required = parser.add_argument_group("required arguments")
+        required.add_argument("-e", "--environment", metavar="ENV", required=True,
+                              choices=["gotc-dev", "gotc-prod", "aou"],
+                              help="Specify 'gotc-deploy/deploy/{ENV}' with one of: %(choices)s")
+        required.add_argument("-i", "--instance", required=True,
+                              help="Provide the ID of the target instance in the environment")
+        specific = parser.add_argument_group("miscellaneous arguments",
+                                             "(rarely necessary; by default inferred from required arguments)")
         specific.add_argument("-v", "--version",
                               help="Specify the exact version to use instead of the 'version' file")
         specific.add_argument("--project",

--- a/ops/cli.py
+++ b/ops/cli.py
@@ -181,7 +181,7 @@ def configure_cloud_sql_proxy(config: WflInstanceConfig) -> None:
                                        f"describe {config.cloud_sql_name}"))["connectionName"]
     config.cloud_sql_local_proxy_container = \
         shell(f"docker run --rm -d -p 127.0.0.1:5432:5432 gcr.io/cloudsql-docker/gce-proxy:1.16 "
-              f"/cloud_sql_proxy -token='{token}' -instances='{connection_name}=tcp:0.0.0.0:5432'")
+              f"/cloud_sql_proxy -token='{token}' -instances='{connection_name}=tcp:0.0.0.0:5432'", quiet=True)
 
 
 def print_cloud_sql_proxy_instructions(config: WflInstanceConfig) -> None:

--- a/ops/cli.py
+++ b/ops/cli.py
@@ -105,6 +105,7 @@ def infer_missing_arguments(config: WflInstanceConfig) -> None:
 
 def print_config(config: WflInstanceConfig) -> None:
     """Print the entire config--be careful about calling this after sensitive info has been stored."""
+    info("=>  Current script configuration:")
     PrettyPrinter().pprint(config)
 
 

--- a/ops/cli.py
+++ b/ops/cli.py
@@ -132,7 +132,7 @@ class Config:
             issues += 1 if self.force else exit(1)
         if self.__namespace_exists():
             success(f"Namespace {self.cluster_namespace} exists in cluster")
-            shell(f"gcloud set-context --current --namespace={self.cluster_namespace}")
+            shell(f"kubectl config set-context --current --namespace={self.cluster_namespace}")
             info("    Namespace now set")
         else:
             error(f"Namespace {self.cluster_namespace} not found in cluster")

--- a/ops/cli.py
+++ b/ops/cli.py
@@ -155,14 +155,14 @@ def render_values_file(config: WflInstanceConfig) -> None:
         os.makedirs(deploy)
     values = "wfl-values.yaml"
     config.rendered_values_file = os.path.join(deploy, values)
-    ctmpl = f"derived/2p/{config.environment}/helm/{values}.ctmpl"
+    ctmpl = f"derived/2p/gotc-deploy/deploy/{config.environment}/helm/{values}.ctmpl"
     shutil.copy(ctmpl, deploy)
     render_ctmpl(ctmpl_file=f"{config.rendered_values_file}.ctmpl", WFL_VERSION=config.version)
     with open(config.rendered_values_file) as values_file:
         helm_values = yaml.safe_load(values_file)
         env = helm_values["api"]["env"]
-        config.db_username = env["WFL_POSTGRES_USERNAME"] or env["ZERO_POSTGRES_USERNAME"]
-        config.db_password = env["WFL_POSTGRES_PASSWORD"] or env["ZERO_POSTGRES_PASSWORD"]
+        config.db_username = env.get("WFL_POSTGRES_USERNAME", "ZERO_POSTGRES_USERNAME")
+        config.db_password = env.get("WFL_POSTGRES_PASSWORD", "ZERO_POSTGRES_PASSWORD")
     success(f"Rendered Helm values file to {config.rendered_values_file}")
 
 

--- a/ops/cli.py
+++ b/ops/cli.py
@@ -149,7 +149,6 @@ def configure_helm(config: WflInstanceConfig) -> None:
 
 def render_values_file(config: WflInstanceConfig) -> None:
     """Render the values file and store pertinent info from it in the config."""
-    info("=>  Rendering Helm values file")
     deploy = os.path.join("derived", "helm", "deploy")
     if not os.path.exists(deploy):
         os.makedirs(deploy)
@@ -163,7 +162,6 @@ def render_values_file(config: WflInstanceConfig) -> None:
         env = helm_values["api"]["env"]
         config.db_username = env.get("WFL_POSTGRES_USERNAME", "ZERO_POSTGRES_USERNAME")
         config.db_password = env.get("WFL_POSTGRES_PASSWORD", "ZERO_POSTGRES_PASSWORD")
-    success(f"Rendered Helm values file to {config.rendered_values_file}")
 
 
 def exit_if_dry_run(config: WflInstanceConfig) -> None:

--- a/ops/cli.py
+++ b/ops/cli.py
@@ -10,16 +10,16 @@ import argparse
 import json
 import os
 import shutil
-import sys
 import subprocess
+import sys
 from dataclasses import dataclass
-from typing import Dict, Callable, List
 from pprint import PrettyPrinter
+from typing import Dict, Callable, List
 
 import yaml
 
-from util.misc import info, success, error, warn, shell
 from render_ctmpl import render_ctmpl
+from util.misc import info, success, error, warn, shell
 
 # In case this will need to run on Windows systems
 if sys.platform.lower() == "win32":

--- a/ops/cli.py
+++ b/ops/cli.py
@@ -10,336 +10,300 @@ import argparse
 import json
 import os
 import shutil
-import subprocess
 import sys
-from typing import Callable
+import subprocess
+from dataclasses import dataclass
+from typing import Dict, Callable, List
+from pprint import PrettyPrinter
 
 import yaml
 
-from render_ctmpl import render_ctmpl
 from util.misc import info, success, error, warn, shell
+from render_ctmpl import render_ctmpl
 
 # In case this will need to run on Windows systems
 if sys.platform.lower() == "win32":
     os.system("color")
 
 
-class Config:
-    """Base class for storing/resolving/validating command line input."""
+@dataclass
+class WflInstanceConfig:
+    """Data class representing the 'state' of this script's configuration as it interacts with infrastructure."""
+    command: str
+    environment: str
+    instance_id: str
+    dry_run: bool = False
+    version: str = None
+    project: str = None
+    cloud_sql_name: str = None
+    cloud_sql_local_proxy_container: str = None
+    cluster_zone: str = None
+    cluster_name: str = None
+    cluster_namespace: str = None
+    db_username: str = None
+    db_password: str = None
+    rendered_values_file: str = None
 
-    def __init__(self, parsed_args: argparse.Namespace):
-        """Resolve and store input from parsed arguments."""
-        self.dry_run: bool = parsed_args.dry_run
-        self.force: bool = parsed_args.force
-        self.environment: str = parsed_args.environment
-        info(f"=>  Resolving configuration")
-        self.version: str = \
-            self.__resolve_config_value("Version", parsed_args.version, lambda: self.__read_version())
-        self.gotc_deploy_folder: str = \
-            self.__resolve_config_value("GotC Deploy folder", f"gotc-deploy/deploy/{self.environment}")
-        self.instance_id: str = \
-            self.__resolve_config_value("Instance ID", parsed_args.instance)
-        self.project: str = \
-            self.__resolve_config_value("GCP project", parsed_args.project, lambda: f"broad-{self.environment}")
-        self.cloudsql_name: str = \
-            self.__resolve_config_value("CloudSQL name", parsed_args.cloud_sql, lambda: self.__find_cloudsql_name())
-        self.cluster_name: str = \
-            self.__resolve_config_value("GKE cluster name", parsed_args.cluster, lambda: self.__find_cluster_name())
-        self.cluster_zone: str = \
-            self.__resolve_config_value("GKE cluster zone", parsed_args.zone, lambda: self.__find_cluster_zone())
-        self.cluster_namespace: str = \
-            self.__resolve_config_value("Kubernetes namespace", parsed_args.namespace,
-                                        lambda: f"{self.instance_id}-wfl")
-        success("Resolved configuration") if not self.force else warn("Resolved forced configuration")
 
-    @staticmethod
-    def __resolve_config_value(description: str, specific: str, default: Callable[[], str] = lambda: None) -> str:
-        """Either use the specific value if truthy or calculate the default, printing accordingly."""
-        val = specific or default()
-        info(f"    {description.ljust(20, '.')}: {val}{' (specifically supplied)' if specific else ''}")
-        return val
+def infer_missing_arguments_pre_validate(config: WflInstanceConfig) -> None:
+    """Infer and store all arguments required for validation steps."""
+    if not config.project:
+        config.project = f"broad-{config.environment}"
 
-    @staticmethod
-    def __read_version() -> str:
+
+def validate_cloud_sql_name(config: WflInstanceConfig) -> None:
+    """Validate that the stored Cloud SQL name exists."""
+    if config.cloud_sql_name:
+        instances = json.loads(shell(f"gcloud --project {config.project} --format=json "
+                                     "sql instances list"))
+        if config.cloud_sql_name not in [i["name"] for i in instances]:
+            info(f"    Available Cloud SQL instances in {config.project}:", plain=True)
+            info(shell(f"gcloud --project {config.project} sql instances list", quiet=True), plain=True)
+            raise RuntimeError(f"Cloud SQL instance {config.cloud_sql_name} not found")
+        else:
+            success(f"Cloud SQL instance {config.cloud_sql_name} exists")
+
+
+def validate_cluster_name(config: WflInstanceConfig) -> None:
+    """Validate that the stored cluster name exists."""
+    if config.cluster_name:
+        clusters = json.loads(shell(f"gcloud --project {config.project} --format=json "
+                                    f"container clusters list"))
+        if config.cluster_name not in [c["name"] for c in clusters]:
+            info(f"    Available clusters in {config.project}:", plain=True)
+            info(shell(f"gcloud --project {config.project} container clusters list", quiet=True), plain=True)
+            raise RuntimeError(f"GKE cluster {config.cluster_name} not found")
+        else:
+            success(f"GKE cluster {config.cluster_name} exists")
+
+
+def infer_missing_arguments(config: WflInstanceConfig) -> None:
+    """Infer and store all arguments not required for validation steps."""
+    if not config.version:
         with open("version") as version_file:
-            return version_file.read().strip()
+            config.version = version_file.read().strip()
+    if not config.cloud_sql_name:
+        config.cloud_sql_name = \
+            json.loads(shell(f"gcloud --project {config.project} --format=json "
+                             "sql instances list "
+                             f"--filter='labels.app_name=wfl AND labels.instance_id={config.instance_id}'",
+                             quiet=True))[0]["name"]
+    if not config.cluster_name:
+        config.cluster_name = \
+            json.loads(shell(f"gcloud --project {config.project} --format=json "
+                             "sql instances list "
+                             f"--filter='labels.app_name=wfl AND labels.instance_id={config.instance_id}'",
+                             quiet=True))[0]["settings"]["userLabels"]["app_cluster"]
+    if not config.cluster_zone:
+        config.cluster_zone = json.loads(shell(f"gcloud --project {config.project} --format=json "
+                                               "container clusters list "
+                                               f"--filter='name={config.cluster_name}'",
+                                               quiet=True))[0]["zone"]
+    if not config.cluster_namespace:
+        config.cluster_namespace = f"{config.instance_id}-wfl"
 
-    def __find_cloudsql_name(self) -> str:
-        """Use labels to identify the Cloud SQL name."""
-        instances = json.loads(shell(f"gcloud --project {self.project} --format=json "
-                                     "sql instances list "
-                                     f"--filter='labels.app_name=wfl AND labels.instance_id={self.instance_id}'",
-                                     quiet=True))
-        if len(instances) == 1:
-            return instances[0]["name"]
-        else:
-            error("No CloudSQL instance could be inferred")
-            info("    Couldn't find a single match for "
-                 f"`--filter='labels.app_name=wfl AND labels.instance_id={self.instance_id}'`")
-            info(f"    Available instances in {self.project}:", plain=True)
-            info(shell(f"gcloud --project {self.project} sql instances list", quiet=True), plain=True)
-            return None if self.force else exit(1)
 
-    def __find_cluster_name(self) -> str:
-        """Look at the Cloud SQL labels to find the cluster name."""
-        instances = json.loads(shell(f"gcloud --project {self.project} --format=json "
-                                     "sql instances list "
-                                     f"--filter='labels.app_name=wfl AND labels.instance_id={self.instance_id}'",
-                                     quiet=True))
-        if len(instances) == 1:
-            return instances[0]["settings"]["userLabels"]["app_cluster"]
-        else:
-            error("No cluster name could be inferred")
-            info("    Couldn't find a single match for "
-                 f"`--filter='labels.app_name=wfl AND labels.instance_id={self.instance_id}'`")
-            info("    The `app_cluster` label is used to find cluster name, see wfl-instance documentation.")
-            info(f"    Available clusters in {self.project}:", plain=True)
-            info(shell(f"gcloud --project {self.project} container clusters list", quiet=True), plain=True)
-            return None if self.force else exit(1)
+def print_config(config: WflInstanceConfig) -> None:
+    """Print the entire config--be careful about calling this after sensitive info has been stored."""
+    PrettyPrinter().pprint(config)
 
-    def __find_cluster_zone(self) -> str:
-        """Look in the cluster list for the cluster's zone."""
-        clusters = json.loads(shell(f"gcloud --project {self.project} --format=json "
-                                    "container clusters list "
-                                    f"--filter='name={self.cluster_name}'",
-                                    quiet=True))
-        if len(clusters) == 1:
-            return clusters[0]["zone"]
-        else:
-            error(f"No cluster zone could be found for cluster named {self.cluster_name}")
-            info("    Couldn't find a single match for "
-                 f"`--filter='name={self.cluster_name}'`")
-            return None if self.force else exit(1)
 
-    def validate(self):
-        """Validate stored configuration, exiting upon failure if not forced."""
-        info(f"=>  Validating configuration")
-        issues = 0
-        if self.__cloudsql_exists():
-            success(f"CloudSQL instance {self.cloudsql_name} exists")
-        else:
-            error(f"CloudSQL instance {self.cloudsql_name} not found")
-            info(f"    Available instances in {self.project}:", plain=True)
-            info(shell(f"gcloud --project {self.project} sql instances list", quiet=True), plain=True)
-            issues += 1 if self.force else exit(1)
-        if self.__cluster_exists():
-            success(f"GKE cluster {self.cluster_name} exists")
-        else:
-            error(f"GKE cluster {self.cluster_name} not found")
-            info(f"    Available clusters in {self.project}:", plain=True)
-            info(shell(f"gcloud --project {self.project} container clusters list", quiet=True), plain=True)
-            issues += 1 if self.force else exit(1)
-        if self.__namespace_exists():
-            success(f"Namespace {self.cluster_namespace} exists in cluster")
-            shell(f"kubectl config set-context --current --namespace={self.cluster_namespace}")
-            info("    Namespace now set")
-        else:
-            error(f"Namespace {self.cluster_namespace} not found in cluster")
-            info(f"    Available namespaces in {self.cluster_name}:", plain=True)
+def configure_kubectl(config: WflInstanceConfig) -> None:
+    """Configure kubectl to use the stored cluster/namespace."""
+    info(f"=>  Configuring Kubernetes for cluster {config.cluster_name}")
+    shell(f"gcloud --project {config.project} container clusters get-credentials "
+          f"{config.cluster_name} --zone {config.cluster_zone}")
+    ctx = f"gke_{config.project}_{config.cluster_zone}_{config.cluster_name}"
+    shell(f"kubectl config use-context {ctx}")
+    try:
+        namespaces = json.loads(shell("kubectl get namespace -o json", timeout=5))
+        if config.cluster_namespace not in [item["metadata"]["name"] for item in namespaces["items"]]:
+            info(f"    Available namespaces in {config.cluster_name}:", plain=True)
             info(shell("kubectl get namespace", quiet=True), plain=True)
-            issues += 1 if self.force else exit(1)
-        if issues != 0:
-            warn(f"{issues} issues but continuing due to '--force'")
+            raise RuntimeError(f"Namespace {config.cluster_namespace} not found in {config.cluster_name}")
         else:
-            success("Validated configuration")
-
-    def __cluster_exists(self) -> bool:
-        """Check that the cluster exists."""
-        clusters = json.loads(shell(f"gcloud --project {self.project} --format=json "
-                                    f"container clusters list "
-                                    f'{f"--zone {self.cluster_zone}" if self.cluster_zone else ""}'))
-        return self.cluster_name in [c["name"] for c in clusters]
-
-    def __cloudsql_exists(self) -> bool:
-        """Check that the Cloud SQL instanc exists."""
-        instances = json.loads(shell(f"gcloud --project {self.project} --format=json "
-                                     f"sql instances list"))
-        return self.cloudsql_name in [i["name"] for i in instances]
-
-    def __namespace_exists(self) -> bool:
-        """Configure K8s context and check that the namespace is present."""
-        info(f"=>  Configuring Kubernetes for cluster {self.cluster_name}")
-        shell(f"gcloud --project {self.project} container clusters get-credentials "
-              f"{self.cluster_name} --zone {self.cluster_zone}")
-        ctx = f"gke_{self.project}_{self.cluster_zone}_{self.cluster_name}"
-        shell(f"kubectl config use-context {ctx}")
-        try:
-            namespaces = json.loads(shell("kubectl get namespace -o json", timeout=5))
-            return self.cluster_namespace in [item["metadata"]["name"] for item in namespaces["items"]]
-        except subprocess.TimeoutExpired:
-            error("Namespace query took too long--maybe you need to be on non-split VPN?")
-            return False
+            shell(f"kubectl config set-context --current --namespace={config.cluster_namespace}")
+            success("Kubernetes configured")
+    except subprocess.TimeoutExpired as timeout:
+        warn("Namespace query took too long--maybe you need to be on non-split VPN?")
+        raise timeout
 
 
-class InfoCommand(Config):
-    """Class for info command that doesn't do anything special, just resolves/validates arguments."""
+def configure_helm(config: WflInstanceConfig) -> None:
+    """Configure helm to connect to gotc-helm-repo."""
+    info(f"=>  Setting up Helm charts ahead of {config.command}")
+    shell("helm repo add gotc-charts https://broadinstitute.github.io/gotc-helm-repo/")
+    shell("helm repo update")
+    success("Set up Helm charts")
 
-    def __init__(self, parsed_args: argparse.Namespace):
-        super().__init__(parsed_args)
 
-    @staticmethod
-    def execute() -> int:
+def render_values_file(config: WflInstanceConfig) -> None:
+    """Render the values file and store pertinent info from it in the config."""
+    info("=>  Rendering Helm values file")
+    deploy = os.path.join("derived", "helm", "deploy")
+    if not os.path.exists(deploy):
+        os.makedirs(deploy)
+    values = "wfl-values.yaml"
+    config.rendered_values_file = os.path.join(deploy, values)
+    ctmpl = f"derived/2p/{config.environment}/helm/{values}.ctmpl"
+    shutil.copy(ctmpl, deploy)
+    render_ctmpl(ctmpl_file=f"{config.rendered_values_file}.ctmpl", WFL_VERSION=config.version)
+    with open(config.rendered_values_file) as values_file:
+        helm_values = yaml.safe_load(values_file)
+        env = helm_values["api"]["env"]
+        config.db_username = env["WFL_POSTGRES_USERNAME"] or env["ZERO_POSTGRES_USERNAME"]
+        config.db_password = env["WFL_POSTGRES_PASSWORD"] or env["ZERO_POSTGRES_PASSWORD"]
+    success(f"Rendered Helm values file to {config.rendered_values_file}")
+
+
+def exit_if_dry_run(config: WflInstanceConfig) -> None:
+    """Exit if the config is storing True for the dry_run flag."""
+    if config.dry_run:
+        warn("Exiting due to --dry-run")
+        exit(0)
+
+
+def configure_cloud_sql_proxy(config: WflInstanceConfig) -> None:
+    """Initiate the Cloud SQL proxy and store the container name in the config."""
+    info("=>  Running cloud_sql_proxy")
+    token = shell("gcloud auth print-access-token")
+    connection_name = json.loads(shell(f"gcloud --project {config.project} --format=json sql instances "
+                                       f"describe {config.cloud_sql_name}"))["connectionName"]
+    config.cloud_sql_local_proxy_container = \
+        shell(f"docker run --rm -d -p 127.0.0.1:5432:5432 gcr.io/cloudsql-docker/gce-proxy:1.16 "
+              f"/cloud_sql_proxy -token='{token}' -instances='{connection_name}=tcp:0.0.0.0:5432'")
+
+
+def print_cloud_sql_proxy_instructions(config: WflInstanceConfig) -> None:
+    """Print instructions for connecting to the Cloud SQL proxy contained stored in the config."""
+    success(f"You have connected to WFL's CloudSQL instance {config.cloud_sql_name} "
+            f"in {config.environment}'s {config.instance_id} wfl-instance")
+    info(f'To use psql, run: \n\t psql "host=127.0.0.1 sslmode=disable  dbname=<DB_NAME> user=<USER_NAME>"')
+    info(f"To disconnect and stop the container, run: \n\t docker stop {config.cloud_sql_local_proxy_container}")
+
+
+def prompt_deploy_version(config: WflInstanceConfig) -> None:
+    """Verify that the user would like to deploy the stored version."""
+    if not input(f"Are you sure you want to deploy version {config.version}? [N/y]").lower().startswith("y"):
+        exit(0)
+
+
+def publish_docker_images(config: WflInstanceConfig) -> None:
+    """Publish existing docker images for the stored version."""
+    info(f"=>  Publishing Docker images for version {config.version}")
+    for module in ["api", "ui"]:
+        shell(f"docker push broadinstitute/workflow-launcher-{module}:{config.version}")
+    success("Published Docker images")
+
+
+def helm_deploy_wfl(config: WflInstanceConfig) -> None:
+    """Deploy the pushed docker images for the stored version to the stored cluster."""
+    info(f"=>  Deploying to {config.cluster_name} in {config.cluster_namespace} namespace")
+    info("    This must run on a non-split VPN", plain=True)
+    shell(f"helm upgrade wfl-k8s gotc-charts/wfl -f {config.rendered_values_file} --install")
+    success("WFL deployed")
+
+
+def run_liquibase_migration(config: WflInstanceConfig) -> None:
+    """Run the liquibase migration using stored credentials from rendering the values file."""
+    info("=>  Running liquibase migration")
+    db_url = "jdbc:postgresql://localhost:5432/wfl?useSSL=false"
+    changelog_dir = os.path.join(os.getcwd(), "database")
+    shell(f"docker run --rm --net=host "
+          f"-v {changelog_dir}:/liquibase/changelog liquibase/liquibase "
+          f"--url='{db_url}' --changeLogFile=/changelog/changelog.xml "
+          f"--username='{config.db_username}' --password='{config.db_password}' update")
+    success("Ran liquibase migration")
+
+
+def stop_cloud_sql_proxy(config: WflInstanceConfig) -> None:
+    """Stop the stored Cloud SQL proxy container."""
+    info("=>  Stopping cloud_sql_proxy")
+    shell(f"docker stop {config.cloud_sql_local_proxy_container}")
+
+
+def print_deployment_success(config: WflInstanceConfig) -> None:
+    """Print success and get pods from existing kubectl context."""
+    success(f"{config.command} is done!")
+    info(shell("kubectl get pods"), plain=True)
+
+
+command_mapping: Dict[str, List[Callable[[WflInstanceConfig], None]]] = {
+    "info": [
+        infer_missing_arguments_pre_validate,
+        validate_cloud_sql_name,
+        validate_cluster_name,
+        infer_missing_arguments,
+        print_config
+    ],
+    "connect": [
+        infer_missing_arguments_pre_validate,
+        validate_cloud_sql_name,
+        infer_missing_arguments,
+        print_config,
+        exit_if_dry_run,
+        configure_cloud_sql_proxy,
+        print_cloud_sql_proxy_instructions
+    ],
+    "deploy": [
+        infer_missing_arguments_pre_validate,
+        validate_cloud_sql_name,
+        validate_cluster_name,
+        infer_missing_arguments,
+        print_config,
+        configure_kubectl,
+        configure_helm,
+        render_values_file,
+        exit_if_dry_run,
+        prompt_deploy_version,
+        configure_cloud_sql_proxy,
+        publish_docker_images,
+        helm_deploy_wfl,
+        run_liquibase_migration,
+        stop_cloud_sql_proxy,
+        print_deployment_success
+    ]
+}
+
+
+def cli() -> WflInstanceConfig:
+    """Configure the arguments, help text, and parsing."""
+    parser = argparse.ArgumentParser(description="deploy or connect to WFL infrastructure",
+                                     usage="%(prog)s [-h] [-d] COMMAND ENV INSTANCE [...]")
+    parser.add_argument("command", choices=command_mapping.keys(), metavar="COMMAND",
+                        help=f"one of [{', '.join(command_mapping.keys())}]")
+    parser.add_argument("environment", choices=["gotc-dev", "gotc-prod", "aou"], metavar="ENV",
+                        help="specify 'gotc-deploy/deploy/{ENV}' with one of [%(choices)s]")
+    parser.add_argument("instance_id", metavar="INSTANCE",
+                        help="specify the ID of the instance to use in the environment")
+    parser.add_argument("-d", "--dry-run", action="store_true",
+                        help="exit before COMMAND makes any remote changes")
+    parser.add_argument("-v", "--version",
+                        help="specify the version to use instead of the 'version' file")
+    parser.add_argument("--project",
+                        help="specify the GCP project name instead of 'broad-{ENV}'")
+    parser.add_argument("--cloud-sql-name",
+                        help="specify the Cloud SQL name instead of inferring from labels")
+    parser.add_argument("--cluster-zone",
+                        help="specify the zone for the GKE cluster instead of inferring from CLUSTER_NAME")
+    parser.add_argument("--cluster-name",
+                        help="specify the GKE cluster name instead of inferring from labels")
+    parser.add_argument("--cluster-namespace",
+                        help="specify the K8s namespace instead of '{INSTANCE}-wfl'")
+    return WflInstanceConfig(**vars(parser.parse_args()))
+
+
+def main() -> int:
+    """Call `cli` and run each function in the command mapping in order."""
+    config = cli()
+    try:
+        for func in command_mapping[config.command]:
+            func(config)
         return 0
-
-
-class ConnectCommand(Config):
-    """Class for connect command that enables `psql` to the Cloud SQL instance."""
-
-    def __init__(self, parsed_args: argparse.Namespace):
-        super().__init__(parsed_args)
-
-    def execute(self) -> int:
-        """Run the Cloud SQL proxy and print `psql` instructions."""
-        container = self.run_cloudsql_proxy()
-        success(f"You have connected to WFL's CloudSQL instance {self.cloudsql_name} "
-                f"in {self.environment}'s {self.instance_id} wfl-instance")
-        info(f'To use psql, run: \n\t psql "host=127.0.0.1 sslmode=disable  dbname=<DB_NAME> user=<USER_NAME>"')
-        info(f"To disconnect and stop the container, run: \n\t docker stop {container}")
-        return 0
-
-    def run_cloudsql_proxy(self):
-        """Use docker via gce-proxy to connect to the Cloud SQL instance."""
-        info("=>  Running cloud_sql_proxy")
-        token = shell("gcloud auth print-access-token")
-        connectionName = json.loads(shell(f"gcloud --project {self.project} --format=json sql instances"
-                                          f"describe {self.cloudsql_name}"))["connectionName"]
-        return shell(f"docker run --rm -d -p 127.0.0.1:5432:5432 gcr.io/cloudsql-docker/gce-proxy:1.16 "
-                     f"/cloud_sql_proxy -token='{token}' -instances='{connectionName}=tcp:0.0.0.0:5432'")
-
-
-class DeployCommand(ConnectCommand):
-    """Class for deploy command that deploys WFL to infrastructure."""
-
-    def __init__(self, parsed_args: argparse.Namespace):
-        super().__init__(parsed_args)
-
-    def execute(self) -> int:
-        """Set up helm, publish docker, render CTMPL, helm deploy, migrate liquibase."""
-
-        if not input(f"Are you sure you want to deploy version {self.version}? [N/y]").lower().startswith("y"):
-            exit(0)
-
-        self.__set_up_helm()
-
-        self.__publish_docker_images()
-
-        deploy = os.path.join("derived", "helm", "deploy")
-        if not os.path.exists(deploy):
-            os.makedirs(deploy)
-
-        values = "wfl-values.yaml"
-        ctmpl = f"derived/2p/{self.gotc_deploy_folder}/helm/{values}.ctmpl"
-        shutil.copy(ctmpl, deploy)
-
-        render_ctmpl(ctmpl_file=f"{deploy}/{values}.ctmpl", WFL_VERSION=self.version)
-        self.__helm_deploy_wfl(values=f"{deploy}/{values}")
-
-        container = self.run_cloudsql_proxy()
-        with open(f"{deploy}/{values}") as values_file:
-            helm_values = yaml.safe_load(values_file)
-            env = helm_values['api']['env']
-            self.__run_liquibase_migration(env['ZERO_POSTGRES_USERNAME'], env['ZERO_POSTGRES_PASSWORD'])
-        info("=>  Stopping cloud_sql_proxy")
-        shell(f"docker stop {container}")
-
-        success("Deployment is done!")
-        info(shell("kubectl get pods"), plain=True)
-
-        return 0
-
-    @staticmethod
-    def __set_up_helm():
-        """Add helm repo and update."""
-        info("=>  Setting up Helm charts")
-        shell("helm repo add gotc-charts https://broadinstitute.github.io/gotc-helm-repo/")
-        shell("helm repo update")
-        success("Set up Helm charts")
-
-    def __publish_docker_images(self):
-        """Publish docker build."""
-        info(f"=>  Publishing Docker images for version {self.version}")
-        for module in ["api", "ui"]:
-            shell(f"docker push broadinstitute/workflow-launcher-{module}:{self.version}")
-        success("Published Docker images")
-
-    def __helm_deploy_wfl(self, values: str):
-        """Helm deploy using gotc-charts/wfl."""
-        info(f"=>  Deploying to {self.cluster_name} in {self.cluster_namespace} namespace")
-        info("    This must run on a non-split VPN", plain=True)
-        shell(f"helm upgrade wfl-k8s gotc-charts/wfl -f {values} --install")
-        success("WFL deployed")
-
-    @staticmethod
-    def __run_liquibase_migration(db_username: str, db_password: str):
-        info("=>  Running liquibase migration")
-        db_url = "jdbc:postgresql://localhost:5432/wfl?useSSL=false"
-        changelog_dir = os.path.join(os.getcwd(), "database")
-        shell(f"docker run --rm --net=host "
-              f"-v {changelog_dir}:/liquibase/changelog liquibase/liquibase "
-              f"--url='{db_url}' --changeLogFile=/changelog/changelog.xml "
-              f"--username='{db_username}' --password='{db_password}' update")
-        success("[✔] Ran liquibase migration")
-
-
-class CLI:
-    command_mapping = {
-        "deploy": DeployCommand,
-        "connect": ConnectCommand,
-        "info": InfoCommand
-    }
-
-    def __init__(self):
-        """Set up the parser."""
-        parser = argparse.ArgumentParser(description="Deploy or connect to WFL infrastructure instances",
-                                         usage="%(prog)s [-h] [-d | -f] COMMAND -e ENV -i INSTANCE [...]")
-        parser.add_argument("-d", "--dry-run", action="store_true",
-                            help="Prevent COMMAND from enacting changes")
-        parser.add_argument("-f", "--force", action="store_true",
-                            help="Force COMMAND to run even if validation fails")
-        commands = parser.add_argument_group("COMMAND")
-        commands.add_argument("command",
-                              type=lambda s: self.command_mapping.get(s),
-                              choices=self.command_mapping.values(),
-                              metavar=f"{{{', '.join(self.command_mapping.keys())}}}",
-                              help="Deploy the local build to the instance, "
-                                   "connect to the instance's Cloud SQL, "
-                                   "or display instance config")
-        required = parser.add_argument_group("required arguments")
-        required.add_argument("-e", "--environment", metavar="ENV", required=True,
-                              choices=["gotc-dev", "gotc-prod", "aou"],
-                              help="Specify 'gotc-deploy/deploy/{ENV}' with one of: %(choices)s")
-        required.add_argument("-i", "--instance", required=True,
-                              help="Provide the ID of the target instance in the environment")
-        specific = parser.add_argument_group("miscellaneous arguments",
-                                             "(rarely necessary; by default inferred from required arguments)")
-        specific.add_argument("-v", "--version",
-                              help="Specify the exact version to use instead of the 'version' file")
-        specific.add_argument("--project",
-                              help="Specify the exact GCP project name instead of 'broad-{ENV}'")
-        specific.add_argument("--cloud-sql",
-                              help="Specify the exact Cloud SQL name instead of inferring from labels")
-        specific.add_argument("--zone",  # don't set default here so Config knows if this was set
-                              help="Specify the exact GCP cluster zone instead of inferring from labels")
-        specific.add_argument("--cluster",
-                              help="Specify the exact GKE cluster name instead of inferring from labels")
-        specific.add_argument("--namespace",
-                              help="Specify the exact K8s namespace instead of '{INSTANCE}-wfl'")
-        self.parser = parser
-
-    def execute(self) -> int:
-        """Run command."""
-        args = self.parser.parse_args()
-        for cmd in ["docker", "gcloud", "git", "helm", "java", "kubectl", "jq"]:
-            if not shutil.which(cmd):
-                error(f"{cmd} is not in PATH. Please install it!")
-        config = args.command(args)
-        config.validate()
-        if config.dry_run:
-            success("Exiting due to '--dry-run'")
-            return 0
-        else:
-            return config.execute()
+    except Exception as err:
+        error(f"{err}")
+        return 1
 
 
 if __name__ == "__main__":
-    exit(CLI().execute())
+    exit(main())

--- a/ops/cli.py
+++ b/ops/cli.py
@@ -304,7 +304,7 @@ def main() -> int:
             func(config)
         return 0
     except Exception as err:
-        error(f"{err}")
+        error(str(err))
         return 1
 
 

--- a/ops/cli.py
+++ b/ops/cli.py
@@ -11,7 +11,6 @@ import json
 import os
 import shutil
 import subprocess
-import sys
 from dataclasses import dataclass
 from pprint import PrettyPrinter
 from typing import Dict, Callable, List
@@ -20,10 +19,6 @@ import yaml
 
 from render_ctmpl import render_ctmpl
 from util.misc import info, success, error, warn, shell
-
-# In case this will need to run on Windows systems
-if sys.platform.lower() == "win32":
-    os.system("color")
 
 
 @dataclass

--- a/ops/cli.py
+++ b/ops/cli.py
@@ -88,7 +88,7 @@ class Config:
                                      f"--filter='labels.app_name=wfl AND labels.instance_id={self.instance_id}'",
                                      quiet=True))
         if len(instances) == 1:
-            return instances[0]["labels"]["app_cluster"]
+            return instances[0]["settings"]["userLabels"]["app_cluster"]
         else:
             error("No cluster name could be inferred")
             info("    Couldn't find a single match for "

--- a/ops/cli.py
+++ b/ops/cli.py
@@ -113,9 +113,9 @@ def infer_missing_arguments(config: WflInstanceConfig) -> None:
 
 
 def print_config(config: WflInstanceConfig) -> None:
-    """Print the entire config--be careful about calling this after sensitive info has been stored."""
+    """Print the entire config, filtering out any field containing password."""
     info("=>  Current script configuration:")
-    PrettyPrinter().pprint(config)
+    PrettyPrinter().pprint({k: v for (k, v) in vars(config).items() if "password" not in k})
 
 
 def configure_kubectl(config: WflInstanceConfig) -> None:

--- a/ops/render_ctmpl.py
+++ b/ops/render_ctmpl.py
@@ -15,11 +15,11 @@ def render_ctmpl(ctmpl_file: str, **kwargs) -> int:
             envs += f"-e {k}={v}"
     info(f"=>  Feeding variables: {envs}")
     shell_unchecked(" ".join(['docker run -i --rm -v "$(pwd)":/working',
-                    '-v "$HOME"/.vault-token:/root/.vault-token',
-                    f'{envs}',
-                    'broadinstitute/dsde-toolbox:dev',
-                    '/usr/local/bin/render-ctmpls.sh -k',
-                    f'"{ctmpl_file}"']))
+                              '-v "$HOME"/.vault-token:/root/.vault-token',
+                              f'{envs}',
+                              'broadinstitute/dsde-toolbox:dev',
+                              '/usr/local/bin/render-ctmpls.sh -k',
+                              f'"{ctmpl_file}"']))
     success(f"Rendered {ctmpl_file.split('.ctmpl')[0]}")
     return 0
 

--- a/ops/render_ctmpl.py
+++ b/ops/render_ctmpl.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+import argparse
+import shutil
+from pathlib import Path
+
+from .cli import info, success, error, shell
+
+
+def render_ctmpl(ctmpl_file: str, **kwargs) -> int:
+    """Render a ctmpl file."""
+    info("=> Rendering ctmpl file {ctmpl_file}")
+    envs = ""
+    if kwargs:
+        for k, v in kwargs.items():
+            envs += f"-e {k}={v}"
+    info(f"=>  Feeding variables: {envs}")
+    shell(" ".join(['docker run -i --rm -v "$(pwd)":/working',
+                    '-v "$HOME"/.vault-token:/root/.vault-token',
+                    f'{envs}',
+                    'broadinstitute/dsde-toolbox:dev',
+                    '/usr/local/bin/render-ctmpls.sh -k',
+                    f'"{ctmpl_file}"']))
+    success(f"Rendered file {ctmpl_file.split('.ctmpl')[0]}")
+    return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("file", help="CTMPL file to be rendered")
+    parser.add_argument("-v", "--version", help="A specific version to use other than the root's `version` file")
+    args = parser.parse_args()
+    file = Path(args.file)
+    assert file.exists() and file.is_file(), f"{file} is not valid!"
+
+    if args.version:
+        version = args.version
+    else:
+        with open("version") as version_file:
+            version = version_file.read().strip()
+
+    if not shutil.which("docker"):
+        error("Docker is not in PATH. Please install it!")
+
+    exit(render_ctmpl(ctmpl_file=str(file), WFL_VERSION=version))

--- a/ops/render_ctmpl.py
+++ b/ops/render_ctmpl.py
@@ -1,15 +1,9 @@
 #!/usr/bin/env python3
 import argparse
-import os
 import shutil
-import sys
 from pathlib import Path
 
 from util.misc import info, success, error, shell_unchecked
-
-# In case this will need to run on Windows systems
-if sys.platform.lower() == "win32":
-    os.system("color")
 
 
 def render_ctmpl(ctmpl_file: str, **kwargs) -> int:

--- a/ops/render_ctmpl.py
+++ b/ops/render_ctmpl.py
@@ -1,9 +1,15 @@
 #!/usr/bin/env python3
 import argparse
+import os
 import shutil
+import sys
 from pathlib import Path
 
-from .cli import info, success, error, shell
+from util.misc import info, success, error, shell
+
+# In case this will need to run on Windows systems
+if sys.platform.lower() == "win32":
+    os.system("color")
 
 
 def render_ctmpl(ctmpl_file: str, **kwargs) -> int:

--- a/ops/render_ctmpl.py
+++ b/ops/render_ctmpl.py
@@ -28,17 +28,17 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("file", help="CTMPL file to be rendered")
     parser.add_argument("-v", "--version", help="A specific version to use other than the root's `version` file")
+    parser.add_argument("--no-version", action="store_true", help="Don't pass a WFL_VERSION variable")
     args = parser.parse_args()
     file = Path(args.file)
     assert file.exists() and file.is_file(), f"{file} is not valid!"
 
-    if args.version:
-        version = args.version
+    if not args.no_version:
+        if args.version:
+            version = args.version
+        else:
+            with open("version") as version_file:
+                version = version_file.read().strip()
+        exit(render_ctmpl(ctmpl_file=str(file), WFL_VERSION = version))
     else:
-        with open("version") as version_file:
-            version = version_file.read().strip()
-
-    if not shutil.which("docker"):
-        error("Docker is not in PATH. Please install it!")
-
-    exit(render_ctmpl(ctmpl_file=str(file), WFL_VERSION=version))
+        exit(render_ctmpl(ctmpl_file=str(file)))

--- a/ops/render_ctmpl.py
+++ b/ops/render_ctmpl.py
@@ -5,7 +5,7 @@ import shutil
 import sys
 from pathlib import Path
 
-from util.misc import info, success, error, shell
+from util.misc import info, success, error, shell_unchecked
 
 # In case this will need to run on Windows systems
 if sys.platform.lower() == "win32":
@@ -20,7 +20,7 @@ def render_ctmpl(ctmpl_file: str, **kwargs) -> int:
         for k, v in kwargs.items():
             envs += f"-e {k}={v}"
     info(f"=>  Feeding variables: {envs}")
-    shell(" ".join(['docker run -i --rm -v "$(pwd)":/working',
+    shell_unchecked(" ".join(['docker run -i --rm -v "$(pwd)":/working',
                     '-v "$HOME"/.vault-token:/root/.vault-token',
                     f'{envs}',
                     'broadinstitute/dsde-toolbox:dev',

--- a/ops/render_ctmpl.py
+++ b/ops/render_ctmpl.py
@@ -14,7 +14,7 @@ if sys.platform.lower() == "win32":
 
 def render_ctmpl(ctmpl_file: str, **kwargs) -> int:
     """Render a ctmpl file."""
-    info("=> Rendering ctmpl file {ctmpl_file}")
+    info("=>  Rendering ctmpl file {ctmpl_file}")
     envs = ""
     if kwargs:
         for k, v in kwargs.items():
@@ -26,7 +26,7 @@ def render_ctmpl(ctmpl_file: str, **kwargs) -> int:
                     'broadinstitute/dsde-toolbox:dev',
                     '/usr/local/bin/render-ctmpls.sh -k',
                     f'"{ctmpl_file}"']))
-    success(f"Rendered file {ctmpl_file.split('.ctmpl')[0]}")
+    success(f"Rendered {ctmpl_file.split('.ctmpl')[0]}")
     return 0
 
 

--- a/ops/render_ctmpl.py
+++ b/ops/render_ctmpl.py
@@ -39,6 +39,6 @@ if __name__ == "__main__":
         else:
             with open("version") as version_file:
                 version = version_file.read().strip()
-        exit(render_ctmpl(ctmpl_file=str(file), WFL_VERSION = version))
+        exit(render_ctmpl(ctmpl_file=str(file), WFL_VERSION=version))
     else:
         exit(render_ctmpl(ctmpl_file=str(file)))

--- a/ops/util/misc.py
+++ b/ops/util/misc.py
@@ -1,0 +1,62 @@
+"""
+Console and shell utilities shared among ops scripts.
+"""
+
+import subprocess
+import sys
+from enum import Enum
+from typing import Optional
+
+
+class AvailableColors(Enum):
+    GRAY = 90
+    RED = 91
+    GREEN = 92
+    YELLOW = 93
+    BLUE = 94
+    PURPLE = 95
+    WHITE = 97
+    BLACK = 30
+    DEFAULT = 39
+
+
+def _apply_color(color: str, message: str) -> str:
+    """Dye message with color, fall back to default if it fails."""
+    color_code = AvailableColors["DEFAULT"].value
+    try:
+        color_code = AvailableColors[color.upper()].value
+    except KeyError:
+        pass
+    return f"\033[1;{color_code}m{message}\033[0m"
+
+
+def info(message: str, plain=False):
+    """Log the info to stdout"""
+    print(_apply_color("default", message) if not plain else message)
+
+
+def success(message: str):
+    """Log the success to stdout"""
+    print(_apply_color("green", f"[✔] {message}"))
+
+
+def error(message: str):
+    """Log the error to stderr"""
+    print(_apply_color("red", f"[✗] {message}"), file=sys.stderr)
+
+
+def warn(message: str):
+    """Log the warning to stdout"""
+    print(_apply_color("yellow", f"[!] {message}"))
+
+
+def shell(command: str, quiet: bool = False, timeout: Optional[float] = None) -> str:
+    """Run COMMAND in a subprocess."""
+    if not quiet:
+        info(f"Running: {command}")
+    try:
+        return subprocess.check_output(command, shell=True, timeout=timeout, encoding="utf-8").strip()
+    except subprocess.CalledProcessError as err:
+        error(f"Error running: {command}")
+        error(err.output)
+        exit(err.returncode)

--- a/ops/util/misc.py
+++ b/ops/util/misc.py
@@ -60,3 +60,13 @@ def shell(command: str, quiet: bool = False, timeout: Optional[float] = None) ->
         error(f"Error running: {command}")
         error(err.output)
         exit(err.returncode)
+
+
+def shell_unchecked(command: str, quiet: bool = False, timeout: Optional[float] = None) -> str:
+    """Run COMMAND in a subprocess, always returning as if it succeeded."""
+    if not quiet:
+        info(f"Running: {command}")
+    try:
+        return subprocess.check_output(command, shell=True, timeout=timeout, encoding="utf-8").strip()
+    except subprocess.CalledProcessError as err:
+        return err.output.strip()


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-877
- Supersedes #87 

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- New usage:
```
usage: cli.py [-h] [-d] COMMAND ENV INSTANCE [...]

deploy or connect to WFL infrastructure

positional arguments:
  COMMAND               one of [info, connect, deploy]
  ENV                   specify 'gotc-deploy/deploy/{ENV}' with one of [gotc-
                        dev, gotc-prod, aou]
  INSTANCE              specify the ID of the instance to use in the
                        environment

optional arguments:
  -h, --help            show this help message and exit
  -d, --dry-run         exit before COMMAND makes any remote changes
  -v VERSION, --version VERSION
                        specify the version to use instead of the 'version'
                        file
  --project PROJECT     specify the GCP project name instead of 'broad-{ENV}'
  --cloud-sql-name CLOUD_SQL_NAME
                        specify the Cloud SQL name instead of inferring from
                        labels
  --cluster-zone CLUSTER_ZONE
                        specify the zone for the GKE cluster instead of
                        inferring from CLUSTER_NAME
  --cluster-name CLUSTER_NAME
                        specify the GKE cluster name instead of inferring from
                        labels
  --cluster-namespace CLUSTER_NAMESPACE
                        specify the K8s namespace instead of '{INSTANCE}-wfl'
```
- Rendering can be directly accessed through its own script:
```
usage: render_ctmpl.py [-h] [-v VERSION] file

positional arguments:
  file                  CTMPL file to be rendered

optional arguments:
  -h, --help            show this help message and exit
  -v VERSION, --version VERSION
                        A specific version to use other than the root's
                        `version` file
```
- Made a util folder with misc.py to hold common logic between both scripts
- Used functions instead of classes

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- On my branch you can:
  - Run the info command to see it infer arguments
  - Run the connect command (`connect gotc-dev dev`) to be connected to the brand new cloud sql instance in gotc-dev
  - Run deploy dry run (`deploy gotc-dev dev --dry-run`) to see it do everything that doesn't have remote side effects
