### PR TITLE
use random db name in tests

### DIFF
--- a/api/test/wfl/integration/modules/aou_test.clj
+++ b/api/test/wfl/integration/modules/aou_test.clj
@@ -9,7 +9,7 @@
             [wfl.tools.endpoints :as endpoints])
   (:import (java.util UUID)))
 
-(use-fixtures :once fixtures/clean-db-fixture)
+(use-fixtures :once fixtures/temporary-postgresql-database)
 
 (defn mock-submit-workload [& _] (UUID/randomUUID))
 (def mock-cromwell-status (constantly "Succeeded"))

--- a/api/test/wfl/integration/modules/wgs_test.clj
+++ b/api/test/wfl/integration/modules/wgs_test.clj
@@ -7,7 +7,7 @@
             [wfl.module.wgs :as wgs])
   (:import (java.util UUID)))
 
-(clj-test/use-fixtures :once fixtures/clean-db-fixture)
+(clj-test/use-fixtures :once fixtures/temporary-postgresql-database)
 
 (defn- mock-really-submit-one-workflow
   [& _]

--- a/api/test/wfl/integration/modules/xx_test.clj
+++ b/api/test/wfl/integration/modules/xx_test.clj
@@ -10,7 +10,7 @@
   (:import (java.util UUID)
            (java.time OffsetDateTime)))
 
-(clj-test/use-fixtures :once fixtures/clean-db-fixture)
+(clj-test/use-fixtures :once fixtures/temporary-postgresql-database)
 
 (defn ^:private make-xx-workload-request []
   (-> (UUID/randomUUID)

--- a/api/test/wfl/system/v1_endpoint_test.clj
+++ b/api/test/wfl/system/v1_endpoint_test.clj
@@ -3,7 +3,7 @@
             [clojure.test :refer [deftest testing is]]
             [wfl.service.gcs :as gcs]
             [wfl.tools.endpoints :as endpoints]
-            [wfl.tools.fixtures :refer [with-temporary-gcs-folder clean-db-fixture]]
+            [wfl.tools.fixtures :refer [with-temporary-gcs-folder temporary-postgresql-database]]
             [wfl.tools.workloads :as workloads]
             [wfl.util :as util]
             [wfl.service.cromwell :as cromwell])

--- a/api/test/wfl/tools/workloads.clj
+++ b/api/test/wfl/tools/workloads.clj
@@ -10,7 +10,8 @@
             [wfl.tools.endpoints :as endpoints]
             [wfl.util :refer [shell!]]
             [wfl.util :as util]
-            [wfl.jdbc :as jdbc])
+            [wfl.jdbc :as jdbc]
+            [wfl.tools.fixtures :as fixtures])
   (:import (java.util.concurrent TimeoutException)))
 
 (def git-branch (delay (util/shell! "git" "branch" "--show-current")))
@@ -103,25 +104,25 @@
     nil))
 
 (defn create-workload! [workload-request]
-  (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+  (jdbc/with-db-transaction [tx (fixtures/testing-db-config)]
     (wfl.api.workloads/create-workload! tx workload-request)))
 
 (defn start-workload! [workload]
-  (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+  (jdbc/with-db-transaction [tx (fixtures/testing-db-config)]
     (wfl.api.workloads/start-workload! tx workload)))
 
 (defn execute-workload! [workload-request]
-  (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+  (jdbc/with-db-transaction [tx (fixtures/testing-db-config)]
     (wfl.api.workloads/execute-workload! tx workload-request)))
 
 (defn update-workload! [workload]
-  (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+  (jdbc/with-db-transaction [tx (fixtures/testing-db-config)]
     (wfl.api.workloads/update-workload! tx workload)))
 
 (defn load-workload-for-uuid [uuid]
-  (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+  (jdbc/with-db-transaction [tx (fixtures/testing-db-config)]
     (wfl.api.workloads/load-workload-for-uuid tx uuid)))
 
 (defn append-to-workload! [samples workload]
-  (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+  (jdbc/with-db-transaction [tx (fixtures/testing-db-config)]
     (aou/append-to-workload! tx samples workload)))


### PR DESCRIPTION
### Purpose
By popular demand, use a random db name in tests. This means that you no longer need to remove the `wfl` database before running integration tests.
