### PR TITLE
Cloud function test upload able to target prod

### DIFF
--- a/cloud_function/tests/upload_test_files.py
+++ b/cloud_function/tests/upload_test_files.py
@@ -22,10 +22,12 @@ def get_destination_paths(bucket, prefix):
         "ptc": f"gs://{bucket}/{prefix}/ptc.json"
     }
 
-def get_ptc_json(bucket, prefix, chip_well_barcode):
+def get_ptc_json(bucket, prefix, chip_well_barcode, prod):
     return {
-        "cromwell": "https://cromwell-gotc-auth.gotc-dev.broadinstitute.org/",
-        "environment": "aou-dev",
+        "cromwell":
+            "https://cromwell-aou.gotc-prod.broadinstitute.org" if prod
+            else "https://cromwell-gotc-auth.gotc-dev.broadinstitute.org/",
+        "environment": "aou-prod" if prod else "aou-dev",
         "uuid": None,
         "notifications": [{
             "analysis_version_number": 1,
@@ -44,10 +46,10 @@ def get_ptc_json(bucket, prefix, chip_well_barcode):
         }]
     }
 
-def main(bucket):
+def main(bucket, prod):
     chip_well_barcode = uuid.uuid4()
     prefix = f"chip_name/{chip_well_barcode}/v1"
-    ptc_json = get_ptc_json(bucket, prefix, chip_well_barcode)
+    ptc_json = get_ptc_json(bucket, prefix, chip_well_barcode, prod)
     destination_paths = get_destination_paths(bucket, prefix)
     with tempfile.TemporaryDirectory() as tmpdirname:
         with open(f'{tmpdirname}/ptc.json', 'w') as f:
@@ -66,5 +68,11 @@ if __name__ == '__main__':
         default="dev-aou-arrays-input",
         help="The upload destination bucket."
     )
+    parser.add_argument(
+        "-p",
+        "--prod",
+        action="store_true",
+        help="Use infrastructure in broad-aou rather than broad-gotc-dev."
+    )
     args = parser.parse_args()
-    main(args.bucket)
+    main(args.bucket, args.prod)


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- No ticket is linked to this PR.
- In pursuit of QA'ing [GH-868](https://broadinstitute.atlassian.net/browse/GH-868) Saman and I discovered some issues with linking everything together in the `broad-aou` project. Most of the changes were made in gotc-deploy but this one is needed to have the test upload actually reference the right cromwell and environment

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Adds a `-p`/`--prod` flag so you can use `python3 upload_test_files.py -b broad-aou-arrays-input --prod` to kick off the cloud function in the aou environment

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- You can run `python3 upload_test_files.py -b broad-aou-arrays-input --prod` and see that the cloud function logs show that cromwell started
