### PR TITLE
[GH-910] use `bash` as `make`s shell. set pipefail

### DIFF
--- a/makerules/common.mk
+++ b/makerules/common.mk
@@ -1,6 +1,10 @@
 # common.mk
 # Defines common shell utilites for wfl
 
+# Set the shell used on all platforms
+SHELL       := bash
+.SHELLFLAGS += -o pipefail -c
+
 # Common shell programs
 AWK     := awk
 BOOT    := boot


### PR DESCRIPTION
### Purpose
When tests fail, we want `make` to report these failures and fail itself.
I'm `tee`ing test results into a log file because if i parallel build, I have a coherent record of the test failure (rather than fragments strewn about the place)

The solution is to fix the shell on 'nix platforms to `bash` and use the pipefail option. See the following links for more info:
https://stackoverflow.com/questions/25306774/best-way-to-handle-pipes-and-their-exit-status-in-a-makefile
https://unix.stackexchange.com/questions/14270/get-exit-status-of-process-thats-piped-to-another/73180#73180
