### PR TITLE
[GH-987] Split system and integration tests

### DIFF
--- a/api/test/wfl/integration/v1_endpoint_test.clj
+++ b/api/test/wfl/integration/v1_endpoint_test.clj
@@ -1,13 +1,9 @@
 (ns wfl.integration.v1-endpoint-test
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest testing is] :as clj-test]
-            [wfl.module.copyfile :as cp]
-            [wfl.service.cromwell :refer [wait-for-workflow-complete]]
-            [wfl.service.gcs :as gcs]
             [wfl.tools.endpoints :as endpoints]
             [wfl.tools.fixtures :refer [with-temporary-gcs-folder clean-db-fixture]]
-            [wfl.tools.workloads :as workloads]
-            [wfl.util :as util])
+            [wfl.tools.workloads :as workloads])
   (:import (java.util UUID)))
 
 ;; Here we register db-fixture to be called once, wrapping ALL tests in this namespace
@@ -47,22 +43,6 @@
       (is (string? items) "items of the created aou workload should be a string")
       (is (= no-items-project (select-keys response (keys no-items-project)))))))
 
-(deftest test-start-wgs-workload
-  (testing "The `start` endpoint starts an existing WGS workload"
-    (let [unstarted (make-wgs-workload)
-          response  (endpoints/start-workload unstarted)
-          status    (endpoints/get-workload-status (:uuid response))]
-      (is (:uuid unstarted) "Workload should have been assigned a uuid")
-      (is (= (:uuid response) (:uuid unstarted)) "uuids are not modified by start")
-      (is (:started response) "The workload should have a started time stamp")
-      (is (every? :status (:workflows status)) "Not all of the workflows have been started")
-      (let [env             :wgs-dev
-            ids             (map :uuid (:workflows status))
-            non-skipped-ids (remove util/uuid-nil? ids)
-            await     (partial wait-for-workflow-complete env)
-            results   (zipmap ids (map await non-skipped-ids))]
-        (is (every? #{"Succeeded"} (vals results)) "One or more workflows failed")))))
-
 (deftest test-start-aou-workload
   (testing "The `start` endpoint starts an existing AOU workload"
     (let [unstarted (make-aou-workload)
@@ -72,18 +52,6 @@
       (is (= (:uuid response) (:uuid unstarted)) "uuids are not modified by start")
       (is (:started response) "The workload should have a started time stamp")
       (is (nil? (seq (:workflows status))) "The workload should not have any workflows yet"))))
-
-(deftest test-append-to-aou-workload
-  (testing "The `append_to_aou` endpoint appends a new workflow to aou workload."
-    (let [env          :aou-dev
-          unstarted    (make-aou-workload)
-          started      (endpoints/start-workload unstarted)
-          started-uuid (:uuid started)
-          await        (partial wait-for-workflow-complete env)
-          samples      (assoc workloads/aou-sample :uuid started-uuid)
-          ids          (:results (endpoints/append-to-aou-workload samples))
-          results      (zipmap ids (map await ids))]
-      (is (every? #{"Succeeded"} (vals results))))))
 
 (deftest test-exec-wgs-workload
   (testing "The `exec` endpoint creates and starts a WGS workload"
@@ -99,18 +67,3 @@
       (is (not (contains? uuids-before uuid)) "The new workload uuid was not unique")
       (is started "The workload wasn't started"))))
 
-(deftest test-copyfile-workload
-  (with-temporary-gcs-folder uri
-    (let [src (str/join [uri "input.txt"])
-          dst (str/join [uri "output.txt"])]
-      (->
-       (str/join "/" ["test" "wfl" "resources" "copy-me.txt"])
-       (gcs/upload-file src))
-      (let [workload  (workloads/make-copyfile-workload src dst)
-            await     (comp (partial wait-for-workflow-complete :gotc-dev) :uuid)
-            submitted (endpoints/exec-workload workload)]
-        (is (= (:pipeline submitted) cp/pipeline))
-        (is (:started submitted))
-        (let [result (-> submitted :workflows first await)]
-          (is (= "Succeeded" result))
-          (is (gcs/object-meta dst) "The file was not copied!"))))))

--- a/api/test/wfl/system/module_test.clj
+++ b/api/test/wfl/system/module_test.clj
@@ -1,0 +1,58 @@
+(ns wfl.system.module-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest testing is] :as clj-test]
+            [wfl.module.copyfile :as cp]
+            [wfl.service.cromwell :refer [wait-for-workflow-complete]]
+            [wfl.service.gcs :as gcs]
+            [wfl.tools.endpoints :as endpoints]
+            [wfl.tools.fixtures :refer [with-temporary-gcs-folder]]
+            [wfl.tools.workloads :as workloads]
+            [wfl.util :as util])
+  (:import (java.util UUID)))
+
+(def make-wgs-workload (partial endpoints/create-workload (workloads/wgs-workload (UUID/randomUUID))))
+(defn make-aou-workload [] ((partial endpoints/create-workload (workloads/aou-workload (UUID/randomUUID)))))
+
+(deftest test-start-wgs-workload
+  (testing "The `start` endpoint starts an existing WGS workload"
+    (let [unstarted (make-wgs-workload)
+          response  (endpoints/start-workload unstarted)
+          status    (endpoints/get-workload-status (:uuid response))]
+      (is (:uuid unstarted) "Workload should have been assigned a uuid")
+      (is (= (:uuid response) (:uuid unstarted)) "uuids are not modified by start")
+      (is (:started response) "The workload should have a started time stamp")
+      (is (every? :status (:workflows status)) "Not all of the workflows have been started")
+      (let [env             :wgs-dev
+            ids             (map :uuid (:workflows status))
+            non-skipped-ids (remove util/uuid-nil? ids)
+            await     (partial wait-for-workflow-complete env)
+            results   (zipmap ids (map await non-skipped-ids))]
+        (is (every? #{"Succeeded"} (vals results)) "One or more workflows failed")))))
+
+(deftest test-append-to-aou-workload
+  (testing "The `append_to_aou` endpoint appends a new workflow to aou workload."
+    (let [env          :aou-dev
+          unstarted    (make-aou-workload)
+          started      (endpoints/start-workload unstarted)
+          started-uuid (:uuid started)
+          await        (partial wait-for-workflow-complete env)
+          samples      (assoc workloads/aou-sample :uuid started-uuid)
+          ids          (:results (endpoints/append-to-aou-workload samples))
+          results      (zipmap ids (map await ids))]
+      (is (every? #{"Succeeded"} (vals results))))))
+
+(deftest test-copyfile-workload
+  (with-temporary-gcs-folder uri
+    (let [src (str/join [uri "input.txt"])
+         dst (str/join [uri "output.txt"])]
+     (->
+       (str/join "/" ["test" "wfl" "resources" "copy-me.txt"])
+       (gcs/upload-file src))
+     (let [workload  (workloads/make-copyfile-workload src dst)
+           await     (comp (partial wait-for-workflow-complete :gotc-dev) :uuid)
+           submitted (endpoints/exec-workload workload)]
+       (is (= (:pipeline submitted) cp/pipeline))
+       (is (:started submitted))
+       (let [result (-> submitted :workflows first await)]
+         (is (= "Succeeded" result))
+         (is (gcs/object-meta dst) "The file was not copied!"))))))

--- a/api/test/wfl/system/module_test.clj
+++ b/api/test/wfl/system/module_test.clj
@@ -44,15 +44,15 @@
 (deftest test-copyfile-workload
   (with-temporary-gcs-folder uri
     (let [src (str/join [uri "input.txt"])
-         dst (str/join [uri "output.txt"])]
-     (->
+          dst (str/join [uri "output.txt"])]
+      (->
        (str/join "/" ["test" "wfl" "resources" "copy-me.txt"])
        (gcs/upload-file src))
-     (let [workload  (workloads/make-copyfile-workload src dst)
-           await     (comp (partial wait-for-workflow-complete :gotc-dev) :uuid)
-           submitted (endpoints/exec-workload workload)]
-       (is (= (:pipeline submitted) cp/pipeline))
-       (is (:started submitted))
-       (let [result (-> submitted :workflows first await)]
-         (is (= "Succeeded" result))
-         (is (gcs/object-meta dst) "The file was not copied!"))))))
+      (let [workload  (workloads/make-copyfile-workload src dst)
+            await     (comp (partial wait-for-workflow-complete :gotc-dev) :uuid)
+            submitted (endpoints/exec-workload workload)]
+        (is (= (:pipeline submitted) cp/pipeline))
+        (is (:started submitted))
+        (let [result (-> submitted :workflows first await)]
+          (is (= "Succeeded" result))
+          (is (gcs/object-meta dst) "The file was not copied!"))))))

--- a/api/tests.edn
+++ b/api/tests.edn
@@ -6,7 +6,11 @@
              {:id           :unit
               :source-paths ["../derived/api/src" "src"]
               :test-paths   ["test"]
-              :ns-patterns  ["wfl\\.unit\\..*-test$"]}]
+              :ns-patterns  ["wfl\\.unit\\..*-test$"]}
+             {:id           :system
+              :source-paths ["../derived/api/src" "src"]
+              :test-paths   ["test"]
+              :ns-patterns  ["wfl\\.system\\..*-test$"]}]
 
      :plugins [
                :print-invocations


### PR DESCRIPTION
### Purpose
Before automating integration tests to run on PRs, move the time-consuming tests into a separate system test alias. 

Ticket: https://broadinstitute.atlassian.net/browse/GH-987

### Changes
Move every test that waits for a Cromwell workflow to complete under a new system test alias.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

Notes: 
- The append to AoU test succeeds before the workflow actually finishes (looks like a bug) so even though it currently completes very quickly I'm not sure if it would once we fix it (created a ticket for this here: https://broadinstitute.atlassian.net/browse/GH-995)
- The WGS create test waits for a Cromwell workflow to succeed, but it actually completes very quickly due to call-caching so I wasn't sure where to put that one.
