### PR TITLE
[GH-1034] Fix reference_fasta function

### DIFF
--- a/api/src/wfl/references.clj
+++ b/api/src/wfl/references.clj
@@ -1,23 +1,21 @@
 (ns wfl.references
-  "Define shared static references."
-  (:require [clojure.string :as str]))
+  "Define shared static references.")
 
 (defn reference_fasta
-  "Value for references.reference_fastas, possibly prefixed with a different bucket than default."
-  ([ref-prefix]
-   (let [default "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38"
-         prefix (partial str (if (str/blank? ref-prefix) default ref-prefix))]
-     {:ref_dict        (prefix ".dict")
-      :ref_fasta       (prefix ".fasta")
-      :ref_fasta_index (prefix ".fasta.fai")
-      :ref_ann         (prefix ".fasta.64.ann")
-      :ref_bwt         (prefix ".fasta.64.bwt")
-      :ref_pac         (prefix ".fasta.64.pac")
-      :ref_alt         (prefix ".fasta.64.alt")
-      :ref_amb         (prefix ".fasta.64.amb")
-      :ref_sa          (prefix ".fasta.64.sa")}))
+  "Default value for references.reference_fastas."
+  ([prefix]
+   {:ref_dict        (str prefix ".dict")
+    :ref_fasta       (str prefix ".fasta")
+    :ref_fasta_index (str prefix ".fasta.fai")
+    :ref_ann         (str prefix ".fasta.64.ann")
+    :ref_bwt         (str prefix ".fasta.64.bwt")
+    :ref_pac         (str prefix ".fasta.64.pac")
+    :ref_alt         (str prefix ".fasta.64.alt")
+    :ref_amb         (str prefix ".fasta.64.amb")
+    :ref_sa          (str prefix ".fasta.64.sa")})
   ([]
-   (reference_fasta nil)))
+   (reference_fasta
+     "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38")))
 
 (defn hg38-genome-references
   "HG38 reference files for genome reprocessing."

--- a/api/src/wfl/references.clj
+++ b/api/src/wfl/references.clj
@@ -34,7 +34,7 @@
                                   (hg hsa  ".known_indels.vcf.gz.tbi")]
      :known_indels_sites_vcfs    [(hg gold ".vcf.gz")
                                   (hg hsa  ".known_indels.vcf.gz")]
-     :reference_fasta             (reference_fasta prefix)}))
+     :reference_fasta             (if prefix (reference_fasta prefix) (reference_fasta))}))
 
 (def hg38-exome-references
   "HG38 reference files for exome reprocessing."

--- a/api/src/wfl/references.clj
+++ b/api/src/wfl/references.clj
@@ -1,21 +1,23 @@
 (ns wfl.references
-  "Define shared static references.")
+  "Define shared static references."
+  (:require [clojure.string :as str]))
 
 (defn reference_fasta
-  "Default value for references.reference_fastas."
-  ([prefix]
-   {:ref_dict        (str prefix ".dict")
-    :ref_fasta       (str prefix ".fasta")
-    :ref_fasta_index (str prefix ".fasta.fai")
-    :ref_ann         (str prefix ".fasta.64.ann")
-    :ref_bwt         (str prefix ".fasta.64.bwt")
-    :ref_pac         (str prefix ".fasta.64.pac")
-    :ref_alt         (str prefix ".fasta.64.alt")
-    :ref_amb         (str prefix ".fasta.64.amb")
-    :ref_sa          (str prefix ".fasta.64.sa")})
+  "Value for references.reference_fastas, possibly prefixed with a different bucket than default."
+  ([ref-prefix]
+   (let [default "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38"
+         prefix (partial str (if (str/blank? ref-prefix) default ref-prefix))]
+     {:ref_dict        (prefix ".dict")
+      :ref_fasta       (prefix ".fasta")
+      :ref_fasta_index (prefix ".fasta.fai")
+      :ref_ann         (prefix ".fasta.64.ann")
+      :ref_bwt         (prefix ".fasta.64.bwt")
+      :ref_pac         (prefix ".fasta.64.pac")
+      :ref_alt         (prefix ".fasta.64.alt")
+      :ref_amb         (prefix ".fasta.64.amb")
+      :ref_sa          (prefix ".fasta.64.sa")}))
   ([]
-   (reference_fasta
-     "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38")))
+   (reference_fasta nil)))
 
 (defn hg38-genome-references
   "HG38 reference files for genome reprocessing."

--- a/api/test/wfl/unit/references_test.clj
+++ b/api/test/wfl/unit/references_test.clj
@@ -5,8 +5,10 @@
 
 (deftest prefix-handling
   (testing "reference_fasta function"
-    (testing "treats nil as no arg"
-      (is (= (references/reference_fasta) (references/reference_fasta nil))))
+    (testing "treats nil/empty as no arg"
+      (is (= (references/reference_fasta)
+             (references/reference_fasta nil)
+             (references/reference_fasta ""))))
     (testing "supplies a bucket prefix if no arg"
       (run! #(is (str/starts-with? % "gs://")) (vals (references/reference_fasta))))
     (testing "uses a given prefix"

--- a/api/test/wfl/unit/references_test.clj
+++ b/api/test/wfl/unit/references_test.clj
@@ -1,0 +1,14 @@
+(ns wfl.unit.references-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest testing is]]
+            [wfl.references :as references]))
+
+(deftest prefix-handling
+  (testing "reference_fasta function"
+    (testing "treats nil as no arg"
+      (is (= (references/reference_fasta) (references/reference_fasta nil))))
+    (testing "supplies a bucket prefix if no arg"
+      (run! #(is (str/starts-with? % "gs://")) (vals (references/reference_fasta))))
+    (testing "uses a given prefix"
+      (let [prefix "foo"]
+        (run! #(is (str/starts-with? % prefix)) (vals (references/reference_fasta prefix)))))))

--- a/api/test/wfl/unit/references_test.clj
+++ b/api/test/wfl/unit/references_test.clj
@@ -5,12 +5,18 @@
 
 (deftest prefix-handling
   (testing "reference_fasta function"
-    (testing "treats nil/empty as no arg"
-      (is (= (references/reference_fasta)
-             (references/reference_fasta nil)
-             (references/reference_fasta ""))))
     (testing "supplies a bucket prefix if no arg"
-      (run! #(is (str/starts-with? % "gs://")) (vals (references/reference_fasta))))
+      (run! #(is (str/starts-with? % "gs://"))
+            (vals (references/reference_fasta))))
     (testing "uses a given prefix"
       (let [prefix "foo"]
-        (run! #(is (str/starts-with? % prefix)) (vals (references/reference_fasta prefix)))))))
+        (run! #(is (str/starts-with? % prefix))
+              (vals (references/reference_fasta prefix))))))
+  (testing "hg38-genome-references function"
+    (testing "supplies a reference_fasta default if nil"
+      (run! #(is (str/starts-with? % "gs://"))
+            (vals (:reference_fasta (references/hg38-genome-references nil)))))
+    (testing "uses a given prefix for reference_fasta"
+      (let [prefix "bar"]
+        (run! #(is (str/starts-with? % prefix))
+              (vals (:reference_fasta (references/hg38-genome-references prefix))))))))


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1034

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Make `hg38-genome-references` smarter about not passing nil to `reference_fasta`
  - Can't use fnil because the default is in the function
- Add a test for prefix handling in the references file

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- See the ticket for more info on what happened here
