### PR TITLE
[GH-936] Make cloudfn only check files uploaded by PTC

### DIFF
--- a/cloud_function/main.py
+++ b/cloud_function/main.py
@@ -100,7 +100,7 @@ def submit_aou_workload(event, context):
     input_data = json.loads(manifest_file_content)
     notification = input_data['notifications'][0]
     input_values = notification.values()
-    input_files = set([f for f in input_values if str(f).startswith("gs://")])
+    input_files = set([f for f in input_values if str(f).startswith("gs://") and not str(f).endswith("/")])
 
     # Check if the input files have been uploaded
     upload_complete = True

--- a/cloud_function/main.py
+++ b/cloud_function/main.py
@@ -100,7 +100,7 @@ def submit_aou_workload(event, context):
     input_data = json.loads(manifest_file_content)
     notification = input_data['notifications'][0]
     input_values = notification.values()
-    input_files = set([f for f in input_values if str(f).startswith("gs://") and not str(f).endswith("/")])
+    input_files = set([f for f in input_values if str(f).startswith(f"gs://{bucket}")])
 
     # Check if the input files have been uploaded
     upload_complete = True


### PR DESCRIPTION
### Purpose
The cloud function SA does not have access to the cloud chip metadata directory containing the extended chip manifest file.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

Make the cloud function only check for files that PTC uploads. If the extended chip manifest file isn't there (which is not likely to happen) the cromwell workflow would still fail.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
