### PR TITLE
[GH-1022] Repurpose external exome table for batch workloads

### DIFF
--- a/api/src/wfl/module/batch.clj
+++ b/api/src/wfl/module/batch.clj
@@ -7,7 +7,7 @@
 
 (defn add-workload-table!
   "Create row in workload table for `workload-request` using transaction `tx`.
-  Instantiate a BatchWorkload table for the workload.
+  Instantiate a CromwellWorkflow table for the workload.
   Returns: [id table-name]"
   [tx
    {:keys [release top] :as _workflow-wdl}
@@ -22,7 +22,7 @@
     (jdbc/execute! tx
       ["UPDATE workload SET pipeline = ?::pipeline WHERE id = ?" pipeline id])
     (jdbc/db-do-commands tx
-      (map #(format "CREATE TABLE %s OF BatchWorkflow (PRIMARY KEY (id))" %)
+      (map #(format "CREATE TABLE %s OF CromwellWorkflow (PRIMARY KEY (id))" %)
         [table]))
     (jdbc/update! tx :workload {:items table} ["id = ?" id])
     [id table]))

--- a/api/src/wfl/module/batch.clj
+++ b/api/src/wfl/module/batch.clj
@@ -1,0 +1,28 @@
+(ns wfl.module.batch
+  "Some utilities shared between batch workloads in cromwell."
+  (:require [clojure.pprint :refer [pprint]]
+            [wfl.jdbc :as jdbc]
+            [wfl.wfl :as wfl])
+  (:import [java.util UUID]))
+
+(defn add-workload-table!
+  "Create row in workload table for `workload-request` using transaction `tx`.
+  Instantiate a BatchWorkload table for the workload.
+  Returns: [id table-name]"
+  [tx
+   {:keys [release top] :as _workflow-wdl}
+   {:keys [pipeline] :as workload-request}]
+  (let [[{:keys [id]}]
+        (-> workload-request
+          (select-keys [:creator :cromwell :input :output :project])
+          (merge (-> (wfl/get-the-version) (select-keys [:commit :version])))
+          (assoc :release release :wdl top :uuid (UUID/randomUUID))
+          (->> (jdbc/insert! tx :workload)))
+        table (format "%s_%09d" pipeline id)]
+    (jdbc/execute! tx
+      ["UPDATE workload SET pipeline = ?::pipeline WHERE id = ?" pipeline id])
+    (jdbc/db-do-commands tx
+      (map #(format "CREATE TABLE %s OF BatchWorkflow (PRIMARY KEY (id))" %)
+        [table]))
+    (jdbc/update! tx :workload {:items table} ["id = ?" id])
+    [id table]))

--- a/api/src/wfl/module/xx.clj
+++ b/api/src/wfl/module/xx.clj
@@ -109,10 +109,10 @@
             (->> (make-combined-inputs-to-save output common_inputs inputs)
               json/write-str
               (assoc {:id id} :inputs)))]
-    (let [[uuid table] (batch/add-workload-table! tx workflow-wdl request)]
+    (let [[id table] (batch/add-workload-table! tx workflow-wdl request)]
       (->> (map make-workflow-record (range) (map :inputs items))
         (jdbc/insert-multi! tx table))
-      (workloads/load-workload-for-id tx uuid))))
+      (workloads/load-workload-for-id tx id))))
 
 (defn start-xx-workload! [tx {:keys [items id] :as workload}]
   (if (:started workload)

--- a/api/src/wfl/module/xx.clj
+++ b/api/src/wfl/module/xx.clj
@@ -9,6 +9,7 @@
             [wfl.environments :as env]
             [wfl.jdbc :as jdbc]
             [wfl.module.all :as all]
+            [wfl.module.batch :as batch]
             [wfl.references :as references]
             [wfl.service.gcs :as gcs]
             [wfl.service.postgres :as postgres]
@@ -108,10 +109,10 @@
             (->> (make-combined-inputs-to-save output common_inputs inputs)
               json/write-str
               (assoc {:id id} :inputs)))]
-    (let [[uuid table] (all/add-workload-table! tx workflow-wdl request)]
+    (let [[uuid table] (batch/add-workload-table! tx workflow-wdl request)]
       (->> (map make-workflow-record (range) (map :inputs items))
         (jdbc/insert-multi! tx table))
-      (workloads/load-workload-for-uuid tx uuid))))
+      (workloads/load-workload-for-id tx uuid))))
 
 (defn start-xx-workload! [tx {:keys [items id] :as workload}]
   (if (:started workload)

--- a/database/changelog.xml
+++ b/database/changelog.xml
@@ -19,6 +19,6 @@
     <include file="changesets/20200616_AllOfUsArraysEnum.xml"                    relativeToChangelogFile="true"/>
     <include file="changesets/20200616_AllOfUsArraysTable.xml"                   relativeToChangelogFile="true"/>
     <include file="changesets/20200827_ExternalWholeGenomeReprocessingTable.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/20201029_BatchWorkflow.xml"                        relativeToChangelogFile="true"/>
+    <include file="changesets/20201029_CromwellWorkflow.xml"                     relativeToChangelogFile="true"/>
     <include file="changesets/20201030_ExternalExomeReprocessing.xml"            relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/database/changelog.xml
+++ b/database/changelog.xml
@@ -19,5 +19,6 @@
     <include file="changesets/20200616_AllOfUsArraysEnum.xml"                    relativeToChangelogFile="true"/>
     <include file="changesets/20200616_AllOfUsArraysTable.xml"                   relativeToChangelogFile="true"/>
     <include file="changesets/20200827_ExternalWholeGenomeReprocessingTable.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/20200909_ExternalExomeReprocessing.xml"            relativeToChangelogFile="true"/>
+    <include file="changesets/20201029_BatchWorkflow.xml"                        relativeToChangelogFile="true"/>
+    <include file="changesets/20201030_ExternalExomeReprocessing.xml"            relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/database/changesets/20201029_BatchWorkflow.xml
+++ b/database/changesets/20201029_BatchWorkflow.xml
@@ -1,0 +1,28 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext
+                        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
+                        http://www.liquibase.org/xml/ns/dbchangelog
+                        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+    <changeSet author="ehigham@broadinstitute.org"
+               dbms="postgresql"
+               id="20201029"
+               logicalFilePath="20201029_BatchWorkload.xml"
+               runInTransaction="false">
+        <sql>
+            ALTER TABLE workload ALTER COLUMN input DROP NOT NULL
+        </sql>
+        <sql>
+            CREATE Type BatchWorkflow AS (
+                id         bigint,      -- primary key
+                status     text,        -- Cromwell workflow status
+                updated    timestamptz, -- status update time
+                uuid       text,        -- Cromwell workflow UUID
+                inputs     text         -- JSON string of non-default workflow inputs
+            )
+        </sql>
+    </changeSet>
+</databaseChangeLog>

--- a/database/changesets/20201029_CromwellWorkflow.xml
+++ b/database/changesets/20201029_CromwellWorkflow.xml
@@ -10,13 +10,13 @@
     <changeSet author="ehigham@broadinstitute.org"
                dbms="postgresql"
                id="20201029"
-               logicalFilePath="20201029_BatchWorkload.xml"
+               logicalFilePath="20201029_CromwellWorkload.xml"
                runInTransaction="false">
         <sql>
             ALTER TABLE workload ALTER COLUMN input DROP NOT NULL
         </sql>
         <sql>
-            CREATE Type BatchWorkflow AS (
+            CREATE Type CromwellWorkflow AS (
                 id         bigint,      -- primary key
                 status     text,        -- Cromwell workflow status
                 updated    timestamptz, -- status update time

--- a/database/changesets/20201030_ExternalExomeReprocessing.xml
+++ b/database/changesets/20201030_ExternalExomeReprocessing.xml
@@ -9,23 +9,11 @@
                         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
     <changeSet author="ehigham@broadinstitute.org"
                dbms="postgresql"
-               id="20200909"
-               logicalFilePath="20200909_ExternalExomeReprocessing.xml"
+               id="20201030"
+               logicalFilePath="20201030_ExternalExomeReprocessing.xml"
                runInTransaction="false">
         <sql>
             ALTER TYPE pipeline ADD VALUE 'ExternalExomeReprocessing'
-        </sql>
-        <sql>
-            ALTER TABLE workload ALTER COLUMN input DROP NOT NULL
-        </sql>
-        <sql>
-            CREATE Type ExternalExomeReprocessing AS (
-                id                          bigint,      -- primary key
-                status                      text,        -- Cromwell workflow status
-                updated                     timestamptz, -- status update time
-                uuid                        text,        -- Cromwell workflow UUID
-                inputs                      text         -- JSON string of non-default workflow inputs
-            )
         </sql>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
### Purpose
The table I wrote for external exome reprocessing is actually generic across the set of batch workloads in cromwell.
I intend to re-use this when extending the WGS module.

### Changes
Note that the database changes are breaking. Since the exomes module is not released yet, however, I don't think this is an issue.
I could have unified the all/create-workload-table and the batch version but decided against otherwise it would have caused a lot of merge conflicts for jack. I'll tidy this up later.