### PR TITLE
remove logging from zero.main and dx

### DIFF
--- a/api/src/zero/dx.clj
+++ b/api/src/zero/dx.clj
@@ -7,7 +7,6 @@
             [clojure.java.io :as io]
             [clojure.pprint :refer [pprint]]
             [clojure.string :as str]
-            [clojure.tools.logging :as log]
             [clj-http.client :as http]
             [zero.once :as once]
             [zero.service.cromwell :as cromwell]
@@ -414,14 +413,10 @@
 (defn run
   "Run diagnostic program specified by ARGS."
   [& args]
-  (try
     (if-let [diagnostic (commands (first args))]
       (apply diagnostic (rest args))
       (let [error (if-let [verb (first args)]
                     (format "Error: %s is not a dx <tool>." verb)
-                    "Error: Must specify a dx <tool> to run.")]
-        (throw (IllegalArgumentException. error))))
-    (catch Exception x
-      (log/error x)
-      (log/debug (describe commands))
-      (throw x))))
+                    "Error: Must specify a dx <tool> to run.")
+            usage (describe commands)]
+        (throw (IllegalArgumentException. (str error "\n" usage))))))

--- a/api/src/zero/main.clj
+++ b/api/src/zero/main.clj
@@ -3,7 +3,6 @@
   (:require [clojure.data.json :as json]
             [clojure.pprint :refer [pprint]]
             [clojure.string :as str]
-            [clojure.tools.logging :as log]
             [zero.util :as util]
             [zero.zero :as zero])
   (:gen-class))
@@ -78,14 +77,9 @@
           (apply run args)
           (exit 0))
         (do
-          (log/error (if verb
-                       (format "%s is not a command." verb)
-                       "Must specify a <command> to run."))
-          (log/debug "Output from zero.main/describe on zero.main/commands:")
-          (log/debug (describe commands)))))
-    (catch Exception x
-      (log/error x "Uncaught exception rose to zero.main/-main")
-      (log/debug "Output from zero.main/trace-stack:")
-      (log/debug (trace-stack x))
-      (log/debug \newline "BTW:" "You ran:" zero/the-name the-args))
-    (finally (exit 1))))
+          (if verb (printf "%s is not a command.\n" verb))
+          (help)
+          (exit 1))))
+    (catch Throwable t
+      (println (.getMessage t))
+      (exit 1))))


### PR DESCRIPTION
### Purpose
The behaviour of `dx` was different to what was documented in README. Specifically, it contained a lot of logging information.
Logging in `zero/main` make the command line usage of `wfl` noisy. In server mode, logging makes a lot of sense but not as a console application.

### Changes
Remove logging from the `zero.main/main` and `zero.dx` namespaces to restore old behaviour.
