### PR TITLE
[GH-948] Fix "output already exists" error in WGS tests

### DIFF
--- a/api/test/wfl/tools/endpoints.clj
+++ b/api/test/wfl/tools/endpoints.clj
@@ -7,7 +7,7 @@
   "The WFL server URL to test."
   (if (System/getenv "WFL_DEPLOY_ENVIRONMENT")
     "https://dev-wfl.gotc-dev.broadinstitute.org"
-    "http://localhost:8080"))
+    "http://localhost:3000"))
 
 (defn parse-json-string
   "Parse the json string STR into a keyword-string map"

--- a/api/test/wfl/tools/workloads.clj
+++ b/api/test/wfl/tools/workloads.clj
@@ -7,12 +7,13 @@
 
 (def git-branch (delay (shell! "git" "branch" "--show-current")))
 
-(def wgs-workload
+(defn wgs-workload
+  [identifier]
   "A whole genome sequencing workload used for testing."
   (let [path "/single_sample/plumbing/truth"]
     {:cromwell (get-in stuff [:gotc-dev :cromwell :url])
      :input    (str "gs://broad-gotc-test-storage" path)
-     :output   (str "gs://broad-gotc-dev-zero-test/wgs-test-output" path)
+     :output   (str "gs://broad-gotc-dev-zero-test/wgs-test-output/" identifier)
      :pipeline wgs/pipeline
      :project  (format "(Test) %s" @git-branch)
      :items    [{:unmapped_bam_suffix  ".unmapped.bam",


### PR DESCRIPTION
### Purpose
Fixes: https://broadinstitute.atlassian.net/browse/GH-948

### Changes
- Make the WGS test workload output directory different for each test run. Otherwise WFL will not start the workload because there's an output already in that directory.
- Make the integrations tests use the api server when running locally

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
