### PR TITLE
[GH-949] Consolidate test buckets

### DIFF
--- a/api/src/wfl/service/gcs.clj
+++ b/api/src/wfl/service/gcs.clj
@@ -122,38 +122,6 @@
               "https://cloud.google.com/storage/docs/naming#requirements"
               (s/explain-str ::bucket-name bucket))))))
 
-(defn make-bucket
-  "Make a storageClass CLASS bucket in PROJECT named BUCKET at LOCATION."
-  [project bucket location class]
-  (valid-bucket-name-or-throw! bucket)
-  (-> {:method       :post              ; :debug true :debug-body true
-       :url          bucket-url
-       :query-params {:project project}
-       :content-type :application/json
-       :headers      (once/get-auth-header)
-       :form-params  {:name         bucket
-                      :location     location
-                      :storageClass class}}
-      http/request :body (json/read-str :key-fn keyword)))
-
-(defn delete-bucket
-  "Throw or delete the bucket in PROJECT named NAME."
-  [name]
-  (letfn [(deleted-this-time? [{:keys [status] :as response}]
-            (case status
-              204 true
-              404 false
-              (-> 'delete-bucket
-                  (list name)
-                  pr-str
-                  (ex-info response)
-                  throw)))]
-    (-> {:method            :delete     ; :debug true :debug-body true
-         :url               (str bucket-url name)
-         :headers           (once/get-auth-header)
-         :throw-exceptions? false}
-        http/request deleted-this-time?)))
-
 (defn upload-file
   "Upload FILE to BUCKET with name OBJECT."
   ([file bucket object]

--- a/api/test/wfl/tools/fixtures.clj
+++ b/api/test/wfl/tools/fixtures.clj
@@ -18,7 +18,7 @@
     (run-test)
     (remove-method multifn dispatch-val)))
 
-(def gcs-test-bucket "broad-gotc-dev-zero-test")
+(def gcs-test-bucket "broad-gotc-dev-wfl-ptc-test-outputs")
 (def delete-test-object (partial gcs/delete-object gcs-test-bucket))
 
 (defmacro with-temporary-gcs-folder

--- a/api/test/wfl/tools/workloads.clj
+++ b/api/test/wfl/tools/workloads.clj
@@ -13,7 +13,7 @@
   (let [path "/single_sample/plumbing/truth"]
     {:cromwell (get-in stuff [:gotc-dev :cromwell :url])
      :input    (str "gs://broad-gotc-test-storage" path)
-     :output   (str "gs://broad-gotc-dev-zero-test/wgs-test-output/" identifier)
+     :output   (str "gs://broad-gotc-dev-wfl-ptc-test-outputs/wgs-test-output/" identifier)
      :pipeline wgs/pipeline
      :project  (format "(Test) %s" @git-branch)
      :items    [{:unmapped_bam_suffix  ".unmapped.bam",
@@ -28,7 +28,7 @@
   [identifier]
   {:cromwell (get-in stuff [:gotc-dev :cromwell :url])
    :input    "aou-inputs-placeholder"
-   :output   "gs://broad-gotc-dev-zero-test/aou-test-output"
+   :output   "gs://broad-gotc-dev-wfl-ptc-test-outputs/aou-test-output"
    :pipeline aou/pipeline
    :project  (format "(Test) %s %s" @git-branch identifier)
    :items    [{}]})

--- a/api/test/wfl/tools/workloads.clj
+++ b/api/test/wfl/tools/workloads.clj
@@ -12,7 +12,7 @@
   "A whole genome sequencing workload used for testing."
   (let [path "/single_sample/plumbing/truth"]
     {:cromwell (get-in stuff [:gotc-dev :cromwell :url])
-     :input    (str "gs://broad-gotc-test-storage" path)
+     :input    (str "gs://broad-gotc-dev-wfl-ptc-test-inputs" path)
      :output   (str "gs://broad-gotc-dev-wfl-ptc-test-outputs/wgs-test-output/" identifier)
      :pipeline wgs/pipeline
      :project  (format "(Test) %s" @git-branch)
@@ -37,19 +37,19 @@
   "An aou arrays sample for testing."
   {:cromwell      "https://cromwell-gotc-auth.gotc-dev.broadinstitute.org/",
    :notifications [{:chip_well_barcode           "7991775143_R01C01",
-                    :bead_pool_manifest_file     "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/HumanExome-12v1-1_A.bpm",
+                    :bead_pool_manifest_file     "gs://broad-gotc-dev-wfl-ptc-test-inputs/arrays/metadata/HumanExome-12v1-1_A/HumanExome-12v1-1_A.bpm",
                     :analysis_version_number     1,
                     :call_rate_threshold         0.98
-                    :extended_chip_manifest_file "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/HumanExome-12v1-1_A.1.3.extended.csv",
-                    :red_idat_cloud_path         "gs://broad-gotc-test-storage/arrays/HumanExome-12v1-1_A/idats/7991775143_R01C01/7991775143_R01C01_Red.idat",
-                    :zcall_thresholds_file       "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/IBDPRISM_EX.egt.thresholds.txt",
+                    :extended_chip_manifest_file "gs://broad-gotc-dev-wfl-ptc-test-inputs/arrays/metadata/HumanExome-12v1-1_A/HumanExome-12v1-1_A.1.3.extended.csv",
+                    :red_idat_cloud_path         "gs://broad-gotc-dev-wfl-ptc-test-inputs/arrays/HumanExome-12v1-1_A/idats/7991775143_R01C01/7991775143_R01C01_Red.idat",
+                    :zcall_thresholds_file       "gs://broad-gotc-dev-wfl-ptc-test-inputs/arrays/metadata/HumanExome-12v1-1_A/IBDPRISM_EX.egt.thresholds.txt",
                     :reported_gender             "Female",
-                    :cluster_file                "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/HumanExomev1_1_CEPH_A.egt",
+                    :cluster_file                "gs://broad-gotc-dev-wfl-ptc-test-inputs/arrays/metadata/HumanExome-12v1-1_A/HumanExomev1_1_CEPH_A.egt",
                     :sample_lsid                 "broadinstitute.org:bsp.dev.sample:NOTREAL.NA12878",
                     :sample_alias                "NA12878",
-                    :green_idat_cloud_path       "gs://broad-gotc-test-storage/arrays/HumanExome-12v1-1_A/idats/7991775143_R01C01/7991775143_R01C01_Grn.idat",
-                    :params_file                 "gs://broad-gotc-test-storage/arrays/HumanExome-12v1-1_A/inputs/7991775143_R01C01/params.txt",
-                    :gender_cluster_file         "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/HumanExomev1_1_gender.egt"}],
+                    :green_idat_cloud_path       "gs://broad-gotc-dev-wfl-ptc-test-inputs/arrays/HumanExome-12v1-1_A/idats/7991775143_R01C01/7991775143_R01C01_Grn.idat",
+                    :params_file                 "gs://broad-gotc-dev-wfl-ptc-test-inputs/arrays/HumanExome-12v1-1_A/inputs/7991775143_R01C01/params.txt",
+                    :gender_cluster_file         "gs://broad-gotc-dev-wfl-ptc-test-inputs/arrays/metadata/HumanExome-12v1-1_A/HumanExomev1_1_gender.egt"}],
    :environment   "aou-dev",
    :uuid          nil})
 

--- a/api/test/wfl/unit/datarepo_test.clj
+++ b/api/test/wfl/unit/datarepo_test.clj
@@ -5,67 +5,44 @@
             [clojure.test          :refer [deftest is testing]]
             [wfl.environments     :as env]
             [wfl.service.datarepo :as datarepo]
-            [wfl.service.gcs      :as gcs])
-  (:import (java.util UUID)))
+            [wfl.service.gcs      :as gcs]
+            [wfl.tools.fixtures :refer [with-temporary-gcs-folder]]))
 
 ;; UUIDs known to the Data Repo.
 ;;
 (def dataset "f359303e-15d7-4cd8-a4c7-c50499c90252")
 (def profile "390e7a85-d47f-4531-b612-165fc977d3bd")
 
-(def project
-  "Run in this project."
-  "broad-gotc-dev-storage")
-
-(def unique
-  "A string likely to be unique."
-  (str/replace (str (UUID/randomUUID)) "-" ""))
-
-(def bucket
-  "A bucket name unlikely to exist already."
-  (str/join "-" [(or (System/getenv "USER") "wfl") "test" unique]))
-
-(defn make-day-bucket
-  "Return a BUCKET that will live for 1 day."
-  []
-  (gcs/make-bucket   project bucket "US" "STANDARD")
-  (gcs/patch-bucket! project bucket
-                     {:lifecycle {:rule [{:action    {:type "Delete"}
-                                          :condition {:age 1}}]}}))
-
 (deftest delivery
-  (testing "delivery succceeds"
-    (let [vcf (str bucket ".vcf")
-          table (str bucket ".tabular.json")
-          vcf-url (gcs/gs-url bucket vcf)
-          ingest-file (partial datarepo/file-ingest :gotc-dev dataset profile)
-          drsa (get-in env/stuff [:debug :data-repo :service-account])]
-      (letfn [(stage [file content]
-                (spit file content)
-                (gcs/upload-file file bucket file)
-                (gcs/add-object-reader drsa bucket file))
-              (ingest [path vdest]
-                (let [job (ingest-file path vdest)]
-                  (:fileId (datarepo/poll-job :gotc-dev job))))
-              (cleanup []
-                (gcs/delete-object bucket vcf)
-                (gcs/delete-object bucket (str vcf ".tbi"))
-                (gcs/delete-object bucket table)
-                (gcs/delete-bucket bucket)
-                (io/delete-file vcf)
-                (io/delete-file (str vcf ".tbi"))
-                (io/delete-file table))]
-        (make-day-bucket)
-        (stage vcf "bogus vcf content")
-        (stage (str vcf ".tbi") "bogus index content")
-        (stage table (json/write-str
-                      {:id        bucket
-                       :vcf       (ingest vcf-url vcf)
-                       :vcf_index (ingest vcf-url (str vcf ".tbi"))}
-                      :escape-slash false))
-        (let [table-url (gcs/gs-url bucket table)
-              job (datarepo/tabular-ingest :gotc-dev dataset table-url "sample")
-              {:keys [bad_row_count row_count]} (datarepo/poll-job :gotc-dev job)]
-          (is (= 1 row_count))
-          (is (= 0 bad_row_count)))
-        (cleanup)))))
+  (with-temporary-gcs-folder uri
+    (testing "delivery succeeds"
+      (let [[bucket object] (gcs/parse-gs-url uri)
+            vcf "test.vcf"
+            table "test.tabular.json"
+            vcf-url (gcs/gs-url bucket (str object vcf))
+            ingest-file (partial datarepo/file-ingest :gotc-dev dataset profile)
+            drsa (get-in env/stuff [:debug :data-repo :service-account])]
+        (letfn [(stage [file content]
+                  (spit file content)
+                  (gcs/upload-file file bucket (str object file))
+                  (gcs/add-object-reader drsa bucket (str object file)))
+                (ingest [path vdest]
+                  (let [job (ingest-file path vdest)]
+                    (:fileId (datarepo/poll-job :gotc-dev job))))
+                (cleanup []
+                  (io/delete-file vcf)
+                  (io/delete-file (str vcf ".tbi"))
+                  (io/delete-file table))]
+          (stage vcf "bogus vcf content")
+          (stage (str vcf ".tbi") "bogus index content")
+          (stage table (json/write-str
+                        {:id        bucket
+                         :vcf       (ingest vcf-url vcf)
+                         :vcf_index (ingest vcf-url (str vcf ".tbi"))}
+                        :escape-slash false))
+          (let [table-url (gcs/gs-url bucket (str object table))
+                job (datarepo/tabular-ingest :gotc-dev dataset table-url "sample")
+                {:keys [bad_row_count row_count]} (datarepo/poll-job :gotc-dev job)]
+            (is (= 1 row_count))
+            (is (= 0 bad_row_count)))
+          (cleanup))))))

--- a/api/test/wfl/unit/gcs_test.clj
+++ b/api/test/wfl/unit/gcs_test.clj
@@ -41,13 +41,9 @@
       (is (thrown? IllegalArgumentException (gcs/gs-url ""  "")))
       (is (thrown? IllegalArgumentException (gcs/gs-url ""  "o"))))))
 
-(def blame
-  "Who is to blame?"
-  (or (System/getenv "USER") "wfl"))
-
 (def local-file-name
   "A disposable local file name for object-test."
-  (str/join "-" [blame "junk" uid]))
+  (str/join "-" ["wfl" "test" uid]))
 
 (defn cleanup-object-test
   "Clean up after the object-test."

--- a/api/test/wfl/unit/gcs_test.clj
+++ b/api/test/wfl/unit/gcs_test.clj
@@ -41,6 +41,10 @@
       (is (thrown? IllegalArgumentException (gcs/gs-url ""  "")))
       (is (thrown? IllegalArgumentException (gcs/gs-url ""  "o"))))))
 
+(def blame
+  "Who is to blame?"
+  (or (System/getenv "USER") "wfl"))
+
 (def local-file-name
   "A disposable local file name for object-test."
   (str/join "-" [blame "junk" uid]))

--- a/cloud_function/tests/upload_test_files.py
+++ b/cloud_function/tests/upload_test_files.py
@@ -13,8 +13,8 @@ import sys
 import subprocess
 import tempfile
 
-arrays_path = "gs://broad-gotc-test-storage/arrays/HumanExome-12v1-1_A/"
-arrays_metadata_path = "gs://broad-gotc-test-storage/arrays/metadata/HumanExome-12v1-1_A/"
+arrays_path = "gs://broad-gotc-dev-wfl-ptc-test-inputs/arrays/HumanExome-12v1-1_A/"
+arrays_metadata_path = "gs://broad-gotc-dev-wfl-ptc-test-inputs/arrays/metadata/HumanExome-12v1-1_A/"
 
 def get_destination_paths(bucket, prefix):
     return {
@@ -32,6 +32,7 @@ def get_ptc_json(bucket, prefix, chip_well_barcode, analysis_version, prod):
         "uuid": None,
         "notifications": [{
             "analysis_version_number": analysis_version,
+            "call_rate_threshold": 0.98,
             "chip_well_barcode": chip_well_barcode,
             "green_idat_cloud_path": f"gs://{bucket}/{prefix}/arrays/HumanExome-12v1-1_A/idats/7991775143_R01C01/7991775143_R01C01_Grn.idat",
             "params_file": f"gs://{bucket}/{prefix}/arrays/HumanExome-12v1-1_A/inputs/7991775143_R01C01/params.txt",


### PR DESCRIPTION
### Purpose

Ticket: https://broadinstitute.atlassian.net/browse/GH-949

### Changes
- Make `with-temporary-gcs-folder` use the new test output bucket `broad-gotc-dev-wfl-ptc-test-outputs` that has an object lifecycle policy of 1 day
- Make the gcs-object test use `with-temporary-gcs-folder` instead of creating new buckets
- Make the data-repo test use `with-temporary-gcs-folder`instead of creating a new bucket
- Remove `bucket-test` for creating, listing & deleting buckets
- Remove gcs `make-bucket` and `delete-bucket` since they are no longer used after these changes (they were previously only used by the tests)
- Updated WGS and AOU test workloads inputs to use `broad-gotc-dev-wfl-ptc-test-inputs`
- Updated cloud function helper script to use AOU test inputs from `broad-gotc-dev-wfl-ptc-test-inputs`

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

The data-repo test makes more sense as an integration test, since it's not testing individual functions. Thoughts on moving it?