### PR TITLE
[GH-1032] append-to-aou accepts one or more sample

### DIFF
--- a/api/src/wfl/api/spec.clj
+++ b/api/src/wfl/api/spec.clj
@@ -73,7 +73,7 @@
                                                                ::chip_well_barcode]))))
 (s/def ::chip_well_barcode string?)
 (s/def ::items-aou (constantly true))     ; stub
-(s/def ::notifications (s/* map?))
+(s/def ::notifications (s/+ map?))
 (s/def ::workflow-aou map?)               ; stub
 
 ;; wgs


### PR DESCRIPTION
### Purpose

Fixes GH-1032:
In spec, accept one or more samples.
Add test points to `test-append-to-aou-workload` to lock down behaviour.