### PR TITLE
[GH-911] configure pytest environment with `pytest-env` plugin

### DIFF
--- a/cloud_function/README.md
+++ b/cloud_function/README.md
@@ -2,7 +2,7 @@ Overview
 --------
 When the push to cloud service uploads arrays data to a GCS bucket, it will trigger execution of this cloud function.
 The function checks the parent directory of the uploaded file `"gs://{bucket}/{chip_name}/{chipwell_barcode}/{analysis_version}/"`
-for a manifest file named `ptc.json`. If all the files listed in the manifest have been uploaded, a request is sent 
+for a manifest file named `ptc.json`. If all the files listed in the manifest have been uploaded, a request is sent
 to the WFL API to start processing this sample.
 
 
@@ -16,11 +16,6 @@ Testing
 1) Create a virtual python3 environment
 2) Install requirements with `pip install -r dev-requirements.txt`
 3) Run the unit tests:
-```
-WFL_URL="https://workflow-launcher.gotc-dev.broadinstitute.org"
-CROMWELL_URL="https://cromwell-gotc-auth.gotc-dev.broadinstitute.org/"
-WFL_ENVIRONMENT="aou-dev"
-OUTPUT_BUCKET="gs://fake-bucket"
-WFL_URL=${WFL_URL} CROMWELL_URL=${CROMWELL_URL} WFL_ENVIRONMENT=${WFL_ENVIRONMENT} OUTPUT_BUCKET=${OUTPUT_BUCKET} \
-    pytest tests/unit_tests.py
+```bash
+$ pytest tests/unit_tests.py
 ```

--- a/cloud_function/dev-requirements.txt
+++ b/cloud_function/dev-requirements.txt
@@ -1,4 +1,5 @@
 mock==4.0.2
 pytest==5.4.3
+pytest-env==0.6.2
 requests==2.21.0
 google-cloud-storage>=1.10.0,<2

--- a/cloud_function/module.mk
+++ b/cloud_function/module.mk
@@ -10,13 +10,13 @@ SCM_SRC := \
 	$(SRC_DIR)/__init__.py \
 	$(SRC_DIR)/main.py
 
-TEST_SCM_SRC = $(shell $(FIND) $(TEST_DIR) -type f -name '*.py')
+TEST_SCM_SRC = \
+	$(shell $(FIND) $(TEST_DIR) -type f -name '*.py') \
+	$(MODULE_DIR)/pytest.ini
 
-WFL_URL := https://workflow-launcher.gotc-dev.broadinstitute.org
 LOGFILE := $(DERIVED_MODULE_DIR)/test.log
 $(CHECK): $(SCM_SRC) $(TEST_SCM_SRC)
 	$(call using-python-environment,                                      \
-		$(EXPORT) WFL_URL=$(WFL_URL);                                     \
 		$(PYTHON) -m pytest $(TEST_DIR)/unit_tests.py | $(TEE) $(LOGFILE) \
 	)
 	@$(TOUCH) $@

--- a/cloud_function/pytest.ini
+++ b/cloud_function/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 env =
-    WFL_URL="https://workflow-launcher.gotc-dev.broadinstitute.org"
+    WFL_URL="https://dev-wfl.gotc-dev.broadinstitute.org"
     CROMWELL_URL="https://cromwell-gotc-auth.gotc-dev.broadinstitute.org/"
     WFL_ENVIRONMENT="aou-dev"
     OUTPUT_BUCKET="gs://fake-bucket"

--- a/cloud_function/pytest.ini
+++ b/cloud_function/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+env =
+    WFL_URL="https://workflow-launcher.gotc-dev.broadinstitute.org"
+    CROMWELL_URL="https://cromwell-gotc-auth.gotc-dev.broadinstitute.org/"
+    WFL_ENVIRONMENT="aou-dev"
+    OUTPUT_BUCKET="gs://fake-bucket"


### PR DESCRIPTION
### Purpose
`make cloud_function TARGET=check` currently fails as the environment is misconfigured.
This is a symptom of a larger problem in that to run the tests, we have to manually set the environment.

[pytest-env](https://github.com/MobileDynasty/pytest-env) is a nice little plugin that reads the environment variables out of `pytest.ini`. I propose we use this to manage and configure the environment.

This PR fixes GH-911.

related SO article:
https://stackoverflow.com/questions/36141024/how-to-pass-environment-variables-to-pytest