### PR TITLE
[GH-982] Move datarepo test to integration and mark it as pending

### DIFF
--- a/api/test/wfl/integration/datarepo_test.clj
+++ b/api/test/wfl/integration/datarepo_test.clj
@@ -14,7 +14,7 @@
 (def dataset "f359303e-15d7-4cd8-a4c7-c50499c90252")
 (def profile "390e7a85-d47f-4531-b612-165fc977d3bd")
 
-(deftest ^:pending delivery
+(deftest ^:exclude delivery
   (with-temporary-gcs-folder uri
     (testing "delivery succeeds"
       (let [[bucket object] (gcs/parse-gs-url uri)

--- a/api/test/wfl/integration/datarepo_test.clj
+++ b/api/test/wfl/integration/datarepo_test.clj
@@ -1,4 +1,4 @@
-(ns wfl.unit.datarepo-test
+(ns wfl.integration.datarepo-test
   (:require [clojure.data.json     :as json]
             [clojure.java.io       :as io]
             [clojure.string        :as str]
@@ -14,7 +14,7 @@
 (def dataset "f359303e-15d7-4cd8-a4c7-c50499c90252")
 (def profile "390e7a85-d47f-4531-b612-165fc977d3bd")
 
-(deftest delivery
+(deftest ^:pending delivery
   (with-temporary-gcs-folder uri
     (testing "delivery succeeds"
       (let [[bucket object] (gcs/parse-gs-url uri)

--- a/api/tests.edn
+++ b/api/tests.edn
@@ -1,6 +1,6 @@
 #kaocha/v1
     {:tests [{:id           :integration
-              :skip-meta    [:pending]
+              :skip-meta    [:exclude]
               :source-paths ["../derived/api/src" "src"]
               :test-paths   ["test"]
               :ns-patterns  ["wfl\\.integration\\..*-test$"]}

--- a/api/tests.edn
+++ b/api/tests.edn
@@ -1,5 +1,6 @@
 #kaocha/v1
     {:tests [{:id           :integration
+              :skip-meta    [:pending]
               :source-paths ["../derived/api/src" "src"]
               :test-paths   ["test"]
               :ns-patterns  ["wfl\\.integration\\..*-test$"]}


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-982

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Move datarepo test to integration and mark it as pending

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- Run `clojure -A:test unit` and make sure `datarepo` test is not run anymore.
