### PR TITLE
[GH-1044] Set default maxRetries workflow option

### DIFF
--- a/api/src/wfl/module/aou.clj
+++ b/api/src/wfl/module/aou.clj
@@ -106,11 +106,11 @@
 
 ;; visible for testing
 (def default-options
-  {; TODO: add :default_runtime_attributes {:maxRetries 3} here
-   :use_relative_output_paths  true
+  {:use_relative_output_paths  true
    :read_from_cache            true
    :write_to_cache             true
-   :default_runtime_attributes {:zones "us-central1-a us-central1-b us-central1-c us-central1-f"}})
+   :default_runtime_attributes {:zones "us-central1-a us-central1-b us-central1-c us-central1-f"
+                                :maxRetries 1}})
 
 (defn make-labels
   "Return labels for aou arrays pipeline from PER-SAMPLE-INPUTS and OTHER-LABELS."

--- a/api/src/wfl/util.clj
+++ b/api/src/wfl/util.clj
@@ -312,7 +312,8 @@ vault.client.http/http-client                               ; Keep :clint eastwo
            :write_to_cache  true
            :default_runtime_attributes
                             {:docker (str/join "/" [gcr repo image])
-                             :zones  google-cloud-zones}}
+                             :zones  google-cloud-zones
+                             :maxRetries 1}}
         (maybe :monitoring_script cromwell)
         (maybe :noAddress noAddress)))))
 


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

Ticket: https://broadinstitute.atlassian.net/browse/GH-1044

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

Set the `maxRetries` workflow option to 1 by default to automatically retry transient failures in Cromwell: https://cromwell.readthedocs.io/en/stable/RuntimeAttributes/#maxretries. 

This includes the `aou`, `wgs`, `xx` and `copyfile` modules.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
