### PR TITLE
[GH-1050] disable `wfl.integration.datarepo-test/delivery`

### DIFF
--- a/api/test/wfl/integration/datarepo_test.clj
+++ b/api/test/wfl/integration/datarepo_test.clj
@@ -14,6 +14,7 @@
 (def dataset "f359303e-15d7-4cd8-a4c7-c50499c90252")
 (def profile "390e7a85-d47f-4531-b612-165fc977d3bd")
 
+;; rr: GH-1048
 (deftest ^:excluded delivery
   (with-temporary-gcs-folder uri
     (testing "delivery succeeds"

--- a/api/test/wfl/integration/datarepo_test.clj
+++ b/api/test/wfl/integration/datarepo_test.clj
@@ -14,7 +14,7 @@
 (def dataset "f359303e-15d7-4cd8-a4c7-c50499c90252")
 (def profile "390e7a85-d47f-4531-b612-165fc977d3bd")
 
-(deftest delivery
+(deftest ^:excluded delivery
   (with-temporary-gcs-folder uri
     (testing "delivery succeeds"
       (let [[bucket object] (gcs/parse-gs-url uri)

--- a/api/tests.edn
+++ b/api/tests.edn
@@ -1,14 +1,16 @@
 #kaocha/v1
     {:tests [{:id           :integration
-              :skip-meta    [:exclude]
+              :skip-meta    [:excluded]
               :source-paths ["../derived/api/src" "src"]
               :test-paths   ["test"]
               :ns-patterns  ["wfl\\.integration\\..*-test$"]}
              {:id           :unit
+              :skip-meta    [:excluded]
               :source-paths ["../derived/api/src" "src"]
               :test-paths   ["test"]
               :ns-patterns  ["wfl\\.unit\\..*-test$"]}
              {:id           :system
+              :skip-meta    [:excluded]
               :source-paths ["../derived/api/src" "src"]
               :test-paths   ["test"]
               :ns-patterns  ["wfl\\.system\\..*-test$"]}]


### PR DESCRIPTION
### Purpose
Really this could be automated... Disable failing test until https://broadinstitute.atlassian.net/browse/GH-1048 is complete
