### PR TITLE
Revert "[GH-985] Use WARP for AoU (#167)"

### DIFF
--- a/api/src/wfl/boot.clj
+++ b/api/src/wfl/boot.clj
@@ -123,8 +123,8 @@
   [version second-party derived]
   (letfn [(frob [{:keys [release top] :as _wdl}]
             [(last (str/split top #"/")) release])]
-    (let [wdls [ukb/workflow-wdl xx/workflow-wdl]
-          warp-wdls [wgs/workflow-wdl aou/workflow-wdl]
+    (let [wdls [ukb/workflow-wdl xx/workflow-wdl aou/workflow-wdl]
+          warp-wdls [wgs/workflow-wdl]
           clones (find-repos second-party)
           sources (io/file derived "src" "wfl")
           resources (io/file derived "resources" "wfl")

--- a/api/src/wfl/module/aou.clj
+++ b/api/src/wfl/module/aou.clj
@@ -20,7 +20,7 @@
 (def workflow-wdl
   "The top-level WDL file and its version."
   {:release "Arrays_v2.0"
-   :top     "pipelines/broad/arrays/single_sample/Arrays.wdl"})
+   :top     "pipelines/arrays/single_sample/Arrays.wdl"})
 
 (def cromwell-label-map
   "The WDL label applied to Cromwell metadata."


### PR DESCRIPTION
This reverts commit fdefbf9c66248be5b53598ab12e6da6ea9e6659c.

Arrays_v2.0 in WARP is unusable and I don't know what to do about it, we just need to revert WFL to not use WARP for AoU ASAP.

dsde-pipeline's InternalArraysTasks.wdl#L148 @ Arrays_v2.0:
```
      'NR==1{for(i=1;i<=NF;i++){if($i==col){c=i;break}}} NR==2{print $c}  NR>2{exit 1}')
```
WARP's InternalArraysTasks.wdl#L148 @ Arrays_v2.0:
```
      'NR==1{for(i=1;i<=NF;i++){if($i==col){c=i;break}}} NR==2{print $c} NR>2{exit 1}'')
```
(Notice the extra `'`, which causes an EOF error when Cromwell tries to parse it)