### PR TITLE
[GH-953] get creator from auth token instead of via the workload-request

### DIFF
--- a/api/src/wfl/api/spec.clj
+++ b/api/src/wfl/api/spec.clj
@@ -30,8 +30,7 @@
 (s/def ::uuid-query (s/keys :opt-un [::uuid]))
 (s/def ::version string?)
 (s/def ::wdl string?)
-(s/def ::workload-request (s/keys :req-un [::creator
-                                           ::cromwell
+(s/def ::workload-request (s/keys :req-un [::cromwell
                                            ::input
                                            ::items
                                            ::output

--- a/api/src/wfl/service/gcs.clj
+++ b/api/src/wfl/service/gcs.clj
@@ -271,3 +271,13 @@
            :headers      (once/get-auth-header)
            :body         (json/write-str metadata :escape-slash false)}
           http/request :body (json/read-str :key-fn keyword)))))
+
+(defn userinfo
+  "Query Google Cloud services for who made the http REQUEST"
+  [request]
+  (if-let [auth-token (or (get-in request [:headers "Authorization"])
+                          (get-in request [:headers "authorization"]))]
+    (let [response (http/get (str api-url "oauth2/v3/userinfo")
+                     {:headers {"Authorization" auth-token}})]
+      (json/read-str (:body response) :key-fn keyword))
+    (throw (IllegalArgumentException. "no auth header in request"))))

--- a/api/test/wfl/tools/workloads.clj
+++ b/api/test/wfl/tools/workloads.clj
@@ -6,13 +6,11 @@
             [wfl.module.aou :as aou]))
 
 (def git-branch (delay (shell! "git" "branch" "--show-current")))
-(def git-email (delay (shell! "git" "config" "user.email")))
 
 (def wgs-workload
   "A whole genome sequencing workload used for testing."
   (let [path "/single_sample/plumbing/truth"]
-    {:creator  @git-email
-     :cromwell (get-in stuff [:gotc-dev :cromwell :url])
+    {:cromwell (get-in stuff [:gotc-dev :cromwell :url])
      :input    (str "gs://broad-gotc-test-storage" path)
      :output   (str "gs://broad-gotc-dev-zero-test/wgs-test-output" path)
      :pipeline wgs/pipeline
@@ -27,8 +25,7 @@
   "An allofus arrays workload used for testing.
   Randomize it with IDENTIFIER for easier testing."
   [identifier]
-  {:creator  @git-email
-   :cromwell (get-in stuff [:gotc-dev :cromwell :url])
+  {:cromwell (get-in stuff [:gotc-dev :cromwell :url])
    :input    "aou-inputs-placeholder"
    :output   "gs://broad-gotc-dev-zero-test/aou-test-output"
    :pipeline aou/pipeline
@@ -58,8 +55,7 @@
 (defn make-copyfile-workload
   "Make a workload to copy a file from SRC to DST"
   [src dst]
-  {:creator  @git-email
-   :cromwell (get-in stuff [:gotc-dev :cromwell :url])
+  {:cromwell (get-in stuff [:gotc-dev :cromwell :url])
    :input    ""
    :output   ""
    :pipeline cp/pipeline

--- a/api/test/wfl/unit/gcs_test.clj
+++ b/api/test/wfl/unit/gcs_test.clj
@@ -1,9 +1,10 @@
 (ns wfl.unit.gcs-test
   "Test the Google Cloud Storage namespace."
-  (:require [clojure.java.io  :as io]
-            [clojure.string   :as str]
-            [clojure.test     :refer [deftest is testing]]
-            [wfl.service.gcs :as gcs])
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [wfl.service.gcs :as gcs]
+            [wfl.once :as once])
   (:import [java.util UUID]))
 
 (def project
@@ -119,3 +120,10 @@
             (gcs/download-file local-file-name url)
             (is (= (slurp properties) (slurp local-file-name)))))))
     (finally (cleanup-object-test))))
+
+(deftest userinfo-test
+  (testing "no \"Authorization\" header in request should throw"
+    (is (thrown? Exception (gcs/userinfo {:headers {}}))))
+  (testing "fetching userinfo from request with \"Authorization\" header"
+    (let [info (gcs/userinfo {:headers (once/get-auth-header)})]
+      (is (:email info)))))

--- a/cloud_function/main.py
+++ b/cloud_function/main.py
@@ -5,7 +5,6 @@ from google.cloud import storage
 from google.cloud import exceptions
 
 
-_SERVICE_ACCOUNT = os.environ.get('FUNCTION_IDENTITY')  # Set by the cloud fn
 WFL_URL = os.environ.get("WFL_URL")
 CROMWELL_URL = os.environ.get("CROMWELL_URL")
 WFL_ENVIRONMENT = os.environ.get("WFL_ENVIRONMENT")
@@ -38,7 +37,6 @@ def get_manifest_path(object_name):
 
 def get_or_create_workload(headers):
     payload = {
-        "creator": _SERVICE_ACCOUNT,
         "cromwell": CROMWELL_URL,
         "input": "aou-inputs-placeholder",
         "output": OUTPUT_BUCKET,

--- a/ops/server.sh
+++ b/ops/server.sh
@@ -9,6 +9,7 @@ test "$1" && export WFL_DEPLOY_ENVIRONMENT="$1"
 npm run serve --prefix=derived/ui -- --port 8080 &
 
 pushd api
+export _JAVA_OPTIONS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"
 "./wfl" server 3000 &
 popd
 


### PR DESCRIPTION
### Purpose
https://broadinstitute.atlassian.net/browse/GH-954

Interestingly, the keys in the header map are lower case, hence I'm checking for Authorization as well as authorization. Not sure whats cauing this... Ideas welcome.

### Changes
Remove `creator` as a field from the `workload-request`
Get this information from the `userinfo` gcs oauth api.

Added automated test.

### Review Instructions
@samanehsan  Is this change going to cause problems for the cloud function?