### PR TITLE
[GH-1026] Make the `/oauth2id` endpoint lazier

### DIFF
--- a/api/src/wfl/api/routes.clj
+++ b/api/src/wfl/api/routes.clj
@@ -39,7 +39,7 @@
             :swagger {:tags ["Informational"]}}}]
    ["/oauth2id"
     {:get {:summary   "Get the OAuth2 Client ID for this deployment of the server"
-           :handler   (handlers/success {:oauth2-client-id @once/oauth-client-id})
+           :handler   (fn [_] (handlers/succeed {:oauth2-client-id @once/oauth-client-id}))
            :responses {200 {:body {:oauth2-client-id string?}}}
            :swagger   {:tags ["Informational"]}}}]
    ["/api/v1/environments"


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1026

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Makes the `/oauth2id` endpoint lazier so that it won't try to come up with its response during `prebuild`

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- You can run a local server to see that the endpoint still works
- Tests here should still pass
- There should be no error text in the output of the `prebuild` step of the github action here
