### PR TITLE
[GH-1005] fix api/v1/workload endpoint; simplify endpoints; do exec i…

### DIFF
--- a/ops/server.sh
+++ b/ops/server.sh
@@ -9,6 +9,7 @@ test "$1" && export WFL_DEPLOY_ENVIRONMENT="$1"
 npm run serve --prefix=derived/ui -- --port 8080 &
 
 pushd api
+clojure -A:liquibase
 export _JAVA_OPTIONS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005"
 "./wfl" server 3000 &
 popd


### PR DESCRIPTION
### Purpose
Fixes: https://broadinstitute.atlassian.net/browse/GH-1005 - "Table null not found"

Included changes:
- `post-exec` now uses a single transaction
- simplified `post-start`

Exposed a number of code improvements we can make. Will commit to code in the exomes endpoint.