### PR TITLE
[GH-797] Sandbox parameterization

### DIFF
--- a/ops/cli.py
+++ b/ops/cli.py
@@ -160,7 +160,8 @@ def render_values_file(config: WflInstanceConfig) -> None:
     render_ctmpl(ctmpl_file=f"{config.rendered_values_file}.ctmpl",
                  WFL_VERSION=config.version,
                  WFL_DB_URL=f"'jdbc:postgresql://google/wfl?cloudSqlInstance={config.db_connection_name}"
-                            f"&socketFactory=com.google.cloud.sql.postgres.SocketFactory'")
+                            f"&socketFactory=com.google.cloud.sql.postgres.SocketFactory'",
+                 WFL_INSTANCE=config.instance_id)
     with open(config.rendered_values_file) as values_file:
         helm_values = yaml.safe_load(values_file)
         env = helm_values["api"]["env"]

--- a/ops/cli.py
+++ b/ops/cli.py
@@ -211,7 +211,7 @@ def helm_deploy_wfl(config: WflInstanceConfig) -> None:
     """Deploy the pushed docker images for the stored version to the stored cluster."""
     info(f"=>  Deploying to {config.cluster_name} in {config.cluster_namespace} namespace")
     info("    This must run on a non-split VPN", plain=True)
-    shell(f"helm upgrade wfl-k8s gotc-charts/wfl -f {config.rendered_values_file} --install "
+    shell(f"helm upgrade {config.instance_id}-wfl gotc-charts/wfl -f {config.rendered_values_file} --install "
           f"--namespace {config.cluster_namespace}")
     success("WFL deployed")
 


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-797
- A result of https://broadinstitute.atlassian.net/browse/GH-877
- The deploy script just needs a smidge more parameterization internally to let values files be flexible enough for sandboxes

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Interpolate the helm installation name
- Supply the instance id to the template so the template can do more interpolation if it needs
- Also allow the render script to actually supply things to the template

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- From the root of WFL's directory you can run the following to see that the render function works with the custom arguments:
```
./ops/render_ctmpl.py derived/2p/gotc-deploy/deploy/gotc-dev/helm/wfl-values.yaml.ctmpl -e WFL_DB_URL=foo
```
foo will appear in the rendered file
- The deploy stuff will be tested by me deploying to gotc-dev and aou once this is merged.
