### PR TITLE
Use generated environments in JAR

### DIFF
--- a/api/build.boot
+++ b/api/build.boot
@@ -12,11 +12,10 @@
   (str "../derived/api/" part))
 
 (set-env!
- ; At first glance these paths might appear slightly fishy and you'd be right.
- ; "Why is (derived "resources") a :source while "resources" is a :resource?"
- ; I hear you cry! Well, it's the only configuration that seems to not clobber
- ; the (derived "resources/zero/environments.clj") with
- ; "resources/zero/environments.clj" in the JAR.
+ ; There's something fishu going on with these paths... "Why are the generated
+ ; `resources` a :source while `resources` are a :resource?", I hear you cry!
+ ; This is because the generated `environments.clj` needs to be treated as a
+ ; source rather then a resource to be compiled into the jar.
  ; 
  ; ROBIN: What if you get the configuration wrong?
  ; ARTHUR: Then you are cast into the Gorge of Eternal Peril.

--- a/api/build.boot
+++ b/api/build.boot
@@ -8,19 +8,12 @@
 
 (def second-party "../derived/2p")
 (defn derived
-  [part]
-  (str "../derived/api/" part))
+  ([] "../derived/api")
+  ([part] (str (derived) "/" part)))
 
 (set-env!
- ; There's something fishu going on with these paths... "Why are the generated
- ; `resources` a :source while `resources` are a :resource?", I hear you cry!
- ; This is because the generated `environments.clj` needs to be treated as a
- ; source rather then a resource to be compiled into the jar.
- ; 
- ; ROBIN: What if you get the configuration wrong?
- ; ARTHUR: Then you are cast into the Gorge of Eternal Peril.
- :resource-paths #{"resources"}
- :source-paths #{(derived "resources") "src"}
+ :resource-paths #{(derived "resources") "resources"}
+ :source-paths #{(derived "src") "src"}
  :target-path (derived "target")
  :repositories
  '[["broad"
@@ -72,7 +65,7 @@
   "Add WDL files and version information to /resources/."
   []
   (let [resources (clojure.java.io/file (derived "resources"))]
-    (zero.boot/manage-version-and-resources the-version second-party resources)
+    (zero.boot/manage-version-and-resources the-version second-party (derived))
     (with-pre-wrap fileset (-> fileset (add-resource resources) commit!))))
 
 ;; So boot.lein can pick up the project name and version.

--- a/api/build.boot
+++ b/api/build.boot
@@ -12,56 +12,59 @@
   (str "../derived/api/" part))
 
 (set-env!
-  :resource-paths #{(derived "resources") "resources"}
-  :source-paths #{"src"}
-  :target-path (derived "target")
-  :repositories
-  '[["broad"
-     {:url "https://broadinstitute.jfrog.io/broadinstitute/ext-release-local"}]
-    ["clojars"
-     {:url "https://repo.clojars.org/"}]
-    ["maven-central"
-     {:url "https://repo1.maven.org/maven2"}]]
-  :dependencies                         ; See the ordering note above.
-  '[[org.clojure/clojure                       "1.10.1"]
-    [org.clojure/data.json                     "0.2.6"]
-    [org.clojure/data.xml                      "0.2.0-alpha6"]
-    [org.clojure/data.zip                      "0.1.3"]
-    [org.clojure/java.jdbc                     "0.7.8"]
-    [org.clojure/tools.logging                 "1.1.0"]
-    [amperity/vault-clj                        "0.5.1"]
-    [buddy/buddy-sign                          "3.1.0"]
-    [clj-commons/clj-yaml                      "0.7.0"]
-    [clj-http                                  "3.7.0"]
-    [clj-time                                  "0.15.1"]
-    [com.fasterxml.jackson.core/jackson-core   "2.10.0"]
-    [metosin/muuntaja                          "0.6.6"]
-    [metosin/reitit                            "0.4.2" :exclusions [metosin/ring-swagger-ui]]
-    [metosin/ring-swagger-ui                   "3.20.1"]
-    [org.apache.tika/tika-core                 "1.19.1"]
-    [org.apache.logging.log4j/log4j-api        "2.13.3"]
-    [org.apache.logging.log4j/log4j-core       "2.13.3"]
-    [org.apache.logging.log4j/log4j-slf4j-impl "2.13.3"]
-    [org.postgresql/postgresql                 "42.2.9"]
-    [org.slf4j/slf4j-api                       "1.7.30"]
-    [ring-oauth2                               "0.1.4"]
-    [ring/ring-core                            "1.7.1"]
-    [ring/ring-defaults                        "0.3.2"]
-    [ring/ring-devel                           "1.7.1"]
-    [ring/ring-jetty-adapter                   "1.7.1"]
-    [ring/ring-json                            "0.5.0"]
-    [com.google.cloud.sql/postgres-socket-factory            "1.0.15"]
-    [com.google.cloud.sql/jdbc-socket-factory-core           "1.0.15"]
-    [com.google.auth/google-auth-library-oauth2-http         "0.20.0"]
-    [adzerk/boot-test                  "1.2.0"   :scope "test"]
-    [onetom/boot-lein-generate         "0.1.3"   :scope "test"]])
+ ; At first glance these paths might appear slightly fishy and you'd be right.
+ ; "Why is (derived "resources") a :source while "resources" is a :resource?"
+ ; I hear you cry! Well, it's the only configuration that seems to not clobber
+ ; the (derived "resources/zero/environments.clj") with
+ ; "resources/zero/environments.clj" in the JAR.
+ ; 
+ ; ROBIN: What if you get the configuration wrong?
+ ; ARTHUR: Then you are cast into the Gorge of Eternal Peril.
+ :resource-paths #{"resources"}
+ :source-paths #{(derived "resources") "src"}
+ :target-path (derived "target")
+ :repositories
+ '[["broad"
+    {:url "https://broadinstitute.jfrog.io/broadinstitute/ext-release-local"}]
+   ["clojars"
+    {:url "https://repo.clojars.org/"}]
+   ["maven-central"
+    {:url "https://repo1.maven.org/maven2"}]]
+ :dependencies                         ; See the ordering note above.
+ '[[org.clojure/clojure                       "1.10.1"]
+   [org.clojure/data.json                     "0.2.6"]
+   [org.clojure/data.xml                      "0.2.0-alpha6"]
+   [org.clojure/data.zip                      "0.1.3"]
+   [org.clojure/java.jdbc                     "0.7.8"]
+   [org.clojure/tools.logging                 "1.1.0"]
+   [amperity/vault-clj                        "0.5.1"]
+   [buddy/buddy-sign                          "3.1.0"]
+   [clj-commons/clj-yaml                      "0.7.0"]
+   [clj-http                                  "3.7.0"]
+   [clj-time                                  "0.15.1"]
+   [com.fasterxml.jackson.core/jackson-core   "2.10.0"]
+   [metosin/muuntaja                          "0.6.6"]
+   [metosin/reitit                            "0.4.2" :exclusions [metosin/ring-swagger-ui]]
+   [metosin/ring-swagger-ui                   "3.20.1"]
+   [org.apache.tika/tika-core                 "1.19.1"]
+   [org.apache.logging.log4j/log4j-api        "2.13.3"]
+   [org.apache.logging.log4j/log4j-core       "2.13.3"]
+   [org.apache.logging.log4j/log4j-slf4j-impl "2.13.3"]
+   [org.postgresql/postgresql                 "42.2.9"]
+   [org.slf4j/slf4j-api                       "1.7.30"]
+   [ring-oauth2                               "0.1.4"]
+   [ring/ring-core                            "1.7.1"]
+   [ring/ring-defaults                        "0.3.2"]
+   [ring/ring-devel                           "1.7.1"]
+   [ring/ring-jetty-adapter                   "1.7.1"]
+   [ring/ring-json                            "0.5.0"]
+   [com.google.cloud.sql/postgres-socket-factory            "1.0.15"]
+   [com.google.cloud.sql/jdbc-socket-factory-core           "1.0.15"]
+   [com.google.auth/google-auth-library-oauth2-http         "0.20.0"]
+   [adzerk/boot-test                  "1.2.0"   :scope "test"]
+   [onetom/boot-lein-generate         "0.1.3"   :scope "test"]])
 
 (require '[boot.lein])
-(boot.lein/generate)
-
-(when-not (.exists (clojure.java.io/file "./wfl"))
-  (dosh "ln" "-s" "./build.boot" "./wfl"))
-
 (require 'zero.boot)
 
 (def the-version (zero.boot/make-the-version))
@@ -81,7 +84,9 @@
 (deftask prebuild
   ""
   []
-  (manage-version-and-resources))
+  (do
+    (boot.lein/generate)
+    (manage-version-and-resources)))
 
 (deftask build
   "Build this."

--- a/api/deps.edn
+++ b/api/deps.edn
@@ -4,12 +4,7 @@
   "central" {:url "https://repo1.maven.org/maven2/"}
   "clojars" {:url "https://clojars.org/repo"}}
 
- ; derived/api/resources must come first so the environments.clj there is found before
- ; the placeholder in src
- :paths ["../derived/api/resources" "resources" "src"]
-
  :deps
-
  {org.clojure/clojure                       {:mvn/version "1.10.1"}
   org.clojure/data.json                     {:mvn/version "0.2.6"}
   org.clojure/data.xml                      {:mvn/version "0.2.0-alpha6"}
@@ -46,9 +41,14 @@
   com.google.cloud.sql/postgres-socket-factory {:mvn/version "1.0.15"}
   com.google.cloud.sql/jdbc-socket-factory-core {:mvn/version "1.0.15"}}
 
- :aliases
+ ; derived/api/src must come first so environments.clj is found before
+ ; placeholder in src/.
+ :paths ["../derived/api/src" "src"
+         "../derived/api/resources" "resources"]
 
- {:lint
+ :aliases
+ { 
+  :lint
   {:extra-deps {cljfmt {:mvn/version "0.6.7"}}
    :main-opts  ["-m" "cljfmt.main" "check"]}
 

--- a/api/module.mk
+++ b/api/module.mk
@@ -11,6 +11,7 @@ DERIVED_RESOURCES_DIR := $(DERIVED_MODULE_DIR)/resources
 DERIVED_SRC_DIR		  := $(DERIVED_MODULE_DIR)/src
 DERIVED_TARGET_DIR    := $(DERIVED_MODULE_DIR)/target
 BOOT_PROJECT          := $(MODULE_DIR)/build.boot
+CLOJURE_PROJECT       := $(MODULE_DIR)/deps.edn
 LEIN_PROJECT          := $(MODULE_DIR)/project.clj
 
 CLEAN_DIRS  += $(CPCACHE_DIR)
@@ -36,9 +37,9 @@ $(BUILD): $(SCM_SRC) $(SCM_RESOURCES)
 	@$(TOUCH) $@
 
 LOGFILE := $(DERIVED_MODULE_DIR)/test.log
-$(CHECK): $(SCM_SRC)
+$(CHECK): $(SCM_SRC) $(SCM_RESOURCES) $(CLOJURE_PROJECT)
 	$(EXPORT) CPCACHE=$(CPCACHE_DIR);                        \
-	$(CLOJURE) $(CLJFLAGS) -A:test unit | $(TEE) $(LOGFILE);
+	$(CLOJURE) $(CLJFLAGS) -A:test unit | $(TEE) $(LOGFILE)
 	@$(TOUCH) $@
 
 DOCKER_API_IMAGE := broadinstitute/workflow-launcher-$(MODULE):$(WFL_VERSION)

--- a/api/module.mk
+++ b/api/module.mk
@@ -3,10 +3,12 @@
 REQUIRED_2P_REPOSITORIES := dsde-pipelines pipeline-config
 include $(MAKE_INCLUDE_DIR)/Makefile.module
 
+
 CPCACHE_DIR           := $(MODULE_DIR)/.cpcache
-SRC_DIR               := $(MODULE_DIR)/src
 RESOURCES_DIR         := $(MODULE_DIR)/resources
+SRC_DIR               := $(MODULE_DIR)/src
 DERIVED_RESOURCES_DIR := $(DERIVED_MODULE_DIR)/resources
+DERIVED_SRC_DIR		  := $(DERIVED_MODULE_DIR)/src
 DERIVED_TARGET_DIR    := $(DERIVED_MODULE_DIR)/target
 BOOT_PROJECT          := $(MODULE_DIR)/build.boot
 LEIN_PROJECT          := $(MODULE_DIR)/project.clj
@@ -20,7 +22,7 @@ JAR          := $(DERIVED_TARGET_DIR)/wfl-$(WFL_VERSION).jar
 JAR_LINK     := $(DERIVED_TARGET_DIR)/wfl.jar
 
 $(PREBUILD): $(MODULE_DIR)/wfl
-	@$(MKDIR) $(DERIVED_RESOURCES_DIR)
+	@$(MKDIR) $(DERIVED_RESOURCES_DIR) $(DERIVED_SRC_DIR)
 	$(BOOT) prebuild
 	@$(TOUCH) $@
 

--- a/api/module.mk
+++ b/api/module.mk
@@ -3,29 +3,34 @@
 REQUIRED_2P_REPOSITORIES := dsde-pipelines pipeline-config
 include $(MAKE_INCLUDE_DIR)/Makefile.module
 
-
 CPCACHE_DIR           := $(MODULE_DIR)/.cpcache
 SRC_DIR               := $(MODULE_DIR)/src
+RESOURCES_DIR         := $(MODULE_DIR)/resources
 DERIVED_RESOURCES_DIR := $(DERIVED_MODULE_DIR)/resources
 DERIVED_TARGET_DIR    := $(DERIVED_MODULE_DIR)/target
+BOOT_PROJECT          := $(MODULE_DIR)/build.boot
+LEIN_PROJECT          := $(MODULE_DIR)/project.clj
 
 CLEAN_DIRS  += $(CPCACHE_DIR)
-CLEAN_FILES += $(MODULE_DIR)/project.clj $(MODULE_DIR)/wfl
+CLEAN_FILES += $(LEIN_PROJECT) $(MODULE_DIR)/wfl
 
-RESOURCES   := $(DERIVED_RESOURCES_DIR).$(TS)
-SCM_SRC      = $(shell $(FIND) $(SRC_DIR) -name "*.$(CLJ)")
-ARTIFACT    := $(DERIVED_TARGET_DIR)/wfl-$(WFL_VERSION).jar
-SYMLINK     := $(DERIVED_TARGET_DIR)/wfl.jar
+SCM_SRC       = $(shell $(FIND) $(SRC_DIR) -type f -name "*.$(CLJ)")
+SCM_RESOURCES = $(shell $(FIND) $(RESOURCES_DIR) -type f)
+JAR          := $(DERIVED_TARGET_DIR)/wfl-$(WFL_VERSION).jar
+JAR_LINK     := $(DERIVED_TARGET_DIR)/wfl.jar
 
-$(PREBUILD):
+$(PREBUILD): $(MODULE_DIR)/wfl
 	@$(MKDIR) $(DERIVED_RESOURCES_DIR)
 	$(BOOT) prebuild
 	@$(TOUCH) $@
 
-$(BUILD): $(SCM_SRC)
+$(MODULE_DIR)/wfl:
+	$(LN) $(BOOT_PROJECT) $@
+
+$(BUILD): $(SCM_SRC) $(SCM_RESOURCES)
 	@$(MKDIR) $(DERIVED_TARGET_DIR)
 	$(BOOT) build
-	$(LN) $(ARTIFACT) $(SYMLINK)
+	$(LN) $(JAR) $(JAR_LINK)
 	@$(TOUCH) $@
 
 LOGFILE := $(DERIVED_MODULE_DIR)/test.log

--- a/api/tests.edn
+++ b/api/tests.edn
@@ -1,10 +1,10 @@
 #kaocha/v1
     {:tests [{:id           :integration
-              :source-paths ["../derived/api/resources" "resources" "src"]
+              :source-paths ["../derived/api/src" "src"]
               :test-paths   ["test"]
               :ns-patterns  ["zero\\.integration\\..*-test$"]}
              {:id           :unit
-              :source-paths ["../derived/api/resources" "resources" "src"]
+              :source-paths ["../derived/api/src" "src"]
               :test-paths   ["test"]
               :ns-patterns  ["zero\\.unit\\..*-test$"]}]
 

--- a/makerules/Makefile.module
+++ b/makerules/Makefile.module
@@ -36,7 +36,7 @@ all: $(MAKE_TARGETS)
 # Configure `make` dependencies via their time stamps.
 $(PREBUILD): | $(DERIVED_MODULE_DIR)
 $(LINT):     $(PREBUILD)
-$(BUILD):    $(PREBUILD)
+$(BUILD):    $(LINT)
 $(CHECK):    $(BUILD)
 $(IMAGES):   $(BUILD)
 

--- a/ops/server.sh
+++ b/ops/server.sh
@@ -9,7 +9,8 @@ test "$1" && export ZERO_DEPLOY_ENVIRONMENT="$1"
 npm run serve --prefix=derived/ui -- --port 8080 &
 
 pushd api
-"${WFL:-.}/../wfl" server 3000 &
+"./wfl" server 3000 &
+popd
 
 declare OPEN=open
 test CharlesDarwin = Charles$(uname) || OPEN=xdg-open


### PR DESCRIPTION
### Purpose
I misconfigured boot to not treat the generated `environments.clj` as a source.
I've moved the generated source into a "derived sources" directory and changed project configuration accordingly.

Bonus fixes:
prebuild when boot.build changes
check when deps.edn changes

Testing:
Verified that the jar now contains the environments. From the wfl directory:
```bash
$ clojure -Scp derived/api/target/wfl.jar`
user=> (load "zero/environments")
user=> zero.environments/aou-prod
{:cromwell {:job-mgr nil, :labels [:data_type :project :regulatory_designation :sample_name :version], :monitoring_script nil, :url 
[SNIP]
```

We still have all the resources too:
```bash
$ java -cp derived/api/target/wfl.jar zero.main version-json
{"ExternalExomeReprocessing.wdl":"ExternalExomeReprocessing_v1.1",
 "built":"2020-08-13T16:02:37Z",
 "Arrays.wdl":"Arrays_v1.9.1",
 "committed":"2020-08-13T15:59:11Z",
 "WhiteAlbumExomeReprocessing.wdl":
 "8ed294ede7fe8ee7d15013de105b3458eb478339",
 "commit":"cc8d410a5fe71ae3dc758af71b75aecf09f06653",
 "version":"0.1.0",
 "ExternalWholeGenomeReprocessing.wdl":
 "ExternalWholeGenomeReprocessing_v1.0",
 "pipeline-config":"9fecc4601b8e8c4812ec97e2bbc02d56e99c3a8f",
 "user":"edmund",
 "dsde-pipelines":"224266145f2e6497a6719174a78476e817b1675f"}
```