### PR TITLE
[GH-1031] Fix unknown pipeline version

### DIFF
--- a/api/src/wfl/boot.clj
+++ b/api/src/wfl/boot.clj
@@ -128,7 +128,7 @@
           clones (find-repos second-party)
           sources (io/file derived "src" "wfl")
           resources (io/file derived "resources" "wfl")
-          edn (merge version clones (into {} (map frob wdls)))]
+          edn (merge version clones (into {} (map frob (concat wdls warp-wdls))))]
       (pprint edn)
       (stage-some-files second-party sources resources)
       (run! (partial cromwellify-wdl second-party resources) wdls)

--- a/api/test/wfl/unit/all_modules_test.clj
+++ b/api/test/wfl/unit/all_modules_test.clj
@@ -1,7 +1,13 @@
 (ns wfl.unit.all-modules-test
-  (:require [clojure.test :refer [deftest testing is]]
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest testing is]]
             [wfl.environments :as env]
-            [wfl.module.all :as all]))
+            [wfl.module.all :as all]
+            [wfl.module.aou :as aou]
+            [wfl.module.ukb :as ukb]
+            [wfl.module.wgs :as wgs]
+            [wfl.module.xx :as xx]
+            [wfl.wfl :as wfl]))
 
 (deftest test-cromwell-environments
   (let [url (get-in env/gotc-dev [:cromwell :url])]

--- a/api/test/wfl/unit/all_modules_test.clj
+++ b/api/test/wfl/unit/all_modules_test.clj
@@ -4,7 +4,6 @@
             [wfl.environments :as env]
             [wfl.module.all :as all]
             [wfl.module.aou :as aou]
-            [wfl.module.ukb :as ukb]
             [wfl.module.wgs :as wgs]
             [wfl.module.xx :as xx]
             [wfl.wfl :as wfl]))
@@ -22,7 +21,6 @@
 (deftest wdl-verison-in-edn
   (let [wdls [aou/workflow-wdl
               wgs/workflow-wdl
-              ukb/workflow-wdl
               xx/workflow-wdl]
         edn  (wfl/get-the-version)]
     (testing "WDLs have their versions in version.edn"

--- a/api/test/wfl/unit/all_modules_test.clj
+++ b/api/test/wfl/unit/all_modules_test.clj
@@ -18,3 +18,12 @@
                              #{:wgs-dev :wgs-prod :wgs-staging} url))))
     (testing "unknown url"
       (is (nil? (all/cromwell-environments "https://no.such.cromwell/"))))))
+
+(deftest wdl-verison-in-edn
+  (let [wdls [aou/workflow-wdl
+              wgs/workflow-wdl
+              ukb/workflow-wdl
+              xx/workflow-wdl]
+        edn  (wfl/get-the-version)]
+    (testing "WDLs have their versions in version.edn"
+      (is (every? #(= (:release %) (edn (last (str/split (:top %) #"/")))) wdls)))))


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1031

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Add the WARP WDLs back into what ends up in the version file
- Add a fast-running unit test that WDL versions are in the version.edn

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

The PR will run the unit test showing that the version.edn file contains the versions of the WDLs, and since the code that produces "Unknown" is

```clojure
(key-for :wdl-version) (or (the-version wdl-value) "Unknown")
```

we should be all set. Can also verify via logging in to `./ops/server.sh`, you'll see the WARP WDL version info on the right-hand side again which is just read straight out of `version.edn`.
