### PR TITLE
[GH-950] Easier local liquibase migration

### DIFF
--- a/api/build.boot
+++ b/api/build.boot
@@ -43,6 +43,7 @@
    [org.apache.logging.log4j/log4j-core       "2.13.3"]
    [org.apache.logging.log4j/log4j-slf4j-impl "2.13.3"]
    [org.postgresql/postgresql                 "42.2.9"]
+   [org.liquibase/liquibase-core              "4.0.0" :exclusions [ch.qos.logback/logback-classic]]
    [org.slf4j/slf4j-api                       "1.7.30"]
    [ring-oauth2                               "0.1.4"]
    [ring/ring-core                            "1.7.1"]

--- a/api/deps.edn
+++ b/api/deps.edn
@@ -65,9 +65,7 @@
   
   :liquibase
   {:main-opts   ["-m" "wfl.service.postgres"]
-   :extra-deps  {org.liquibase/liquibase-cdi   {:mvn/version "4.0.0"
-                                                :exclusions [ch.qos.logback/logback-classic]}
-                 org.liquibase/liquibase-core  {:mvn/version "4.0.0"
+   :extra-deps  {org.liquibase/liquibase-core  {:mvn/version "4.0.0"
                                                 :exclusions [ch.qos.logback/logback-classic]}}}
 
   :run

--- a/api/deps.edn
+++ b/api/deps.edn
@@ -41,18 +41,18 @@
   com.google.cloud.sql/postgres-socket-factory {:mvn/version "1.0.15"}
   com.google.cloud.sql/jdbc-socket-factory-core {:mvn/version "1.0.15"}}
 
- ; derived/api/src must come first so environments.clj is found before
- ; placeholder in src/.
+ ;; derived/api/src must come first so environments.clj is found before
+ ;; placeholder in src/.
  :paths ["../derived/api/src" "src"
          "../derived/api/resources" "resources"]
 
  :aliases
  {:lint
-  {:extra-deps {cljfmt {:mvn/version "0.6.7"}}
+  {:extra-deps {cljfmt {:mvn/version "0.7.0"}}
    :main-opts  ["-m" "cljfmt.main" "check"]}
 
   :format
-  {:extra-deps {cljfmt {:mvn/version "0.6.7"}}
+  {:extra-deps {cljfmt {:mvn/version "0.7.0"}}
    :main-opts  ["-m" "cljfmt.main" "fix"]}
 
   :kondo
@@ -64,7 +64,7 @@
    :main-opts   ["-e" "(use,'kibit.driver),(external-run,[\"src\"],nil)"]}
   
   :liquibase
-  {:main-opts   ["-m" "wfl.service.postgres.local-liquibase-migration"]
+  {:main-opts   ["-m" "wfl.service.postgres"]
    :extra-deps  {org.liquibase/liquibase-cdi   {:mvn/version "4.0.0"
                                                 :exclusions [ch.qos.logback/logback-classic]}
                  org.liquibase/liquibase-core  {:mvn/version "4.0.0"
@@ -75,8 +75,6 @@
 
   :test
   {:extra-deps  {lambdaisland/kaocha           {:mvn/version "1.0.632"}
-                 org.liquibase/liquibase-cdi   {:mvn/version "4.0.0"
-                                                :exclusions [ch.qos.logback/logback-classic]}
                  org.liquibase/liquibase-core  {:mvn/version "4.0.0"
                                                 :exclusions [ch.qos.logback/logback-classic]}}
    :extra-paths ["test"]

--- a/api/deps.edn
+++ b/api/deps.edn
@@ -47,8 +47,7 @@
          "../derived/api/resources" "resources"]
 
  :aliases
- { 
-  :lint
+ {:lint
   {:extra-deps {cljfmt {:mvn/version "0.6.7"}}
    :main-opts  ["-m" "cljfmt.main" "check"]}
 
@@ -63,6 +62,13 @@
   :kibit
   {:extra-deps  {jonase/kibit {:mvn/version "0.1.6"}}
    :main-opts   ["-e" "(use,'kibit.driver),(external-run,[\"src\"],nil)"]}
+  
+  :liquibase
+  {:main-opts   ["-m" "wfl.service.postgres.local-liquibase-migration"]
+   :extra-deps  {org.liquibase/liquibase-cdi   {:mvn/version "4.0.0"
+                                                :exclusions [ch.qos.logback/logback-classic]}
+                 org.liquibase/liquibase-core  {:mvn/version "4.0.0"
+                                                :exclusions [ch.qos.logback/logback-classic]}}}
 
   :run
   {:main-opts   ["-m" "wfl.main"]}

--- a/api/src/wfl/service/postgres.clj
+++ b/api/src/wfl/service/postgres.clj
@@ -96,18 +96,15 @@
         (catch Exception e
           (unnilify workload))))))
 
-(defn main
+(defn -main
   "Migrate the local database schema using Liquibase."
   []
-  (let [{:strs [USER]} (util/getenv)
-        WFL_POSTGRES_URL "jdbc:postgresql:wfl"
-        status (Main/run
-                (into-array
-                 String
-                 [(str "--url=" WFL_POSTGRES_URL)
-                  (str "--changeLogFile=../database/migration/changelog.xml")
-                  (str "--username=" USER)
-                  "update"]))]
+  (let [status (Main/run
+                (into-array String
+                            ["--url=jdbc:postgresql:wfl"
+                             "--changeLogFile=../database/changelog.xml"
+                             (str "--username=" (util/getenv "USER"))
+                             "update"]))]
     (when-not (zero? status)
       (throw
        (Exception.

--- a/docs/md/dev-process.md
+++ b/docs/md/dev-process.md
@@ -264,6 +264,16 @@ environment's server --
 `resources/wfl/environments.clj` has some environments if you've built locally.
 You can use `--password=$ENV_SOMETHING` to supply it.
 
+!!! tip
+    It is more convenient to use the following alias to migrate the database schema
+    from within the `api` directory:
+    ```
+    clojure -A:liquibase
+    ```
+    if you are working aginst a local database. If you are working with a CloudSQL
+    database, the liquibase migration is a encoded step of the `cli.py`'s `deploy`
+    command.
+
 ### Diagnosis
 
 Workflow Launcher has a diagnostic command, `dx`,

--- a/ops/cli.py
+++ b/ops/cli.py
@@ -7,18 +7,18 @@ requirements: pip3 install pyyaml
 usage: python3 cli.py -h
 """
 import argparse
+import getpass
 import json
 import os
 import shutil
 import subprocess
 from dataclasses import dataclass
 from pprint import PrettyPrinter
-from typing import Dict, Callable, List
+from typing import Callable, Dict, List
 
 import yaml
-
 from render_ctmpl import render_ctmpl
-from util.misc import info, success, error, warn, shell
+from util.misc import error, info, shell, success, warn
 
 
 @dataclass
@@ -243,7 +243,8 @@ def run_liquibase_migration(config: WflInstanceConfig) -> None:
     shell(f"docker run --rm --net=host "
           f"-v {changelog_dir}:/liquibase/changelog liquibase/liquibase "
           f"--url='{db_url}' --changeLogFile=/changelog/changelog.xml "
-          f"--username='{config.db_username}' --password='{config.db_password}' update", quiet=True)
+          f"--username='{(config.db_username or getpass.getuser())}' "
+          f"--password='{config.db_password}' update", quiet=True)
     success("Ran liquibase migration")
 
 
@@ -336,6 +337,11 @@ command_mapping: Dict[str, List[Callable[[WflInstanceConfig], None]]] = {
         run_liquibase_migration,
         stop_cloud_sql_proxy,
         print_deployment_success
+    ],
+    "migrate": [
+        print_config,
+        exit_if_dry_run,
+        run_liquibase_migration
     ],
     "tag-and-push-images": [
         read_version,

--- a/ops/cli.py
+++ b/ops/cli.py
@@ -7,7 +7,6 @@ requirements: pip3 install pyyaml
 usage: python3 cli.py -h
 """
 import argparse
-import getpass
 import json
 import os
 import shutil
@@ -243,8 +242,7 @@ def run_liquibase_migration(config: WflInstanceConfig) -> None:
     shell(f"docker run --rm --net=host "
           f"-v {changelog_dir}:/liquibase/changelog liquibase/liquibase "
           f"--url='{db_url}' --changeLogFile=/changelog/changelog.xml "
-          f"--username='{(config.db_username or getpass.getuser())}' "
-          f"--password='{config.db_password}' update", quiet=True)
+          f"--username='{config.db_username}' --password='{config.db_password}' update", quiet=True)
     success("Ran liquibase migration")
 
 
@@ -337,11 +335,6 @@ command_mapping: Dict[str, List[Callable[[WflInstanceConfig], None]]] = {
         run_liquibase_migration,
         stop_cloud_sql_proxy,
         print_deployment_success
-    ],
-    "migrate": [
-        print_config,
-        exit_if_dry_run,
-        run_liquibase_migration
     ],
     "tag-and-push-images": [
         read_version,


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-950

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Added a new alias `clojure -A:liquibase` to `deps.edn` so it's much easier to run local liquibase migrations. **FULL CREDIT to @tbl3rd**
- It is unexpectedly tricky to add a command to `cli.py` for this. I ran into a similar issue to https://github.com/liquibase/docker/issues/11 that 
```
docker run --rm --net=host -v /path/to/database:/liquibase/changelog liquibase/liquibase --url='jdbc:postgresql://localhost:5432/wfl?useSSL=false' --changeLogFile=/changelog/changelog.xml --username='$USER' --password='None' update` just cannot work and always raise 
```
`Connection could not be created` exceptions. That code is still committed but I plan to revert it since it does not work.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- Try run `clojure -A:liquibase` from within `api/`
