### PR TITLE
[GH-833] Fix parsing file paths in AOU cloud function

### DIFF
--- a/cloud_function/main.py
+++ b/cloud_function/main.py
@@ -27,8 +27,8 @@ def get_auth_headers():
 
 def get_manifest_path(object_name):
     path = object_name.strip("/")
-    chip_well_barcode, analysis_version, file_name = path.split("/", maxsplit=2)
-    return "/".join([chip_well_barcode, analysis_version, "ptc.json"])
+    chip_name, chip_well_barcode, analysis_version, file_name = path.split("/", maxsplit=3)
+    return "/".join([chip_name, chip_well_barcode, analysis_version, "ptc.json"])
 
 def get_or_create_workload(headers, cromwell_url, environment):
     payload = {

--- a/cloud_function/tests/unit_tests.py
+++ b/cloud_function/tests/unit_tests.py
@@ -4,13 +4,13 @@ from cloud_function import main
 
 
 bucket_name = "test_bucket"
-file_name = "chipwell_barcode/analysis_version/arrays/metadata/file.txt"
+file_name = "chip_name/chipwell_barcode/analysis_version/arrays/metadata/file.txt"
 event_data = {'bucket': bucket_name, 'name': file_name}
 
 
 def test_get_manifest_path_from_uploaded_file():
-    uploaded_file = "chipwell_barcode/analysis_version/arrays/metadata/file.txt"
-    manifest_file = "chipwell_barcode/analysis_version/ptc.json"
+    uploaded_file = "chip_name/chipwell_barcode/analysis_version/arrays/metadata/file.txt"
+    manifest_file = "chip_name/chipwell_barcode/analysis_version/ptc.json"
     result = main.get_manifest_path(uploaded_file)
     assert result == manifest_file
 


### PR DESCRIPTION
### Purpose
Fixes https://broadinstitute.atlassian.net/browse/GH-883

### Changes
Update the file path structure that the cloud function uses to find a sample's `ptc.json` file.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
