### PR TITLE
update cloud_function after api tidy-ups

### DIFF
--- a/api/test/wfl/tools/workloads.clj
+++ b/api/test/wfl/tools/workloads.clj
@@ -38,7 +38,6 @@
   Randomize it with IDENTIFIER for easier testing."
   [identifier]
   {:cromwell (get-in stuff [:aou-dev :cromwell :url])
-   :input    "aou-inputs-placeholder"
    :output   "gs://broad-gotc-dev-wfl-ptc-test-outputs/aou-test-output"
    :pipeline aou/pipeline
    :project  (format "(Test) %s %s" @git-branch identifier)})

--- a/cloud_function/main.py
+++ b/cloud_function/main.py
@@ -38,11 +38,9 @@ def get_manifest_path(object_name):
 def get_or_create_workload(headers):
     payload = {
         "cromwell": CROMWELL_URL,
-        "input": "aou-inputs-placeholder",
         "output": OUTPUT_BUCKET,
         "pipeline": "AllOfUsArrays",
-        "project": WFL_ENVIRONMENT,
-        "items": [{}]
+        "project": WFL_ENVIRONMENT
     }
     response = requests.post(
         url=f"{WFL_URL}/api/v1/exec",
@@ -53,8 +51,6 @@ def get_or_create_workload(headers):
 
 def update_workload(headers, workload_uuid, input_data):
     input_data['uuid'] = workload_uuid
-    input_data['cromwell'] = CROMWELL_URL
-    input_data['environment'] = WFL_ENVIRONMENT
     print(f"Updating workload {workload_uuid}")
     response = requests.post(
         url=f"{WFL_URL}/api/v1/append_to_aou",

--- a/cloud_function/module.mk
+++ b/cloud_function/module.mk
@@ -15,10 +15,9 @@ TEST_SCM_SRC = \
 	$(MODULE_DIR)/pytest.ini
 
 LOGFILE := $(DERIVED_MODULE_DIR)/test.log
-$(CHECK): $(SCM_SRC) $(TEST_SCM_SRC)
-	$(call using-python-environment,                                      \
-		$(PYTHON) -m pytest $(TEST_DIR)/unit_tests.py | $(TEE) $(LOGFILE) \
-	)
+$(UNIT): $(SCM_SRC) $(TEST_SCM_SRC)
+	$(call using-python-environment, \
+		$(PYTHON) -m pytest $(TEST_DIR)/unit_tests.py | $(TEE) $(LOGFILE))
 	@$(TOUCH) $@
 
 # Remove any python caches


### PR DESCRIPTION
### Purpose
Change cloud_function after https://github.com/broadinstitute/wfl/pull/196
- remove unused endpoint message fields
- make the tests run

