### PR TITLE
[GH-910] GMake failures on Mac

### DIFF
--- a/makerules/common.mk
+++ b/makerules/common.mk
@@ -2,8 +2,7 @@
 # Defines common shell utilites for wfl
 
 # Set the shell used on all platforms
-SHELL       := bash
-.SHELLFLAGS += -o pipefail -c
+SHELL       := bash -o pipefail -c
 
 # Common shell programs
 AWK     := awk

--- a/ui/module.mk
+++ b/ui/module.mk
@@ -39,8 +39,8 @@ $(CLEAN):
 $(DERIVED_NPM_CONFIG): $(DERIVED_MODULE_DIR)/%.json : $(MODULE_DIR)/%.json
 	$(JQ) '.version="$(WFL_VERSION)"' $< > $@
 
-DERIVED_SRC_DIRS = $(filter-out $(DERIVED_MODULE_DIR),\
-	$(shell eval "$(DIRNAME) $(DERIVED_SRC) | $(SORT) | $(UNIQUE)"))
+DERIVED_SRC_DIRS = \
+	$(filter-out $(DERIVED_MODULE_DIR)/,$(sort $(dir $(DERIVED_SRC))))
 
 $(DERIVED_SRC): | $(DERIVED_SRC_DIRS)
 $(DERIVED_SRC): $(DERIVED_MODULE_DIR)/% : $(MODULE_DIR)/%


### PR DESCRIPTION
### Purpose
The first issue is that MacOS by default ships with an older version of `gmake` that doesn't support `.SHELLFLAGS`
The second issue was that BSD dirname only accepts one file, rather than many. I didn't need to shell out to get the list of uinique dirnames so I'm using build-in Make functions instead.