### PR TITLE
[GH-1024] Make start workload endpoint take a single UUID

### DIFF
--- a/api/src/wfl/api/handlers.clj
+++ b/api/src/wfl/api/handlers.clj
@@ -92,7 +92,7 @@
                (do
                  (logr/infof "starting workload %s" uuid)
                  (workloads/start-workload! tx workload)))
-          (succeed))))))
+          succeed)))))
 
 (defn post-exec
   "Create and start workload described in BODY of REQUEST"

--- a/api/src/wfl/api/handlers.clj
+++ b/api/src/wfl/api/handlers.clj
@@ -81,21 +81,18 @@
             (workloads/load-workloads tx)))))))
 
 (defn post-start
-  "Start the workload with UUID in REQUEST.
-   Can take either a single UUID or a map with UUID as key."
+  "Start the workload with UUID in REQUEST."
   [request]
-  (letfn [(go! [tx uuid]
-            (let [workload (workloads/load-workload-for-uuid tx uuid)]
-              (if (:started workload)
-                workload
-                (do
-                  (logr/infof "starting workload %s" uuid)
-                  (workloads/start-workload! tx workload)))))]
-    (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
-      (let [body  (get-in request [:parameters :body])
-            {uuid :uuid :or {uuid body}} body]
-        (logr/infof "post-start endpoint called: uuid=%s" uuid)
-        (succeed (go! tx uuid))))))
+  (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+    (let [{uuid :uuid} (get-in request [:parameters :body])]
+      (logr/infof "post-start endpoint called: uuid=%s" uuid)
+      (let [workload (workloads/load-workload-for-uuid tx uuid)]
+        (->> (if (:started workload)
+               workload
+               (do
+                 (logr/infof "starting workload %s" uuid)
+                 (workloads/start-workload! tx workload)))
+          (succeed))))))
 
 (defn post-exec
   "Create and start workload described in BODY of REQUEST"

--- a/api/src/wfl/api/handlers.clj
+++ b/api/src/wfl/api/handlers.clj
@@ -87,11 +87,12 @@
     (let [{uuid :uuid} (get-in request [:parameters :body])]
       (logr/infof "post-start endpoint called: uuid=%s" uuid)
       (let [workload (workloads/load-workload-for-uuid tx uuid)]
-        (->> (if (:started workload)
-               workload
-               (do
-                 (logr/infof "starting workload %s" uuid)
-                 (workloads/start-workload! tx workload)))
+        (->>
+          (if (:started workload)
+            workload
+            (do
+              (logr/infof "starting workload %s" uuid)
+              (workloads/start-workload! tx workload)))
           succeed)))))
 
 (defn post-exec

--- a/api/src/wfl/api/routes.clj
+++ b/api/src/wfl/api/routes.clj
@@ -79,7 +79,7 @@
    ["/api/v1/start"
     {:post {:summary    "Start a workload."
             :parameters {:body ::spec/uuid-kv}
-            :responses  {200 {:body ::spec/workload-responses}}
+            :responses  {200 {:body ::spec/workload-response}}
             :handler    handlers/post-start}}]
    ["/api/v1/exec"
     {:post {:summary    "Create and start a new workload."

--- a/api/src/wfl/api/routes.clj
+++ b/api/src/wfl/api/routes.clj
@@ -78,7 +78,7 @@
             :handler    handlers/post-create}}]
    ["/api/v1/start"
     {:post {:summary    "Start a workload."
-            :parameters {:body ::spec/start-workfload-request}
+            :parameters {:body ::spec/uuid-kv}
             :responses  {200 {:body ::spec/workload-responses}}
             :handler    handlers/post-start}}]
    ["/api/v1/exec"

--- a/api/src/wfl/api/routes.clj
+++ b/api/src/wfl/api/routes.clj
@@ -77,12 +77,12 @@
             :responses  {200 {:body ::spec/workload-response}}
             :handler    handlers/post-create}}]
    ["/api/v1/start"
-    {:post {:summary    "Start workloads."
-            :parameters {:body ::spec/uuid-kvs}
+    {:post {:summary    "Start a workload."
+            :parameters {:body ::spec/start-workfload-request}
             :responses  {200 {:body ::spec/workload-responses}}
             :handler    handlers/post-start}}]
    ["/api/v1/exec"
-    {:post {:summary    "Create and start new workload."
+    {:post {:summary    "Create and start a new workload."
             :parameters {:body ::spec/workload-request}
             :responses  {200 {:body ::spec/workload-response}}
             :handler    handlers/post-exec}}]

--- a/api/src/wfl/api/spec.clj
+++ b/api/src/wfl/api/spec.clj
@@ -26,9 +26,7 @@
 (s/def ::started inst?)
 (s/def ::updated inst?)
 (s/def ::uuid (s/and string? uuid-string?))
-(s/def ::uuids (s/* ::uuid))
 (s/def ::uuid-kv (s/keys :req-un [::uuid]))
-(s/def ::uuid-kvs (s/* ::uuid-kv))
 (s/def ::uuid-query (s/keys :opt-un [::uuid]))
 (s/def ::version string?)
 (s/def ::wdl string?)
@@ -66,8 +64,8 @@
 
 (s/def ::workflows (s/* ::workflow))
 (s/def ::workflow
-  (s/keys :req-un [::inputs]
-          :opt-un [::status ::updated ::uuid]))
+(s/keys :req-un [::inputs]
+        :opt-un [::status ::updated ::uuid]))
 
 ;; aou
 (s/def ::analysis_version_number integer?)
@@ -108,3 +106,8 @@
 (s/def ::workflow-request (s/keys :req-un [::end
                                            ::environment
                                            ::start]))
+
+;; /api/v1/start
+(s/def ::start-workfload-request (s/or
+                                   :uuid ::uuid
+                                   :uuid-kv ::uuid-kv))

--- a/api/src/wfl/api/spec.clj
+++ b/api/src/wfl/api/spec.clj
@@ -106,8 +106,3 @@
 (s/def ::workflow-request (s/keys :req-un [::end
                                            ::environment
                                            ::start]))
-
-;; /api/v1/start
-(s/def ::start-workfload-request (s/or
-                                   :uuid ::uuid
-                                   :uuid-kv ::uuid-kv))

--- a/api/test/wfl/tools/endpoints.clj
+++ b/api/test/wfl/tools/endpoints.clj
@@ -51,7 +51,6 @@
   "Start processing WORKLOAD. WORKLOAD must be known to the server."
   [workload]
   (let [payload  (-> (select-keys workload [:uuid])
-                   list
                    (json/write-str :escape-slash false))
         response (client/post (str server "/api/v1/start")
                    {:headers      (once/get-auth-header)

--- a/api/test/wfl/tools/endpoints.clj
+++ b/api/test/wfl/tools/endpoints.clj
@@ -57,7 +57,7 @@
                     :content-type :json
                     :accept       :json
                     :body         payload})]
-    (first (util/parse-json (:body response)))))
+    (util/parse-json (:body response))))
 
 (defn append-to-aou-workload
   "Append SAMPLES to the aou WORKLOAD"

--- a/docs/md/dev-wgs.md
+++ b/docs/md/dev-wgs.md
@@ -54,17 +54,18 @@ so that is its default value
 unless it is specified.
 
 The `reference_fasta_prefix` can be used to override
-the [default value](https://github.com/broadinstitute/wfl/blob/master/api/src/wfl/references.clj#L7) used by this module: 
+the [default value](https://github.com/broadinstitute/wfl/blob/master/api/src/wfl/references.clj#L7) used by this module:
 "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38"
 
 ## Usage
 
-###Create Workload: `/api/v1/create`
+### Create Workload: `/api/v1/create`
 Creates a WFL workload. Before processing, confirm that the WFL and Cromwell service accounts have
 at least read access to the input files.
 
 Request:
-```
+
+```bash
 curl --location --request POST 'https://dev-wfl.gotc-dev.broadinstitute.org/api/v1/create' \
 --header 'Authorization: Bearer '$(gcloud auth print-access-token) \
 --header 'Content-Type: application/json' \
@@ -84,8 +85,10 @@ curl --location --request POST 'https://dev-wfl.gotc-dev.broadinstitute.org/api/
   ]
 }'
 ```
+
 Response:
-```
+
+```json
 {
   "creator": "sehsan@broadinstitute.org",
   "pipeline": "ExternalWholeGenomeReprocessing",
@@ -105,20 +108,24 @@ Response:
 ```
 
 
-###Start Workload: `/api/v1/start`
+### Start Workload: `/api/v1/start`
+
 Starts a Cromwell workflow for each item in the workload. If an output already exists in the output bucket for a
 particular input cram, WFL will not re-submit that workflow.
 
 Request:
-```
+
+```bash
 curl --location --request POST 'https://dev-wfl.gotc-dev.broadinstitute.org/api/v1/start' \
 --header 'Authorization: Bearer '$(gcloud auth print-access-token) \
 --header 'Content-Type: application/json' \
---data-raw '[{"uuid": "74d96a04-fea7-4270-a02b-a319dae2dd5e"}]'
+--data-raw '{"uuid": "74d96a04-fea7-4270-a02b-a319dae2dd5e"}'
 ```
+
 Response:
-```
-[{
+
+```json
+{
   "started": "2020-10-05T15:50:51Z",
   "creator": "username@broadinstitute.org",
   "pipeline": "ExternalWholeGenomeReprocessing",
@@ -126,7 +133,7 @@ Response:
   "release": "ExternalWholeGenomeReprocessing_v1.0",
   "created": "2020-10-05T15:50:01Z",
   "output": "gs://broad-gotc-dev-wfl-ptc-test-outputs/wgs-test-output/",
-  "workflows": [ 
+  "workflows": [
     {
       "id": 1,
       "updated": "2020-10-05T16:15:32Z",
@@ -135,7 +142,7 @@ Response:
         "input_cram": "develop/20k/NA12878_PLUMBING.cram",
         "sample_name": "TestSample1234"
       }
-    } 
+    }
   ],
   "project": "PO-1234",
   "id": 30,
@@ -145,14 +152,16 @@ Response:
   "uuid": "74d96a04-fea7-4270-a02b-a319dae2dd5e",
   "items": "ExternalWholeGenomeReprocessing_000000030",
   "version": "0.3.2"
-}]
+}
 ```
 
-###Exec Workload: `/api/v1/exec`
+### Exec Workload: `/api/v1/exec`
+
 Creates and then starts a Cromwell workflow for each item in the workload.
 
 Request:
-```
+
+```bash
 curl --location --request POST 'https://dev-wfl.gotc-dev.broadinstitute.org/api/v1/exec' \
 --header 'Authorization: Bearer '$(gcloud auth print-access-token) \
 --header 'Content-Type: application/json' \
@@ -172,8 +181,10 @@ curl --location --request POST 'https://dev-wfl.gotc-dev.broadinstitute.org/api/
   ]
 }'
 ```
+
 Response:
-```
+
+```json
 {
   "started": "2020-10-05T16:15:32Z",
   "creator": "username@broadinstitute.org",
@@ -182,7 +193,7 @@ Response:
   "release": "ExternalWholeGenomeReprocessing_v1.0",
   "created": "2020-10-05T16:15:32Z",
   "output": "gs://broad-gotc-dev-wfl-ptc-test-outputs/wgs-test-output/",
-  "workflows": [ 
+  "workflows": [
     {
       "id": 1,
       "updated": "2020-10-05T16:15:32Z",
@@ -191,7 +202,7 @@ Response:
         "input_cram": "develop/20k/NA12878_PLUMBING.cram",
         "sample_name": "TestSample1234"
       }
-    } 
+    }
   ],
   "project": "PO-1234",
   "id": 31,
@@ -204,17 +215,20 @@ Response:
 }
 ```
 
-###Query Workload: `/api/v1/workload?uuid=<uuid>`
+### Query Workload: `/api/v1/workload?uuid=<uuid>`
+
 Queries the WFL database for workloads. Specify the uuid to query for a specific workload.
 
 Request:
-```
+
+```bash
 curl --location --request GET 'https://dev-wfl.gotc-dev.broadinstitute.org/api/v1/workload?uuid=813e3c38-9c11-4410-9888-435569d91d1d' \
 --header 'Authorization: Bearer '$(gcloud auth print-access-token)
 ```
 
 Response:
-```
+
+```json
 [{
   "creator": "username",
   "pipeline": "ExternalWholeGenomeReprocessing",
@@ -222,7 +236,7 @@ Response:
   "release": "ExternalWholeGenomeReprocessing_v1.0",
   "created": "2020-08-27T16:26:59Z",
   "output": "gs://broad-gotc-dev-zero-test/wgs-test-output",
-  "workflows": [ 
+  "workflows": [
     {
       "id": 1,
       "updated": "2020-10-05T16:15:32Z",
@@ -231,7 +245,7 @@ Response:
         "input_cram": "develop/20k/NA12878_PLUMBING.cram",
         "sample_name": "TestSample1234"
       }
-    } 
+    }
   ],
   "project": "wgs-dev",
   "id": 6,

--- a/docs/md/external-exome-reprocessing.md
+++ b/docs/md/external-exome-reprocessing.md
@@ -3,23 +3,24 @@
 ## Inputs
 An `ExternalExomeReprocessing` workload requires the specification of exactly
 one the following inputs for each workflow:
- 
+
 - `input_bam`, OR
 - `input_cram`
 
 Where `input_bam` and `input_cram` are GS URLs of the file to reprocess. Note
 that the `input_bam` and `input_cram` inputs should only be used with CRAM and
-BAM files, respectively. All other WDL inputs are optional - see the output 
+BAM files, respectively. All other WDL inputs are optional - see the output
 below for all options.
 
 ## Usage
 
-###Create Workload: `/api/v1/create`
+### Create Workload: `/api/v1/create`
 Create a new workload. Ensure that `workflow-launcher` and `cromwell`'s service
 accounts have at least read access to the input files.
 
 Request:
-```
+
+```bash
 curl -X POST 'https://workflow-launcher.broadinstitute.org/api/v1/create' \
   -H "Authorization: Bearer $(gcloud auth print-access-token)" \
   -H 'Content-Type: application/json' \
@@ -34,7 +35,8 @@ curl -X POST 'https://workflow-launcher.broadinstitute.org/api/v1/create' \
       }'
 ```
 Response:
-```
+
+```json
 {
   "creator" : "user@domain",
   "pipeline" : "ExternalExomeReprocessing",
@@ -89,111 +91,30 @@ Response:
     }
   } ],
   "commit" : "commit-ish",
-  "project" : "PO-1234",  
-  "uuid" : "1337254e-f7d8-438d-a2b3-a74b199fee3c",  
+  "project" : "PO-1234",
+  "uuid" : "1337254e-f7d8-438d-a2b3-a74b199fee3c",
   "wdl" : "pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl",
   "version" : "X.Y.Z"
 }
 ```
 
-###Start Workload: `/api/v1/start`
+### Start Workload: `/api/v1/start`
+
 Starts a Cromwell workflow for each item in the workload. If an output already exists in the output bucket for a
 particular input cram, WFL will not re-submit that workflow.
 
 Request:
-```
+
+```bash
 curl -X POST 'https://workflow-launcher.broadinstitute.org/api/v1/start' \
  -H "Authorization: Bearer $(gcloud auth print-access-token)" \
  -H 'Content-Type: application/json' \
- -d '[{"uuid": "1337254e-f7d8-438d-a2b3-a74b199fee3c"}]'
-```
-Response:
-```
-[{
-   "creator" : "user@domain",
-   "pipeline" : "ExternalExomeReprocessing",
-   "cromwell" : "https://cromwell-gotc-auth.gotc-dev.broadinstitute.org",
-   "release" : "ExternalExomeReprocessing_vX.Y.Z",
-   "created" : "YYYY-MM-DDTHH:MM:SSZ",
-   "started" : "YYYY-MM-DDTHH:MM:SSZ",
-   "output" : "gs://broad-gotc-dev-wfl-ptc-test-outputs/xx-test-output/",
-   "workflows" : [ {
-     "status" : "Submitted"
-     "updated" : "YYYY-MM-DDTHH:MM:SSZ",
-     "uuid" : "bb0d93e3-1a6a-4816-82d9-713fa58fb235",
-     "inputs" : {
-       "cram_ref_fasta" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",
-       "scatter_settings" : {
-         "haplotype_scatter_count" : 50,
-         "break_bands_at_multiples_of" : 0
-       },
-       "input_cram" : "gs://path/to/a.cram",
-       "destination_cloud_path" : "gs://broad-gotc-dev-wfl-ptc-test-outputs/xx-test-output/to",
-       "sample_name" : "a",
-       "bait_set_name" : "whole_exome_illumina_coding_v1",
-       "references" : {
-         "calling_interval_list" : "gs://gcp-public-data--broad-references/hg38/v0/exome_calling_regions.v1.interval_list",
-         "contamination_sites_bed" : "gs://gcp-public-data--broad-references/hg38/v0/contamination-resources/1000g/1000g.phase3.100k.b38.vcf.gz.dat.bed",
-         "dbsnp_vcf_index" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf.idx",
-         "haplotype_database_file" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.haplotype_database.txt",
-         "known_indels_sites_indices" : [ "gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi", "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz.tbi" ],
-         "evaluation_interval_list" : "gs://gcp-public-data--broad-references/hg38/v0/exome_evaluation_regions.v1.interval_list",
-         "contamination_sites_mu" : "gs://gcp-public-data--broad-references/hg38/v0/contamination-resources/1000g/1000g.phase3.100k.b38.vcf.gz.dat.mu",
-         "dbsnp_vcf" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf",
-         "known_indels_sites_vcfs" : [ "gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz", "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz" ],
-         "reference_fasta" : {
-           "ref_pac" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.pac",
-           "ref_bwt" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.bwt",
-           "ref_dict" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict",
-           "ref_ann" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.ann",
-           "ref_fasta_index" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai",
-           "ref_alt" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.alt",
-           "ref_fasta" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",
-           "ref_sa" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.sa",
-           "ref_amb" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.amb"
-         },
-         "contamination_sites_ud" : "gs://gcp-public-data--broad-references/hg38/v0/contamination-resources/1000g/1000g.phase3.100k.b38.vcf.gz.dat.UD"
-       },
-       "cram_ref_fasta_index" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai",
-       "papi_settings" : {
-         "agg_preemptible_tries" : 3,
-         "preemptible_tries" : 3
-       },
-       "base_file_name" : "a.cram",
-       "bait_interval_list" : "gs://gcp-public-data--broad-references/hg38/v0/HybSelOligos/whole_exome_illumina_coding_v1/whole_exome_illumina_coding_v1.Homo_sapiens_assembly38.baits.interval_list",
-       "final_gvcf_base_name" : "a.cram",
-       "target_interval_list" : "gs://gcp-public-data--broad-references/hg38/v0/HybSelOligos/whole_exome_illumina_coding_v1/whole_exome_illumina_coding_v1.Homo_sapiens_assembly38.targets.interval_list",
-       "unmapped_bam_suffix" : ".unmapped.bam"
-     }
-   } ],
-   "commit" : "commit-ish",
-   "project" : "PO-1234",  
-   "uuid" : "1337254e-f7d8-438d-a2b3-a74b199fee3c",  
-   "wdl" : "pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl",
-   "version" : "X.Y.Z"
- }]
+ -d '{"uuid": "1337254e-f7d8-438d-a2b3-a74b199fee3c"}'
 ```
 
-###Exec Workload: `/api/v1/exec`
-Creates and then starts a Cromwell workflow for each item in the workload.
-
-Request:
-```
-curl -X POST 'https://workflow-launcher.broadinstitute.org/api/v1/exec' \
-  -H "Authorization: Bearer $(gcloud auth print-access-token)" \
-  -H 'Content-Type: application/json' \
-  -d '{
-        "cromwell": "https://cromwell-gotc-auth.gotc-dev.broadinstitute.org",
-        "output": "gs://broad-gotc-dev-wfl-ptc-test-outputs/xx-test-output/",
-        "pipeline": "ExternalExomeReprocessing",
-        "project": "PO-1234",
-        "items": [{
-          "input_cram": "gs://path/to/a.cram"
-        }]
-      }'
-```
 Response:
-```
+
+```json
 {
    "creator" : "user@domain",
    "pipeline" : "ExternalExomeReprocessing",
@@ -252,24 +173,115 @@ Response:
      }
    } ],
    "commit" : "commit-ish",
-   "project" : "PO-1234",  
-   "uuid" : "1337254e-f7d8-438d-a2b3-a74b199fee3c",  
+   "project" : "PO-1234",
+   "uuid" : "1337254e-f7d8-438d-a2b3-a74b199fee3c",
    "wdl" : "pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl",
    "version" : "X.Y.Z"
  }
 ```
 
-###Query Workload: `/api/v1/workload?uuid=<uuid>`
+### Exec Workload: `/api/v1/exec`
+
+Creates and then starts a Cromwell workflow for each item in the workload.
+
+Request:
+```bash
+curl -X POST 'https://workflow-launcher.broadinstitute.org/api/v1/exec' \
+  -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+  -H 'Content-Type: application/json' \
+  -d '{
+        "cromwell": "https://cromwell-gotc-auth.gotc-dev.broadinstitute.org",
+        "output": "gs://broad-gotc-dev-wfl-ptc-test-outputs/xx-test-output/",
+        "pipeline": "ExternalExomeReprocessing",
+        "project": "PO-1234",
+        "items": [{
+          "input_cram": "gs://path/to/a.cram"
+        }]
+      }'
+```
+
+Response:
+
+```json
+{
+   "creator" : "user@domain",
+   "pipeline" : "ExternalExomeReprocessing",
+   "cromwell" : "https://cromwell-gotc-auth.gotc-dev.broadinstitute.org",
+   "release" : "ExternalExomeReprocessing_vX.Y.Z",
+   "created" : "YYYY-MM-DDTHH:MM:SSZ",
+   "started" : "YYYY-MM-DDTHH:MM:SSZ",
+   "output" : "gs://broad-gotc-dev-wfl-ptc-test-outputs/xx-test-output/",
+   "workflows" : [ {
+     "status" : "Submitted"
+     "updated" : "YYYY-MM-DDTHH:MM:SSZ",
+     "uuid" : "bb0d93e3-1a6a-4816-82d9-713fa58fb235",
+     "inputs" : {
+       "cram_ref_fasta" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",
+       "scatter_settings" : {
+         "haplotype_scatter_count" : 50,
+         "break_bands_at_multiples_of" : 0
+       },
+       "input_cram" : "gs://path/to/a.cram",
+       "destination_cloud_path" : "gs://broad-gotc-dev-wfl-ptc-test-outputs/xx-test-output/to",
+       "sample_name" : "a",
+       "bait_set_name" : "whole_exome_illumina_coding_v1",
+       "references" : {
+         "calling_interval_list" : "gs://gcp-public-data--broad-references/hg38/v0/exome_calling_regions.v1.interval_list",
+         "contamination_sites_bed" : "gs://gcp-public-data--broad-references/hg38/v0/contamination-resources/1000g/1000g.phase3.100k.b38.vcf.gz.dat.bed",
+         "dbsnp_vcf_index" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf.idx",
+         "haplotype_database_file" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.haplotype_database.txt",
+         "known_indels_sites_indices" : [ "gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi", "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz.tbi" ],
+         "evaluation_interval_list" : "gs://gcp-public-data--broad-references/hg38/v0/exome_evaluation_regions.v1.interval_list",
+         "contamination_sites_mu" : "gs://gcp-public-data--broad-references/hg38/v0/contamination-resources/1000g/1000g.phase3.100k.b38.vcf.gz.dat.mu",
+         "dbsnp_vcf" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf",
+         "known_indels_sites_vcfs" : [ "gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz", "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz" ],
+         "reference_fasta" : {
+           "ref_pac" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.pac",
+           "ref_bwt" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.bwt",
+           "ref_dict" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict",
+           "ref_ann" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.ann",
+           "ref_fasta_index" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai",
+           "ref_alt" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.alt",
+           "ref_fasta" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",
+           "ref_sa" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.sa",
+           "ref_amb" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.amb"
+         },
+         "contamination_sites_ud" : "gs://gcp-public-data--broad-references/hg38/v0/contamination-resources/1000g/1000g.phase3.100k.b38.vcf.gz.dat.UD"
+       },
+       "cram_ref_fasta_index" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai",
+       "papi_settings" : {
+         "agg_preemptible_tries" : 3,
+         "preemptible_tries" : 3
+       },
+       "base_file_name" : "a.cram",
+       "bait_interval_list" : "gs://gcp-public-data--broad-references/hg38/v0/HybSelOligos/whole_exome_illumina_coding_v1/whole_exome_illumina_coding_v1.Homo_sapiens_assembly38.baits.interval_list",
+       "final_gvcf_base_name" : "a.cram",
+       "target_interval_list" : "gs://gcp-public-data--broad-references/hg38/v0/HybSelOligos/whole_exome_illumina_coding_v1/whole_exome_illumina_coding_v1.Homo_sapiens_assembly38.targets.interval_list",
+       "unmapped_bam_suffix" : ".unmapped.bam"
+     }
+   } ],
+   "commit" : "commit-ish",
+   "project" : "PO-1234",
+   "uuid" : "1337254e-f7d8-438d-a2b3-a74b199fee3c",
+   "wdl" : "pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl",
+   "version" : "X.Y.Z"
+ }
+```
+
+### Query Workload: `/api/v1/workload?uuid=<uuid>`
+
 Queries the WFL database for workloads. Specify the uuid to query for a specific workload.
 
 Request:
-```
+
+```bash
 curl -X GET 'https://workflow-launcher.broadinstitute.org/api/v1/workload?uuid=1337254e-f7d8-438d-a2b3-a74b199fee3c' \
   -H "Authorization: Bearer $(gcloud auth print-access-token)"
 ```
 
 Response:
-```
+
+```json
 [{
    "creator" : "user@domain",
    "pipeline" : "ExternalExomeReprocessing",
@@ -328,8 +340,8 @@ Response:
      }
    } ],
    "commit" : "commit-ish",
-   "project" : "PO-1234",  
-   "uuid" : "1337254e-f7d8-438d-a2b3-a74b199fee3c",  
+   "project" : "PO-1234",
+   "uuid" : "1337254e-f7d8-438d-a2b3-a74b199fee3c",
    "wdl" : "pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl",
    "version" : "X.Y.Z"
  }]
@@ -341,7 +353,7 @@ to check workflow progress and easily see information about any workflow
 failures.
 
 ## A1 External Exome Workload-Request JSON Spec
-```
+```json
 {
      "pipeline": "string",
      "cromwell": "string",
@@ -393,7 +405,7 @@ failures.
              // required - specify either "input_bam" or "input_cram"
              "input_bam":  "string",
              "input_cram": "string",
-             
+
              // optional inputs
              "sample_name":          "string",
              "final_gvcf_base_name":  "string",

--- a/docs/md/modules-arrays.md
+++ b/docs/md/modules-arrays.md
@@ -26,7 +26,7 @@ It supports the following API endpoints:
 | GET    | `/api/v1/workload`             | List all workloads                                             |
 | GET    | `/api/v1/workload/{uuid}`      | Query for a workload by its UUID                               |
 | POST   | `/api/v1/create`               | Create a new workload                                          |
-| POST   | `/api/v1/start`                | Start a or multiple workload(s)                                |
+| POST   | `/api/v1/start`                | Start a workload                                |
 | POST   | `/api/v1/append_to_aou`        | Append a new or multiple sample(s) to an existing AOU workload |
 
 Different from the fixed workload types that caller only needs to create a workload with a series of sample inputs and
@@ -77,11 +77,9 @@ curl -X "POST" "http://localhost:8080/api/v1/create" \
 curl -X "POST" "http://localhost:8080/api/v1/start" \
      -H 'Accept: application/json' \
      -H 'Content-Type: application/json' \
-     -d $'[
-  {
-    "uuid": "00000000-0000-0000-0000-000000000000"
-  }
-]'
+     -d $'{
+            "uuid": "00000000-0000-0000-0000-000000000000"
+          }'
 ```
 
 **GET /api/v1/workload/append_to_aou**


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1024
- Discussions:
    - https://github.com/broadinstitute/wfl/pull/164#discussion_r501691419
    - https://broadinstitute.slack.com/archives/CFA6Q2QBU/p1603916497140900

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- [x] The `/api/v1/start` endpoint now takes a single UUID string or a map that has `:uuid` has its key.
- [x] Specs are updated accordingly.
- [x] Tests are updated accordingly. 
- [x] Docs are updated accordingly.


### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

Now you could run something like:

```bash
curl -X "POST" "http://localhost:3000/api/v1/start" \
     -H 'Authorization: Bearer $(gcloud auth print-access-token)' \
     -H 'Content-Type: application/json' \
     -d $'{
                 "uuid": "d0ab1865-556e-4a7e-8f5c-de80d1081529",
             }'
```
to start a single workload, and the response will also be a single map that represents a workload entity. The easiest way to test is to call `create` and `start` sequentially:

```bash
curl -X "POST" "http://localhost:3000/api/v1/create" \
     -H 'Authorization: Bearer $(gcloud auth print-access-token)' \
     -H 'Content-Type: application/json' \
     -d $'{
  "cromwell": "https://cromwell-gotc-auth.gotc-dev.broadinstitute.org",
  "project": "(Test) Exhaustive WFL Code Bashing Test",
  "input": "fake-input",
  "items": [
    {
      "inputs": {
        "dst": "gs://broad-gotc-dev-zero-test/wfl-test-b17d834c-7c27-4e7a-a6df-3e2a4ef4def7/output.txt",
        "src": "gs://broad-gotc-dev-zero-test/wfl-test-b17d834c-7c27-4e7a-a6df-3e2a4ef4def7/input.txt"
      }
    }
  ],
  "output": "fake-output",
  "pipeline": "copyfile"
}'
```
and then use the JSON response body from this request as the payload of the above `/api/v1/start` endpoint.

### Testing

I'm able to run `unit` and `integration` tests fine. When it comes to system tests, While other modules work as expected, the `wgs` module failed due to an empty payload:
```json
{
      "uuid":""
},
```
with errors like: `01:08:38 WARN  wfl.api.spec - Swallowed exception and returned nil in wfl.util/do-or-nil`. I can see where it came from, not sure if I should fix it in this PR or wait for the work @ehigham mentioned he planned/already doing.

**NVM, there's a place in the testing mock `start` handler that I didn't notice, the issues should be fixed by the latest commit. Will merge once the system test pass.**

The system test is passing now, merging:

```
--- system (clojure.test) ---------------------------
wfl.system.v1-endpoint-test
  test-start-workload
    calling api/v1/start with ExternalWholeGenomeReprocessing workload
    calling api/v1/start with AllOfUsArrays workload
    calling api/v1/start with ExternalExomeReprocessing workload
    calling api/v1/start with copyfile workload

1 tests, 28 assertions, 0 failures.
```