### PR TITLE
[GH-964] don't suspend jvm on entry

### DIFF
--- a/ops/server.sh
+++ b/ops/server.sh
@@ -9,7 +9,7 @@ test "$1" && export WFL_DEPLOY_ENVIRONMENT="$1"
 npm run serve --prefix=derived/ui -- --port 8080 &
 
 pushd api
-export _JAVA_OPTIONS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"
+export _JAVA_OPTIONS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005"
 "./wfl" server 3000 &
 popd
 


### PR DESCRIPTION
The issue is in setting suspend=y- this makes the jvm wait until you attach a debugger.

