### PR TITLE
[GH-887] Add AoU final workflow outputs directory

### DIFF
--- a/api/src/zero/module/all.clj
+++ b/api/src/zero/module/all.clj
@@ -113,6 +113,14 @@
     url
     (str url "/")))
 
+(defn de-slashify
+  [url]
+  (if (str/ends-with? url "/")
+    (->> (seq url)
+         drop-last
+         (str/join ""))
+    url))
+
 (defn cromwell-environments
   "Keywords from the set of ENVIRONMENTS with Cromwell URL."
   ([url]

--- a/api/src/zero/module/aou.clj
+++ b/api/src/zero/module/aou.clj
@@ -102,6 +102,7 @@
   [sample-output-path]
   {; TODO: add :default_runtime_attributes {:maxRetries 3} here
    :final_workflow_outputs_dir sample-output-path
+   :use_relative_output_paths  true
    :read_from_cache            true
    :write_to_cache             true
    :default_runtime_attributes {:zones "us-central1-a us-central1-b us-central1-c us-central1-f"}})

--- a/api/src/zero/module/aou.clj
+++ b/api/src/zero/module/aou.clj
@@ -163,8 +163,8 @@
   (let [{:keys [creator cromwell pipeline project output]} body
         {:keys [release top]} workflow-wdl
         {:keys [commit version]} (zero/get-the-version)
-        probe-result (jdbc/query tx ["SELECT * FROM workload WHERE project = ? AND pipeline = ?::pipeline AND release = ?"
-                                     project pipeline release])
+        probe-result (jdbc/query tx ["SELECT * FROM workload WHERE project = ? AND pipeline = ?::pipeline AND release = ? AND output = ?"
+                                     project pipeline release output])
         checked-output (gcs/parse-gs-url output)]
     (if (seq probe-result)
       ;; if a table already exists, we return its uuid and the name

--- a/api/test/zero/tools/workloads.clj
+++ b/api/test/zero/tools/workloads.clj
@@ -30,7 +30,7 @@
   {:creator  @git-email
    :cromwell (get-in stuff [:gotc-dev :cromwell :url])
    :input    "aou-inputs-placeholder"
-   :output   "aou-outputs-placeholder"
+   :output   "gs://broad-gotc-dev-zero-test/aou-test-output"
    :pipeline aou/pipeline
    :project  (format "(Test) %s %s" @git-branch identifier)
    :items    [{}]})

--- a/cloud_function/deploy.sh
+++ b/cloud_function/deploy.sh
@@ -12,11 +12,13 @@ if [ "${GCLOUD_PROJECT}" == "broad-gotc-dev-storage" ]; then
   _WFL_URL="https://dev-wfl.gotc-dev.broadinstitute.org"
   _CROMWELL_URL="https://cromwell-gotc-auth.gotc-dev.broadinstitute.org/"
   _WFL_ENVIRONMENT="aou-dev"
+  _OUTPUT_BUCKET="gs://dev-aou-arrays-output"
 elif [ "${GCLOUD_PROJECT}" == "broad-aou-storage" ]; then
   SA_EMAIL="aou-cloud-fn@broad-aou-storage.iam.gserviceaccount.com"
   _WFL_URL="https://aou-wfl.gotc-prod.broadinstitute.org"
   _CROMWELL_URL="https://cromwell-aou.gotc-prod.broadinstitute.org/"
   _WFL_ENVIRONMENT="aou-prod"
+  _OUTPUT_BUCKET="gs://broad-aou-arrays-output"
 else
   printf "Unrecognized google project\n"
   exit 1
@@ -28,6 +30,6 @@ gcloud functions deploy submit_aou_workload \
     --trigger-resource ${TRIGGER_BUCKET} \
     --trigger-event ${TRIGGER_EVENT} \
     --service-account ${SA_EMAIL} \
-    --set-env-vars WFL_URL=${_WFL_URL},CROMWELL_URL=${_CROMWELL_URL},WFL_ENVIRONMENT=${_WFL_ENVIRONMENT} \
+    --set-env-vars WFL_URL=${_WFL_URL},CROMWELL_URL=${_CROMWELL_URL},WFL_ENVIRONMENT=${_WFL_ENVIRONMENT},OUTPUT_BUCKET=${_OUTPUT_BUCKET} \
     --runtime python37 \
     --memory 128MB

--- a/cloud_function/main.py
+++ b/cloud_function/main.py
@@ -9,11 +9,12 @@ _SERVICE_ACCOUNT = os.environ.get('FUNCTION_IDENTITY')  # Set by the cloud fn
 WFL_URL = os.environ.get("WFL_URL")
 CROMWELL_URL = os.environ.get("CROMWELL_URL")
 WFL_ENVIRONMENT = os.environ.get("WFL_ENVIRONMENT")
+OUTPUT_BUCKET = os.environ.get("OUTPUT_BUCKET")
 
 assert WFL_URL is not None, "WFL_URL is not set"
 assert CROMWELL_URL is not None, "CROMWELL_URL is not set"
 assert WFL_ENVIRONMENT is not None, "WFL_ENVIRONMENT is not set"
-
+assert OUTPUT_BUCKET is not None, "OUTPUT_BUCKET is not set"
 
 def get_auth_headers():
     scopes_list = ["https://www.googleapis.com/auth/cloud-platform",
@@ -35,19 +36,12 @@ def get_manifest_path(object_name):
     chip_name, chip_well_barcode, analysis_version, file_name = path.split("/", maxsplit=3)
     return "/".join([chip_name, chip_well_barcode, analysis_version, "ptc.json"])
 
-def get_final_output_bucket(environment):
-    if environment == "aou-dev":
-        return "gs://dev-aou-arrays-output"
-    elif environment == "aou-prod":
-        return "gs://broad-aou-arrays-output"
-    return "aou-ouputs-placeholder"
-
 def get_or_create_workload(headers):
     payload = {
         "creator": _SERVICE_ACCOUNT,
         "cromwell": CROMWELL_URL,
         "input": "aou-inputs-placeholder",
-        "output": get_final_output_bucket(WFL_ENVIRONMENT),
+        "output": OUTPUT_BUCKET,
         "pipeline": "AllOfUsArrays",
         "project": WFL_ENVIRONMENT,
         "items": [{}]

--- a/cloud_function/main.py
+++ b/cloud_function/main.py
@@ -35,12 +35,19 @@ def get_manifest_path(object_name):
     chip_name, chip_well_barcode, analysis_version, file_name = path.split("/", maxsplit=3)
     return "/".join([chip_name, chip_well_barcode, analysis_version, "ptc.json"])
 
+def get_final_output_bucket(environment):
+    if environment == "aou-dev":
+        return "gs://dev-aou-arrays-output"
+    elif environment == "aou-prod":
+        return "gs://broad-aou-arrays-output"
+    return "aou-ouputs-placeholder"
+
 def get_or_create_workload(headers):
     payload = {
         "creator": _SERVICE_ACCOUNT,
         "cromwell": CROMWELL_URL,
         "input": "aou-inputs-placeholder",
-        "output": "aou-ouputs-placeholder",
+        "output": get_final_output_bucket(WFL_ENVIRONMENT),
         "pipeline": "AllOfUsArrays",
         "project": WFL_ENVIRONMENT,
         "items": [{}]


### PR DESCRIPTION
### Purpose
Use the cromwell workflow option to copy outputs (ticket https://broadinstitute.atlassian.net/browse/GH-887)

### Changes
- Use the `output` defined in the create/exec workload payload instead of the placeholder string and fail if it is not a valid gs-url
- When creating a workload, check the output in addition to the pipeline, project & release (so changing the output location will result in creating a new workload)
- When appending workflows, construct the final workflow outputs path by appending "/chip-well-barcode/analysis-version-number" to the workload `output`
- Cromwell options specify the final output directory & uses the relative output paths

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
