### PR TITLE
[GH-914] Add Python and Git configurations

### DIFF
--- a/.github/workflows/release_latest_version.yml
+++ b/.github/workflows/release_latest_version.yml
@@ -15,11 +15,24 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      
+      - name: Configure Git
+        run: |
+          git config --local user.email "$(git log --format='%ae' HEAD^!)"
+          git config --local user.name "$(git log --format='%an' HEAD^!)"
 
       - name: Setup Java
         uses: actions/setup-java@v1
         with:
           java-version: '11'
+          
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+          
+      - name: Install Python Dependencies
+        run: python -m pip install --upgrade pip pyyaml
 
       - name: Setup Clojure
         uses: DeLaGuardo/setup-clojure@2.0


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-914

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Locks Python version to what works for me locally. This will solve the issue of the default Python being too old to use `dataclass`
- Use pip to install pyyaml, a dependency I haven't thought about in a while but that I suppose we'll need here
- Competing information online about if we need to do configuration to Git, but I'd rather just play it safe. Git user and email inferred from the commit.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- Wait for a new release, I suppose.
- I wish I had set up better tooling to test this, I'm sorry that getting this working has been so rocky. Since our releases and tags actually have meaning even if I were to do this locally I would still have to wait for real releases.
