### PR TITLE
[GH-819] First draft of baits and targets editing

### DIFF
--- a/api/src/zero/module/xx.clj
+++ b/api/src/zero/module/xx.clj
@@ -10,7 +10,9 @@
             [zero.service.gcs :as gcs]
             [zero.util :as util]
             [zero.wdl :as wdl]
-            [zero.zero :as zero]))
+            [zero.zero :as zero]
+            [zero.environments :as env]
+            [clojure.tools.logging :as log]))
 
 (def description
   "Describe the purpose of this command."
@@ -204,7 +206,12 @@
 (defn print-help
   [& _]
   (println description)
-  (println (describe-overrides "baits and targets" "-B" default-baits-and-targets)))
+  (println (describe-overrides "baits and targets" "-B" default-baits-and-targets))
+  (println)
+  (println (format "Note that any bucket path overrides must be accessible by %s in the %s project"
+                   ; Hardcode because having help text reading from Vault / environments.clj is error-prone
+                   ; (This is very very unlikely to change during the lifetime of this CLI)
+                  "picard-prod" "broad-gotc-prod")))
 
 (defn run
   "Reprocess the BAM or CRAM files described by ARGS."


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-819

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- There was already a `baits-and-targets` map. Now, you can override any of its keys with
```
-B:bait_set_name=my-new-value
```
- The documentation for these options is also automatically generated from the defaults map itself, so we don't have to maintain it:
```
...
Override the baits and targets configuration by specifying arguments prefixed with -B
Example: -B:bait_set_name=my-new-value
Configuration defaults:
:bait_set_name=whole_exome_illumina_coding_v1
:bait_interval_list=gs://broad-references-private/HybSelOligos/whole_exome_illumina_coding_v1/whole_exome_illumina_coding_v1.Homo_sapiens_assembly38.baits.interval_list
:target_interval_list=gs://broad-references-private/HybSelOligos/whole_exome_illumina_coding_v1/whole_exome_illumina_coding_v1.Homo_sapiens_assembly38.targets.interval_list
:cram_ref_fasta=gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta
:cram_ref_fasta_index=gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai
```
- There's nothing hardcoded about this, adding something new to the defaults map makes it editable and appear in the documentation. Parsing happens by literally creating a map from any passed arguments with the `-B` prefix and merging it with the defaults.
- Added a `baits-and-targets` input to several existing functions to let the overridden config makes its way down from the CLI entrypoint
- Improved help text printing (print help text without wrapping it in `log/error`)

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- Nothing yet, this is just a draft to see if I'm heading in the right direction.
