### PR TITLE
[GH-983] Let WFL clone WARP and switch the wgs module over to use warp.

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -35,6 +35,7 @@ jobs:
 
           echo "${{ secrets.dsde_pipelines_deploy_key }}" > ~/.ssh/dsde_pipelines_deploy_key
           echo "${{ secrets.pipeline_config_deploy_key }}" > ~/.ssh/pipeline_config_deploy_key
+          echo "${{ secrets.warp_deploy_key }}" > ~/.ssh/warp_deploy_key
           echo "${{ secrets.wfl_deploy_key }}" > ~/.ssh/wfl_deploy_key
 
           chmod 600 ~/.ssh/dsde_pipelines_deploy_key
@@ -51,6 +52,11 @@ jobs:
             HostName github.com
             User git
             IdentityFile ~/.ssh/pipeline_config_deploy_key
+
+            Host warp.github.com
+            HostName github.com
+            User git
+            IdentityFile ~/.ssh/warp_deploy_key
 
             Host wfl.github.com
             HostName github.com

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -40,6 +40,7 @@ jobs:
 
           chmod 600 ~/.ssh/dsde_pipelines_deploy_key
           chmod 600 ~/.ssh/pipeline_config_deploy_key
+          chmod 600 ~/.ssh/warp_deploy_key
           chmod 600 ~/.ssh/wfl_deploy_key
 
           echo """

--- a/api/module.mk
+++ b/api/module.mk
@@ -1,6 +1,6 @@
 # Makefile for the wfl/api module
 
-REQUIRED_2P_REPOSITORIES := dsde-pipelines pipeline-config
+REQUIRED_2P_REPOSITORIES := dsde-pipelines pipeline-config warp
 include $(MAKE_INCLUDE_DIR)/Makefile.module
 
 CPCACHE_DIR           := $(MODULE_DIR)/.cpcache

--- a/api/src/wfl/module/wgs.clj
+++ b/api/src/wfl/module/wgs.clj
@@ -20,8 +20,8 @@
 
 (def workflow-wdl
   "The top-level WDL file and its version."
-  {:release "ExternalWholeGenomeReprocessing_v1.0"
-   :top     "pipelines/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.wdl"})
+  {:release "ExternalWholeGenomeReprocessing_v1.1.0"
+   :top     "pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.wdl"})
 
 (def cromwell-label-map
   "The WDL label applied to Cromwell metadata."

--- a/docs/md/README.md
+++ b/docs/md/README.md
@@ -209,7 +209,6 @@ Tip: Run `make` at least once after cloning the repo to make sure all the
 necessary files are in place.
 
 ### `api` Module
-
 #### Source code
 
 The Clojure source code is in the `api/src/` directory.

--- a/docs/md/README.md
+++ b/docs/md/README.md
@@ -209,6 +209,7 @@ Tip: Run `make` at least once after cloning the repo to make sure all the
 necessary files are in place.
 
 ### `api` Module
+
 #### Source code
 
 The Clojure source code is in the `api/src/` directory.


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-983

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Let WFL clone WARP and switch the wgs module over to use warp.
- This PR introduces a somewhat duplicated function `cromwellify-warp-wdl` in `boot.clj` in order to support both `dsde-pipelines` and `warp` at the same time.
- This PR updates the Github Actions `pr-test` so it builds without errors.
- This PR updates `wgs.clj` to use `ExternalWholeGenomeReprocessing_v1.1.0` rather than `ExternalWholeGenomeReprocessing_v1.0` since `Warp` does not have the latter tag. This requires PR #157 to resolve merge conflicts later.  

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- `make distclean` and `make api TARGET=check` should pass.
