### PR TITLE
[GH-1007] Check WGS workload values before using defaults

### DIFF
--- a/api/src/wfl/api/spec.clj
+++ b/api/src/wfl/api/spec.clj
@@ -84,21 +84,21 @@
 (s/def ::items-wgs (s/keys :opt-un [::base_file_name
                                     ::final_gvcf_base_name
                                     ::reference_fasta_prefix
+                                    ::sample_name
                                     ::unmapped_bam_suffix]
-                           :req-un [::input_cram
-                                    ::sample_name]))
+                           :req-un [::input_cram]))
 (s/def ::sample_name string?)
 (s/def ::unmapped_bam_suffix string?)
 (s/def ::workflow-wgs (s/keys :opt-un [::base_file_name
                                        ::final_gvcf_base_name
                                        ::reference_fasta_prefix
+                                       ::sample_name
                                        ::status
                                        ::unmapped_bam_suffix
                                        ::updated
                                        ::uuid]
                               :req-un [::id
-                                       ::input_cram
-                                       ::sample_name]))
+                                       ::input_cram]))
 
 ;; /api/v1/workflows
 (s/def ::start string?)

--- a/api/src/wfl/module/wgs.clj
+++ b/api/src/wfl/module/wgs.clj
@@ -97,8 +97,11 @@
         leaf (last (str/split base #"/"))
         [_ out-dir] (gcs/parse-gs-url (util/unsuffix base leaf))
         ref-prefix (get sample :reference_fasta_prefix)
-        inputs (-> (zipmap [:base_file_name :final_gvcf_base_name :sample_name]
-                           (repeat leaf))
+        final_gvcf_base_name (or (:final_gvcf_base_name sample) leaf)
+        inputs (-> {}
+                   (assoc :base_file_name (or (:base_file_name sample) leaf))
+                   (assoc :sample_name (or (:sample_name sample) leaf))
+                   (assoc :final_gvcf_base_name final_gvcf_base_name)
                    (assoc input-key in-gs)
                    (assoc :destination_cloud_path (str out-gs out-dir))
                    (assoc :references (make-references ref-prefix))
@@ -106,8 +109,8 @@
                    (merge cram-ref)
                    (merge (env-inputs environment)
                           hack-task-level-values))
-        output (str (:destination_cloud_path inputs) 
-                    (:final_gvcf_base_name sample) 
+        output (str (:destination_cloud_path inputs)
+                    final_gvcf_base_name
                     ".cram")]
     (all/throw-when-output-exists-already! output)
     (util/prefix-keys inputs :ExternalWholeGenomeReprocessing)))

--- a/api/src/wfl/module/wgs.clj
+++ b/api/src/wfl/module/wgs.clj
@@ -84,7 +84,6 @@
         (env/stuff environment)]
     {:google_account_vault_path google_account_vault_path
      :vault_token_path vault_token_path
-     :unmapped_bam_suffix ".unmapped.bam"
      :papi_settings       {:agg_preemptible_tries 3
                            :preemptible_tries     3}
      :scatter_settings    {:haplotype_scatter_count         10
@@ -101,6 +100,7 @@
         inputs (-> {}
                    (assoc :base_file_name (or (:base_file_name sample) leaf))
                    (assoc :sample_name (or (:sample_name sample) leaf))
+                   (assoc :unmapped_bam_suffix (or (:unmapped_bam_suffix sample) ".unmapped.bam"))
                    (assoc :final_gvcf_base_name final_gvcf_base_name)
                    (assoc input-key in-gs)
                    (assoc :destination_cloud_path (str out-gs out-dir))


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

Ticket: https://broadinstitute.atlassian.net/browse/GH-1007

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

Use the `base_file_name`, `final_gvcf_base_name` or `sample_name` if they are specified in the workload, otherwise use the default input cram name.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

Should "sample_name" actually be an optional field?