### PR TITLE
disable automatic release action

### DIFF
--- a/.github/workflows/release_latest_version.yml
+++ b/.github/workflows/release_latest_version.yml
@@ -1,11 +1,12 @@
 name: Release Latest Version
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - version
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: branch, tag or SHA to checkout.
+        required: false
+        default: 'master'
 
 jobs:
   build:

--- a/.github/workflows/release_latest_version.yml
+++ b/.github/workflows/release_latest_version.yml
@@ -30,7 +30,10 @@ jobs:
       MODULES: api ui
 
     steps:
-      - uses: actions/checkout@v2
+      - name: prepare sources
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.ref }}
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
### Purpose
The purpose of this change is so that we can store in `version` the version of the next release.
This enables backwards compatibility testing where previously, it was impossible to know if the code had already been released was released or not (i.e. `version` contained the last released version)

I've switched the github action to use a manual trigger.