### PR TITLE
[GH-841] Fix some endpoint specs and add Swagger OAuth2 button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -372,11 +372,13 @@ dmypy.json
 
 ### VisualStudioCode ###
 .vscode/*
-!.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
 *.code-workspace
+
+### Calva ###
+.calva/
 
 ### VisualStudioCode Patch ###
 # Ignore all local history of files

--- a/api/src/zero/api/routes.clj
+++ b/api/src/zero/api/routes.clj
@@ -81,6 +81,12 @@
     {:get {:no-doc true ;; exclude this endpoint itself from swagger
            :swagger {:info {:title (str zero/the-name "-API")
                             :version (str (:version (zero/get-the-version)))}
+                     :securityDefinitions {:googleoauth {:type "oauth2"
+                                                         :flow "implicit"
+                                                         :authorizationUrl "https://accounts.google.com/o/oauth2/auth"
+                                                         :scopes {:openid  "open id authorization"
+                                                                  :email   "email authorization"
+                                                                  :profile "profile authorization"}}}
                      :basePath "/"} ;; prefix for all paths
            :handler (swagger/create-swagger-handler)}}]])
 

--- a/api/src/zero/api/spec.clj
+++ b/api/src/zero/api/spec.clj
@@ -27,8 +27,7 @@
 (s/def ::uuids (s/* ::uuid))
 (s/def ::uuid-kv (s/keys :req-un [::uuid]))
 (s/def ::uuid-kvs (s/* ::uuid-kv))
-(s/def ::uuid-query (s/or :none empty?
-                          :one (s/keys :req-un [::uuid])))
+(s/def ::uuid-query (s/keys :opt-un [::uuid]))
 (s/def ::version string?)
 (s/def ::wdl string?)
 (s/def ::workload-request (s/keys :req-un [::creator


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-841

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Fix a mis-configured spec for `/workload`.
- Add partial support for Swagger OAuth2. 

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

**Note:**
The OAuth support for Swagger is not fully-functional. I haven't found a decent way to make it work. We might want to keep an eye on how the `reitit` folks respond to https://github.com/metosin/reitit/issues/430
