### PR TITLE
Discuss/bump pipeline version

### DIFF
--- a/api/src/zero/module/aou.clj
+++ b/api/src/zero/module/aou.clj
@@ -78,9 +78,9 @@
                        :control_sample_vcf_index_file
                        :control_sample_intervals_file
                        :control_sample_name
-                       ;; cloud path of the Illumina gender cluster file
-                       :zcall_thresholds_file
                        ;; cloud path of a thresholds file to be used with zCall
+                       :zcall_thresholds_file
+                       ;; cloud path of the Illumina gender cluster file
                        :gender_cluster_file]
         mandatory  (select-keys inputs mandatory-keys)
         optional   (select-keys inputs optional-keys)

--- a/api/src/zero/module/aou.clj
+++ b/api/src/zero/module/aou.clj
@@ -19,7 +19,7 @@
 
 (def workflow-wdl
   "The top-level WDL file and its version."
-  {:release "Arrays_v1.9.1"
+  {:release "Arrays_v2.0"
    :top     "pipelines/arrays/single_sample/Arrays.wdl"})
 
 (def cromwell-label-map


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->
> Kylee Degatano  17 hours ago
> Yeah I don't think it matters but agreed best to update it
> 
> Kylee Degatano  17 hours ago
> But now that I realize that releases to production impact WFL we'll make sure you're made aware of releases
> 
> Jack Warren  17 hours ago
> Yeah it is minimal work as I understand it, would be best done tomorrow though
> 
> Jack Warren  17 hours ago
> I'm 99% sure I understand how to change it but I definitely don't want to light everything on fire late in the evening
> 
> George Grant  16 hours ago
> I think we went to 2.0 from 1.9.1 because it was a significant fix.  Probably should have gone to 1.10.0 though.  I think that WFL should use the version sent up in the message.  That’s what’s being recorded in the database as the pipeline version.  Otherwise, wfl could parse pipeline_version out of the wdl and put that into the json message to the arrays pipeline (may be more straightforward that way?).  Provenance!
> 
> George Grant  4 hours ago
> Sorry, I rechecked the code and the wdl does the right thing.  It puts the pipeline version that's in the wdl itself into the database.  So wfl can safely ignore the version in the message
> 
> Jack Warren  < 1 minute ago
> I feel like we should still no randomly reference old things in our code. If y'all don't use our reference to the version then I figure we can super safely update it

I figure we should discuss how we want to do this. Dumb way is here, I'm not sure if we want to build out a thing to either not send this at all or to interpret this from the WDL.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Right now, just bumps our hardcoded reference.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
