### PR TITLE
[GH-1023] Support querying workloads by project name

### DIFF
--- a/api/src/wfl/api/handlers.clj
+++ b/api/src/wfl/api/handlers.clj
@@ -78,7 +78,9 @@
         (mapv (partial go! tx)
           (if-let [uuid (-> request :parameters :query :uuid)]
             [(workloads/load-workload-for-uuid tx uuid)]
-            (workloads/load-workloads tx)))))))
+            (if-let [project (-> request :parameters :query :project)]
+              [(workloads/load-workload-for-project tx project)]
+              (workloads/load-workloads tx))))))))
 
 (defn post-start
   "Start the workload with UUID in REQUEST."
@@ -107,3 +109,7 @@
         (assoc workload-request :creator)
         (workloads/execute-workload! tx)
         succeed))))
+
+(comment
+
+  )

--- a/api/src/wfl/api/handlers.clj
+++ b/api/src/wfl/api/handlers.clj
@@ -109,7 +109,3 @@
         (assoc workload-request :creator)
         (workloads/execute-workload! tx)
         succeed))))
-
-(comment
-
-  )

--- a/api/src/wfl/api/handlers.clj
+++ b/api/src/wfl/api/handlers.clj
@@ -65,7 +65,7 @@
           (assoc body :creator email))))))
 
 (defn get-workload!
-  "List all workloads or the workload with UUID in REQUEST."
+  "List all workloads or the workload(s) with UUID or PROJECT in REQUEST."
   [request]
   (letfn [(go! [tx {:keys [uuid] :as workload}]
             (if (:finished workload)
@@ -77,10 +77,16 @@
       (succeed
         (mapv (partial go! tx)
           (if-let [uuid (-> request :parameters :query :uuid)]
-            [(workloads/load-workload-for-uuid tx uuid)]
+            (do
+              (logr/infof "getting workload by uuid %s" uuid)
+              [(workloads/load-workload-for-uuid tx uuid)])
             (if-let [project (-> request :parameters :query :project)]
-              [(workloads/load-workload-for-project tx project)]
-              (workloads/load-workloads tx))))))))
+              (do
+                (logr/infof "getting workloads by project %s" project)
+                (workloads/load-workloads-with-project tx project))
+              (do
+                (logr/infof "getting all workloads")
+                (workloads/load-workloads tx)))))))))
 
 (defn post-start
   "Start the workload with UUID in REQUEST."

--- a/api/src/wfl/api/routes.clj
+++ b/api/src/wfl/api/routes.clj
@@ -68,7 +68,7 @@
             :handler    handlers/append-to-aou-workload}}]
    ["/api/v1/workload"
     {:get  {:summary    "Get the workloads."
-            :parameters {:query ::spec/uuid-query}
+            :parameters {:query ::spec/workload-query}
             :responses  {200 {:body ::spec/workload-responses}}
             :handler    handlers/get-workload!}}]
    ["/api/v1/create"

--- a/api/src/wfl/api/spec.clj
+++ b/api/src/wfl/api/spec.clj
@@ -27,11 +27,12 @@
 (s/def ::updated inst?)
 (s/def ::uuid (s/and string? uuid-string?))
 (s/def ::uuid-kv (s/keys :req-un [::uuid]))
-(s/def ::uuid-query (s/keys :opt-un [::uuid]))
 (s/def ::version string?)
 (s/def ::wdl string?)
 (s/def ::options map?)
 (s/def ::common map?)
+(s/def ::workload-query (s/and (s/keys :opt-un [::uuid ::project])
+                               #(not (and (:uuid %) (:project %)))))
 (s/def ::workload-request (s/keys :opt-un [::common
                                            ::input
                                            ::items]

--- a/api/src/wfl/api/workloads.clj
+++ b/api/src/wfl/api/workloads.clj
@@ -59,6 +59,16 @@
                 :type  ::workload-not-found})))
     (try-load-workload-impl tx (first workloads))))
 
+(defn load-workload-for-project
+  "Use transaction `tx` to load `workload` with `project`."
+  [tx project]
+  (let [workloads (jdbc/query tx ["SELECT * FROM workload WHERE project = ?" project])]
+    (when (empty? workloads)
+      (throw (ex-info "No workload found matching project"
+                      {:cause {:project project}
+                       :type  ::workload-not-found})))
+    (try-load-workload-impl tx (first workloads))))
+
 (defn load-workloads
   "Use transaction TX to load all known `workloads`"
   [tx]

--- a/api/src/wfl/api/workloads.clj
+++ b/api/src/wfl/api/workloads.clj
@@ -59,15 +59,11 @@
                 :type  ::workload-not-found})))
     (try-load-workload-impl tx (first workloads))))
 
-(defn load-workload-for-project
-  "Use transaction `tx` to load `workload` with `project`."
+(defn load-workloads-with-project
+  "Use transaction `tx` to load `workload`(s) with `project`."
   [tx project]
-  (let [workloads (jdbc/query tx ["SELECT * FROM workload WHERE project = ?" project])]
-    (when (empty? workloads)
-      (throw (ex-info "No workload found matching project"
-                      {:cause {:project project}
-                       :type  ::workload-not-found})))
-    (try-load-workload-impl tx (first workloads))))
+  (let [do-load   (partial load-workload-impl tx)]
+    (map do-load (jdbc/query tx ["SELECT * FROM workload WHERE project = ?" project]))))
 
 (defn load-workloads
   "Use transaction TX to load all known `workloads`"

--- a/api/src/wfl/util.clj
+++ b/api/src/wfl/util.clj
@@ -317,9 +317,6 @@ vault.client.http/http-client                               ; Keep :clint eastwo
         (maybe :monitoring_script cromwell)
         (maybe :noAddress noAddress)))))
 
-(comment
-  (make-options :gotc-dev))
-
 (defn is-non-negative!
   "Throw unless integer value of INT-STRING is non-negative."
   [int-string]

--- a/api/test/wfl/integration/modules/copyfile_test.clj
+++ b/api/test/wfl/integration/modules/copyfile_test.clj
@@ -18,7 +18,7 @@
   (-> (workloads/copyfile-workload-request src dst)
     (assoc :creator (:email @endpoints/userinfo))))
 
-(defn ^:private old-create-wgs-workload! []
+(defn ^:private old-create-copyfile-workload! []
   (let [request (make-copyfile-workload-request "gs://fake/input" "gs://fake/output")]
     (jdbc/with-db-transaction [tx (fixtures/testing-db-config)]
       (let [[id table] (all/add-workload-table! tx copyfile/workflow-wdl request)
@@ -28,7 +28,7 @@
         id))))
 
 (deftest test-loading-old-copyfile-workload
-  (let [id       (old-create-wgs-workload!)
+  (let [id       (old-create-copyfile-workload!)
         workload (workloads/load-workload-for-id id)]
     (is (= id (:id workload)))
     (is (= copyfile/pipeline (:pipeline workload)))))

--- a/api/test/wfl/integration/workloads_test.clj
+++ b/api/test/wfl/integration/workloads_test.clj
@@ -1,0 +1,31 @@
+(ns wfl.integration.workloads-test
+  (:require [clojure.test :refer [deftest testing is] :as clj-test]
+            [clojure.test :refer :all]
+            [wfl.jdbc :as jdbc]
+            [wfl.module.all :as all]
+            [wfl.module.copyfile :as copyfile]
+            [wfl.tools.endpoints :as endpoints]
+            [wfl.tools.fixtures :as fixtures]
+            [wfl.tools.workloads :as workloads]))
+
+(clj-test/use-fixtures :once fixtures/temporary-postgresql-database)
+
+(defn ^:private make-copyfile-workload-request
+  [src dst]
+  (-> (workloads/copyfile-workload-request src dst)
+      (assoc :creator (:email @endpoints/userinfo))))
+
+(defn ^:private old-create-copyfile-workload! []
+  (let [request (make-copyfile-workload-request "gs://fake/input" "gs://fake/output")]
+    (jdbc/with-db-transaction [tx (fixtures/testing-db-config)]
+      (let [[id table] (all/add-workload-table! tx copyfile/workflow-wdl request)
+            add-id (fn [m id] (assoc (:inputs m) :id id))]
+        (jdbc/insert-multi! tx table (map add-id (:items request) (range)))
+        (jdbc/update! tx :workload {:version "0.3.8"} ["id = ?" id])
+        table))))
+
+(deftest test-loading-old-copyfile-workload-with-project
+  (let [project (:project (old-create-copyfile-workload!))
+        workloads (workloads/load-workloads-with-project project)]
+    (is (every? #(= copyfile/pipeline (:pipeline %)) workloads))
+    (is (every? #(= project (:project %)) workloads))))

--- a/api/test/wfl/tools/workloads.clj
+++ b/api/test/wfl/tools/workloads.clj
@@ -139,9 +139,13 @@
   (jdbc/with-db-transaction [tx (fixtures/testing-db-config)]
     (wfl.api.workloads/load-workload-for-id tx id)))
 
+;; `doall` is required here for testing otherwise the moment test uses
+;; the result and tries to force realizing, the db tx is already closed
+;;
 (defn load-workloads-with-project [project]
   (jdbc/with-db-transaction [tx (fixtures/testing-db-config)]
-    (wfl.api.workloads/load-workloads-with-project tx project)))
+    (doall
+      (wfl.api.workloads/load-workloads-with-project tx project))))
 
 (defn append-to-workload! [samples workload]
   (jdbc/with-db-transaction [tx (fixtures/testing-db-config)]

--- a/api/test/wfl/tools/workloads.clj
+++ b/api/test/wfl/tools/workloads.clj
@@ -139,6 +139,10 @@
   (jdbc/with-db-transaction [tx (fixtures/testing-db-config)]
     (wfl.api.workloads/load-workload-for-id tx id)))
 
+(defn load-workloads-with-project [project]
+  (jdbc/with-db-transaction [tx (fixtures/testing-db-config)]
+    (wfl.api.workloads/load-workloads-with-project tx project)))
+
 (defn append-to-workload! [samples workload]
   (jdbc/with-db-transaction [tx (fixtures/testing-db-config)]
     (aou/append-to-workload! tx samples workload)))

--- a/api/test/wfl/unit/spec_test.clj
+++ b/api/test/wfl/unit/spec_test.clj
@@ -23,3 +23,19 @@
             mismatched-requests (map #(walk/postwalk-replace {:input_cram :input_bam} %)
                                      requests)]
         (run! invalid? mismatched-requests)))))
+
+(deftest workload-query-spec-test
+  (letfn [(invalid? [req] (is (not (s/valid? ::spec/workload-query req))))
+          (valid? [req] (is (s/valid? ::spec/workload-query req)))]
+    (let [uuid (str (UUID/randomUUID))
+          project "bogus-project"]
+      (testing "Workload UUID and project cannot be specified together"
+        (let [request {:uuid uuid :project project}]
+          (run! invalid? request)))
+      (testing "Workload UUID and project can be omitted together"
+        (let [request {}]
+          (run! valid? request)))
+      (testing "Either workload UUID or project can be specified"
+        (let [uuid-request {:uuid uuid}
+              proj-request {:project project}]
+          (run! valid? [uuid-request proj-request]))))))

--- a/docs/md/dev-wgs.md
+++ b/docs/md/dev-wgs.md
@@ -267,3 +267,56 @@ Response:
 The "workflows" field lists out each Cromwell workflow that was started, and includes their
 status information. It is also possible to use the Job Manager to check workflow progress and
 easily see information about any workflow failures.
+
+### Query Workload with project: `/api/v1/workload?project=<project>`
+
+Queries the WFL database for workloads. Specify the project name to query for a list of specific workload(s).
+
+Request:
+
+```bash
+curl --location --request GET 'https://dev-wfl.gotc-dev.broadinstitute.org/api/v1/workload?project=wgs-dev' \
+--header 'Authorization: Bearer '$(gcloud auth print-access-token)
+```
+
+Response:
+
+```json
+[{
+  "creator": "username",
+  "pipeline": "ExternalWholeGenomeReprocessing",
+  "cromwell": "https://cromwell-gotc-auth.gotc-dev.broadinstitute.org/",
+  "release": "ExternalWholeGenomeReprocessing_v1.0",
+  "created": "2020-08-27T16:26:59Z",
+  "output": "gs://broad-gotc-dev-zero-test/wgs-test-output",
+  "workflows": [
+    {
+      "id": 1,
+      "updated": "2020-10-05T16:15:32Z",
+      "uuid": "2c543b29-2db9-4643-b81b-b16a0654c5cc",
+      "inputs": {
+        "input_cram": "develop/20k/NA12878_PLUMBING.cram",
+        "sample_name": "TestSample1234"
+      }
+    }
+  ],
+  "project": "wgs-dev",
+  "id": 6,
+  "commit": "d2fc38c61c62c44f4fd4d24bdee3121138e6c09e",
+  "wdl": "pipelines/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.wdl",
+  "input": "gs://broad-gotc-test-storage/single_sample/plumbing/truth",
+  "uuid": "813e3c38-9c11-4410-9888-435569d91d1d",
+  "items": "ExternalWholeGenomeReprocessing_000000006",
+  "version": "0.1.7"
+}]
+```
+
+The "workflows" field lists out each Cromwell workflow that was started, and
+includes their status information. It is also possible to use the Job Manager
+to check workflow progress and easily see information about any workflow
+failures.
+
+!!! warning "Note"
+    `project` and `uuid` are optional path parameters to the `/api/v1/workload` endpoint, 
+    hitting this endpoint without them will return all workloads. However, they cannot be specified
+    together.

--- a/docs/md/external-exome-reprocessing.md
+++ b/docs/md/external-exome-reprocessing.md
@@ -240,52 +240,15 @@ Response:
      "updated" : "YYYY-MM-DDTHH:MM:SSZ",
      "uuid" : "bb0d93e3-1a6a-4816-82d9-713fa58fb235",
      "inputs" : {
-       "cram_ref_fasta" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",
-       "scatter_settings" : {
-         "haplotype_scatter_count" : 50,
-         "break_bands_at_multiples_of" : 0
-       },
-       "input_cram" : "gs://path/to/a.cram",
-       "destination_cloud_path" : "gs://broad-gotc-dev-wfl-ptc-test-outputs/xx-test-output/to",
-       "sample_name" : "a",
-       "bait_set_name" : "whole_exome_illumina_coding_v1",
-       "references" : {
-         "calling_interval_list" : "gs://gcp-public-data--broad-references/hg38/v0/exome_calling_regions.v1.interval_list",
-         "contamination_sites_bed" : "gs://gcp-public-data--broad-references/hg38/v0/contamination-resources/1000g/1000g.phase3.100k.b38.vcf.gz.dat.bed",
-         "dbsnp_vcf_index" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf.idx",
-         "haplotype_database_file" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.haplotype_database.txt",
-         "known_indels_sites_indices" : [ "gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi", "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz.tbi" ],
-         "evaluation_interval_list" : "gs://gcp-public-data--broad-references/hg38/v0/exome_evaluation_regions.v1.interval_list",
-         "contamination_sites_mu" : "gs://gcp-public-data--broad-references/hg38/v0/contamination-resources/1000g/1000g.phase3.100k.b38.vcf.gz.dat.mu",
-         "dbsnp_vcf" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf",
-         "known_indels_sites_vcfs" : [ "gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz", "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz" ],
-         "reference_fasta" : {
-           "ref_pac" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.pac",
-           "ref_bwt" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.bwt",
-           "ref_dict" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict",
-           "ref_ann" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.ann",
-           "ref_fasta_index" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai",
-           "ref_alt" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.alt",
-           "ref_fasta" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",
-           "ref_sa" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.sa",
-           "ref_amb" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.amb"
-         },
-         "contamination_sites_ud" : "gs://gcp-public-data--broad-references/hg38/v0/contamination-resources/1000g/1000g.phase3.100k.b38.vcf.gz.dat.UD"
-       },
-       "cram_ref_fasta_index" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai",
-       "papi_settings" : {
-         "agg_preemptible_tries" : 3,
-         "preemptible_tries" : 3
-       },
-       "base_file_name" : "a.cram",
-       "bait_interval_list" : "gs://gcp-public-data--broad-references/hg38/v0/HybSelOligos/whole_exome_illumina_coding_v1/whole_exome_illumina_coding_v1.Homo_sapiens_assembly38.baits.interval_list",
-       "final_gvcf_base_name" : "a.cram",
-       "target_interval_list" : "gs://gcp-public-data--broad-references/hg38/v0/HybSelOligos/whole_exome_illumina_coding_v1/whole_exome_illumina_coding_v1.Homo_sapiens_assembly38.targets.interval_list",
-       "unmapped_bam_suffix" : ".unmapped.bam"
+       "input_cram" : "gs://broad-gotc-dev-wfl-ptc-test-inputs/single_sample/plumbing/truth/develop/20k/NA12878_PLUMBING.cram",
+       "destination_cloud_path" : "gs://broad-gotc-dev-wfl-ptc-test-outputs/xx-test-output/8600be1a-48df-4a51-bdba-0044e0af8d33/single_sample/plumbing/truth/develop/20k",
+       "sample_name" : "NA12878_PLUMBING",
+       "base_file_name" : "NA12878_PLUMBING.cram",
+       "final_gvcf_base_name" : "NA12878_PLUMBING.cram"
      }
    } ],
    "commit" : "commit-ish",
-   "project" : "PO-1234",
+   "project" : "Example Project",
    "uuid" : "1337254e-f7d8-438d-a2b3-a74b199fee3c",
    "wdl" : "pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl",
    "version" : "X.Y.Z"
@@ -298,7 +261,7 @@ to check workflow progress and easily see information about any workflow
 failures.
 
 !!! warning "Note"
-    `project` and `uuid` are optional path parameters to the `/api/v1/workload` endpoint, 
+    `project` and `uuid` are optional path parameters to the `/api/v1/workload` endpoint,
     hitting this endpoint without them will return all workloads. However, they cannot be specified
     together.
 

--- a/docs/md/external-exome-reprocessing.md
+++ b/docs/md/external-exome-reprocessing.md
@@ -361,6 +361,95 @@ includes their status information. It is also possible to use the Job Manager
 to check workflow progress and easily see information about any workflow
 failures.
 
+### Query Workload with project: `/api/v1/workload?project=<project>`
+
+Queries the WFL database for workloads. Specify the project name to query for a list of specific workload(s).
+
+Request:
+
+```bash
+curl -X GET 'https://dev-wfl.gotc-dev.broadinstitute.org/api/v1/workload?project=PO-1234' \
+  -H "Authorization: Bearer $(gcloud auth print-access-token)"
+```
+
+Response:
+
+```json
+[{
+   "creator" : "user@domain",
+   "pipeline" : "ExternalExomeReprocessing",
+   "cromwell" : "https://cromwell-gotc-auth.gotc-dev.broadinstitute.org",
+   "release" : "ExternalExomeReprocessing_vX.Y.Z",
+   "created" : "YYYY-MM-DDTHH:MM:SSZ",
+   "started" : "YYYY-MM-DDTHH:MM:SSZ",
+   "output" : "gs://broad-gotc-dev-wfl-ptc-test-outputs/xx-test-output/",
+   "workflows" : [ {
+     "status" : "Submitted",
+     "updated" : "YYYY-MM-DDTHH:MM:SSZ",
+     "uuid" : "bb0d93e3-1a6a-4816-82d9-713fa58fb235",
+     "inputs" : {
+       "cram_ref_fasta" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",
+       "scatter_settings" : {
+         "haplotype_scatter_count" : 50,
+         "break_bands_at_multiples_of" : 0
+       },
+       "input_cram" : "gs://path/to/a.cram",
+       "destination_cloud_path" : "gs://broad-gotc-dev-wfl-ptc-test-outputs/xx-test-output/to",
+       "sample_name" : "a",
+       "bait_set_name" : "whole_exome_illumina_coding_v1",
+       "references" : {
+         "calling_interval_list" : "gs://gcp-public-data--broad-references/hg38/v0/exome_calling_regions.v1.interval_list",
+         "contamination_sites_bed" : "gs://gcp-public-data--broad-references/hg38/v0/contamination-resources/1000g/1000g.phase3.100k.b38.vcf.gz.dat.bed",
+         "dbsnp_vcf_index" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf.idx",
+         "haplotype_database_file" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.haplotype_database.txt",
+         "known_indels_sites_indices" : [ "gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi", "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz.tbi" ],
+         "evaluation_interval_list" : "gs://gcp-public-data--broad-references/hg38/v0/exome_evaluation_regions.v1.interval_list",
+         "contamination_sites_mu" : "gs://gcp-public-data--broad-references/hg38/v0/contamination-resources/1000g/1000g.phase3.100k.b38.vcf.gz.dat.mu",
+         "dbsnp_vcf" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf",
+         "known_indels_sites_vcfs" : [ "gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz", "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz" ],
+         "reference_fasta" : {
+           "ref_pac" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.pac",
+           "ref_bwt" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.bwt",
+           "ref_dict" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict",
+           "ref_ann" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.ann",
+           "ref_fasta_index" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai",
+           "ref_alt" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.alt",
+           "ref_fasta" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",
+           "ref_sa" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.sa",
+           "ref_amb" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.amb"
+         },
+         "contamination_sites_ud" : "gs://gcp-public-data--broad-references/hg38/v0/contamination-resources/1000g/1000g.phase3.100k.b38.vcf.gz.dat.UD"
+       },
+       "cram_ref_fasta_index" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai",
+       "papi_settings" : {
+         "agg_preemptible_tries" : 3,
+         "preemptible_tries" : 3
+       },
+       "base_file_name" : "a.cram",
+       "bait_interval_list" : "gs://gcp-public-data--broad-references/hg38/v0/HybSelOligos/whole_exome_illumina_coding_v1/whole_exome_illumina_coding_v1.Homo_sapiens_assembly38.baits.interval_list",
+       "final_gvcf_base_name" : "a.cram",
+       "target_interval_list" : "gs://gcp-public-data--broad-references/hg38/v0/HybSelOligos/whole_exome_illumina_coding_v1/whole_exome_illumina_coding_v1.Homo_sapiens_assembly38.targets.interval_list",
+       "unmapped_bam_suffix" : ".unmapped.bam"
+     }
+   } ],
+   "commit" : "commit-ish",
+   "project" : "PO-1234",
+   "uuid" : "1337254e-f7d8-438d-a2b3-a74b199fee3c",
+   "wdl" : "pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl",
+   "version" : "X.Y.Z"
+ }]
+```
+
+The "workflows" field lists out each Cromwell workflow that was started, and
+includes their status information. It is also possible to use the Job Manager
+to check workflow progress and easily see information about any workflow
+failures.
+
+!!! warning "Note"
+    `project` and `uuid` are optional path parameters to the `/api/v1/workload` endpoint, 
+    hitting this endpoint without them will return all workloads. However, they cannot be specified
+    together.
+
 ## A1 External Exome Workload-Request JSON Spec
 ```json
 {

--- a/docs/md/external-exome-reprocessing.md
+++ b/docs/md/external-exome-reprocessing.md
@@ -28,11 +28,11 @@ curl -X POST 'https://dev-wfl.gotc-dev.broadinstitute.org/api/v1/create' \
         "cromwell": "https://cromwell-gotc-auth.gotc-dev.broadinstitute.org",
         "output": "gs://broad-gotc-dev-wfl-ptc-test-outputs/xx-test-output/",
         "pipeline": "ExternalExomeReprocessing",
-        "project": "PO-1234",
+        "project": "Example Project",
         "items": [{
-            "inputs": {
-                "input_cram": "gs://path/to/a.cram"
-            }
+          "inputs": {
+            "input_cram" : "gs://broad-gotc-dev-wfl-ptc-test-inputs/single_sample/plumbing/truth/develop/20k/NA12878_PLUMBING.cram"
+          }
         }]
       }'
 ```
@@ -48,52 +48,15 @@ Response:
   "output" : "gs://broad-gotc-dev-wfl-ptc-test-outputs/xx-test-output/",
   "workflows" : [ {
     "inputs" : {
-      "cram_ref_fasta" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",
-      "scatter_settings" : {
-        "haplotype_scatter_count" : 50,
-        "break_bands_at_multiples_of" : 0
-      },
-      "input_cram" : "gs://path/to/a.cram",
-      "destination_cloud_path" : "gs://broad-gotc-dev-wfl-ptc-test-outputs/xx-test-output/to",
-      "sample_name" : "a",
-      "bait_set_name" : "whole_exome_illumina_coding_v1",
-      "references" : {
-        "calling_interval_list" : "gs://gcp-public-data--broad-references/hg38/v0/exome_calling_regions.v1.interval_list",
-        "contamination_sites_bed" : "gs://gcp-public-data--broad-references/hg38/v0/contamination-resources/1000g/1000g.phase3.100k.b38.vcf.gz.dat.bed",
-        "dbsnp_vcf_index" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf.idx",
-        "haplotype_database_file" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.haplotype_database.txt",
-        "known_indels_sites_indices" : [ "gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi", "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz.tbi" ],
-        "evaluation_interval_list" : "gs://gcp-public-data--broad-references/hg38/v0/exome_evaluation_regions.v1.interval_list",
-        "contamination_sites_mu" : "gs://gcp-public-data--broad-references/hg38/v0/contamination-resources/1000g/1000g.phase3.100k.b38.vcf.gz.dat.mu",
-        "dbsnp_vcf" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf",
-        "known_indels_sites_vcfs" : [ "gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz", "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz" ],
-        "reference_fasta" : {
-          "ref_pac" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.pac",
-          "ref_bwt" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.bwt",
-          "ref_dict" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict",
-          "ref_ann" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.ann",
-          "ref_fasta_index" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai",
-          "ref_alt" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.alt",
-          "ref_fasta" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",
-          "ref_sa" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.sa",
-          "ref_amb" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.amb"
-        },
-        "contamination_sites_ud" : "gs://gcp-public-data--broad-references/hg38/v0/contamination-resources/1000g/1000g.phase3.100k.b38.vcf.gz.dat.UD"
-      },
-      "cram_ref_fasta_index" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai",
-      "papi_settings" : {
-        "agg_preemptible_tries" : 3,
-        "preemptible_tries" : 3
-      },
-      "base_file_name" : "a.cram",
-      "bait_interval_list" : "gs://gcp-public-data--broad-references/hg38/v0/HybSelOligos/whole_exome_illumina_coding_v1/whole_exome_illumina_coding_v1.Homo_sapiens_assembly38.baits.interval_list",
-      "final_gvcf_base_name" : "a.cram",
-      "target_interval_list" : "gs://gcp-public-data--broad-references/hg38/v0/HybSelOligos/whole_exome_illumina_coding_v1/whole_exome_illumina_coding_v1.Homo_sapiens_assembly38.targets.interval_list",
-      "unmapped_bam_suffix" : ".unmapped.bam"
+      "input_cram" : "gs://broad-gotc-dev-wfl-ptc-test-inputs/single_sample/plumbing/truth/develop/20k/NA12878_PLUMBING.cram",
+      "destination_cloud_path" : "gs://broad-gotc-dev-wfl-ptc-test-outputs/xx-test-output/8600be1a-48df-4a51-bdba-0044e0af8d33/single_sample/plumbing/truth/develop/20k",
+      "sample_name" : "NA12878_PLUMBING",
+      "base_file_name" : "NA12878_PLUMBING.cram",
+      "final_gvcf_base_name" : "NA12878_PLUMBING.cram"
     }
   } ],
   "commit" : "commit-ish",
-  "project" : "PO-1234",
+  "project" : "Example Project",
   "uuid" : "1337254e-f7d8-438d-a2b3-a74b199fee3c",
   "wdl" : "pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl",
   "version" : "X.Y.Z"
@@ -134,52 +97,15 @@ Response:
      "updated" : "YYYY-MM-DDTHH:MM:SSZ",
      "uuid" : "bb0d93e3-1a6a-4816-82d9-713fa58fb235",
      "inputs" : {
-       "cram_ref_fasta" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",
-       "scatter_settings" : {
-         "haplotype_scatter_count" : 50,
-         "break_bands_at_multiples_of" : 0
-       },
-       "input_cram" : "gs://path/to/a.cram",
-       "destination_cloud_path" : "gs://broad-gotc-dev-wfl-ptc-test-outputs/xx-test-output/to",
-       "sample_name" : "a",
-       "bait_set_name" : "whole_exome_illumina_coding_v1",
-       "references" : {
-         "calling_interval_list" : "gs://gcp-public-data--broad-references/hg38/v0/exome_calling_regions.v1.interval_list",
-         "contamination_sites_bed" : "gs://gcp-public-data--broad-references/hg38/v0/contamination-resources/1000g/1000g.phase3.100k.b38.vcf.gz.dat.bed",
-         "dbsnp_vcf_index" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf.idx",
-         "haplotype_database_file" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.haplotype_database.txt",
-         "known_indels_sites_indices" : [ "gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi", "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz.tbi" ],
-         "evaluation_interval_list" : "gs://gcp-public-data--broad-references/hg38/v0/exome_evaluation_regions.v1.interval_list",
-         "contamination_sites_mu" : "gs://gcp-public-data--broad-references/hg38/v0/contamination-resources/1000g/1000g.phase3.100k.b38.vcf.gz.dat.mu",
-         "dbsnp_vcf" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf",
-         "known_indels_sites_vcfs" : [ "gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz", "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz" ],
-         "reference_fasta" : {
-           "ref_pac" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.pac",
-           "ref_bwt" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.bwt",
-           "ref_dict" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict",
-           "ref_ann" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.ann",
-           "ref_fasta_index" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai",
-           "ref_alt" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.alt",
-           "ref_fasta" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",
-           "ref_sa" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.sa",
-           "ref_amb" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.amb"
-         },
-         "contamination_sites_ud" : "gs://gcp-public-data--broad-references/hg38/v0/contamination-resources/1000g/1000g.phase3.100k.b38.vcf.gz.dat.UD"
-       },
-       "cram_ref_fasta_index" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai",
-       "papi_settings" : {
-         "agg_preemptible_tries" : 3,
-         "preemptible_tries" : 3
-       },
-       "base_file_name" : "a.cram",
-       "bait_interval_list" : "gs://gcp-public-data--broad-references/hg38/v0/HybSelOligos/whole_exome_illumina_coding_v1/whole_exome_illumina_coding_v1.Homo_sapiens_assembly38.baits.interval_list",
-       "final_gvcf_base_name" : "a.cram",
-       "target_interval_list" : "gs://gcp-public-data--broad-references/hg38/v0/HybSelOligos/whole_exome_illumina_coding_v1/whole_exome_illumina_coding_v1.Homo_sapiens_assembly38.targets.interval_list",
-       "unmapped_bam_suffix" : ".unmapped.bam"
+       "input_cram" : "gs://broad-gotc-dev-wfl-ptc-test-inputs/single_sample/plumbing/truth/develop/20k/NA12878_PLUMBING.cram",
+       "destination_cloud_path" : "gs://broad-gotc-dev-wfl-ptc-test-outputs/xx-test-output/8600be1a-48df-4a51-bdba-0044e0af8d33/single_sample/plumbing/truth/develop/20k",
+       "sample_name" : "NA12878_PLUMBING",
+       "base_file_name" : "NA12878_PLUMBING.cram",
+       "final_gvcf_base_name" : "NA12878_PLUMBING.cram"
      }
    } ],
    "commit" : "commit-ish",
-   "project" : "PO-1234",
+   "project" : "Example Project",
    "uuid" : "1337254e-f7d8-438d-a2b3-a74b199fee3c",
    "wdl" : "pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl",
    "version" : "X.Y.Z"
@@ -200,11 +126,11 @@ curl -X POST 'https://dev-wfl.gotc-dev.broadinstitute.org/api/v1/exec' \
         "cromwell": "https://cromwell-gotc-auth.gotc-dev.broadinstitute.org",
         "output": "gs://broad-gotc-dev-wfl-ptc-test-outputs/xx-test-output/",
         "pipeline": "ExternalExomeReprocessing",
-        "project": "PO-1234",
+        "project": "Example Project",
         "items": [{
-            "inputs": {
-                "input_cram": "gs://path/to/a.cram"
-            }
+          "inputs" : {
+            "input_cram" : "gs://broad-gotc-dev-wfl-ptc-test-inputs/single_sample/plumbing/truth/develop/20k/NA12878_PLUMBING.cram",
+          }
         }]
       }'
 ```
@@ -225,52 +151,15 @@ Response:
      "updated" : "YYYY-MM-DDTHH:MM:SSZ",
      "uuid" : "bb0d93e3-1a6a-4816-82d9-713fa58fb235",
      "inputs" : {
-       "cram_ref_fasta" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",
-       "scatter_settings" : {
-         "haplotype_scatter_count" : 50,
-         "break_bands_at_multiples_of" : 0
-       },
-       "input_cram" : "gs://path/to/a.cram",
-       "destination_cloud_path" : "gs://broad-gotc-dev-wfl-ptc-test-outputs/xx-test-output/to",
-       "sample_name" : "a",
-       "bait_set_name" : "whole_exome_illumina_coding_v1",
-       "references" : {
-         "calling_interval_list" : "gs://gcp-public-data--broad-references/hg38/v0/exome_calling_regions.v1.interval_list",
-         "contamination_sites_bed" : "gs://gcp-public-data--broad-references/hg38/v0/contamination-resources/1000g/1000g.phase3.100k.b38.vcf.gz.dat.bed",
-         "dbsnp_vcf_index" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf.idx",
-         "haplotype_database_file" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.haplotype_database.txt",
-         "known_indels_sites_indices" : [ "gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi", "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz.tbi" ],
-         "evaluation_interval_list" : "gs://gcp-public-data--broad-references/hg38/v0/exome_evaluation_regions.v1.interval_list",
-         "contamination_sites_mu" : "gs://gcp-public-data--broad-references/hg38/v0/contamination-resources/1000g/1000g.phase3.100k.b38.vcf.gz.dat.mu",
-         "dbsnp_vcf" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf",
-         "known_indels_sites_vcfs" : [ "gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz", "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz" ],
-         "reference_fasta" : {
-           "ref_pac" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.pac",
-           "ref_bwt" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.bwt",
-           "ref_dict" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict",
-           "ref_ann" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.ann",
-           "ref_fasta_index" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai",
-           "ref_alt" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.alt",
-           "ref_fasta" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",
-           "ref_sa" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.sa",
-           "ref_amb" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.amb"
-         },
-         "contamination_sites_ud" : "gs://gcp-public-data--broad-references/hg38/v0/contamination-resources/1000g/1000g.phase3.100k.b38.vcf.gz.dat.UD"
-       },
-       "cram_ref_fasta_index" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai",
-       "papi_settings" : {
-         "agg_preemptible_tries" : 3,
-         "preemptible_tries" : 3
-       },
-       "base_file_name" : "a.cram",
-       "bait_interval_list" : "gs://gcp-public-data--broad-references/hg38/v0/HybSelOligos/whole_exome_illumina_coding_v1/whole_exome_illumina_coding_v1.Homo_sapiens_assembly38.baits.interval_list",
-       "final_gvcf_base_name" : "a.cram",
-       "target_interval_list" : "gs://gcp-public-data--broad-references/hg38/v0/HybSelOligos/whole_exome_illumina_coding_v1/whole_exome_illumina_coding_v1.Homo_sapiens_assembly38.targets.interval_list",
-       "unmapped_bam_suffix" : ".unmapped.bam"
-     }
+        "input_cram" : "gs://broad-gotc-dev-wfl-ptc-test-inputs/single_sample/plumbing/truth/develop/20k/NA12878_PLUMBING.cram",
+        "destination_cloud_path" : "gs://broad-gotc-dev-wfl-ptc-test-outputs/xx-test-output/8600be1a-48df-4a51-bdba-0044e0af8d33/single_sample/plumbing/truth/develop/20k",
+        "sample_name" : "NA12878_PLUMBING",
+        "base_file_name" : "NA12878_PLUMBING.cram",
+        "final_gvcf_base_name" : "NA12878_PLUMBING.cram"
+      }
    } ],
    "commit" : "commit-ish",
-   "project" : "PO-1234",
+   "project" : "Example Project",
    "uuid" : "1337254e-f7d8-438d-a2b3-a74b199fee3c",
    "wdl" : "pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl",
    "version" : "X.Y.Z"
@@ -304,52 +193,15 @@ Response:
      "updated" : "YYYY-MM-DDTHH:MM:SSZ",
      "uuid" : "bb0d93e3-1a6a-4816-82d9-713fa58fb235",
      "inputs" : {
-       "cram_ref_fasta" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",
-       "scatter_settings" : {
-         "haplotype_scatter_count" : 50,
-         "break_bands_at_multiples_of" : 0
-       },
-       "input_cram" : "gs://path/to/a.cram",
-       "destination_cloud_path" : "gs://broad-gotc-dev-wfl-ptc-test-outputs/xx-test-output/to",
-       "sample_name" : "a",
-       "bait_set_name" : "whole_exome_illumina_coding_v1",
-       "references" : {
-         "calling_interval_list" : "gs://gcp-public-data--broad-references/hg38/v0/exome_calling_regions.v1.interval_list",
-         "contamination_sites_bed" : "gs://gcp-public-data--broad-references/hg38/v0/contamination-resources/1000g/1000g.phase3.100k.b38.vcf.gz.dat.bed",
-         "dbsnp_vcf_index" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf.idx",
-         "haplotype_database_file" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.haplotype_database.txt",
-         "known_indels_sites_indices" : [ "gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi", "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz.tbi" ],
-         "evaluation_interval_list" : "gs://gcp-public-data--broad-references/hg38/v0/exome_evaluation_regions.v1.interval_list",
-         "contamination_sites_mu" : "gs://gcp-public-data--broad-references/hg38/v0/contamination-resources/1000g/1000g.phase3.100k.b38.vcf.gz.dat.mu",
-         "dbsnp_vcf" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf",
-         "known_indels_sites_vcfs" : [ "gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz", "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz" ],
-         "reference_fasta" : {
-           "ref_pac" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.pac",
-           "ref_bwt" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.bwt",
-           "ref_dict" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict",
-           "ref_ann" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.ann",
-           "ref_fasta_index" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai",
-           "ref_alt" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.alt",
-           "ref_fasta" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",
-           "ref_sa" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.sa",
-           "ref_amb" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.amb"
-         },
-         "contamination_sites_ud" : "gs://gcp-public-data--broad-references/hg38/v0/contamination-resources/1000g/1000g.phase3.100k.b38.vcf.gz.dat.UD"
-       },
-       "cram_ref_fasta_index" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai",
-       "papi_settings" : {
-         "agg_preemptible_tries" : 3,
-         "preemptible_tries" : 3
-       },
-       "base_file_name" : "a.cram",
-       "bait_interval_list" : "gs://gcp-public-data--broad-references/hg38/v0/HybSelOligos/whole_exome_illumina_coding_v1/whole_exome_illumina_coding_v1.Homo_sapiens_assembly38.baits.interval_list",
-       "final_gvcf_base_name" : "a.cram",
-       "target_interval_list" : "gs://gcp-public-data--broad-references/hg38/v0/HybSelOligos/whole_exome_illumina_coding_v1/whole_exome_illumina_coding_v1.Homo_sapiens_assembly38.targets.interval_list",
-       "unmapped_bam_suffix" : ".unmapped.bam"
+       "input_cram" : "gs://broad-gotc-dev-wfl-ptc-test-inputs/single_sample/plumbing/truth/develop/20k/NA12878_PLUMBING.cram",
+       "destination_cloud_path" : "gs://broad-gotc-dev-wfl-ptc-test-outputs/xx-test-output/8600be1a-48df-4a51-bdba-0044e0af8d33/single_sample/plumbing/truth/develop/20k",
+       "sample_name" : "NA12878_PLUMBING",
+       "base_file_name" : "NA12878_PLUMBING.cram",
+       "final_gvcf_base_name" : "NA12878_PLUMBING.cram"
      }
    } ],
    "commit" : "commit-ish",
-   "project" : "PO-1234",
+   "project" : "Example Project",
    "uuid" : "1337254e-f7d8-438d-a2b3-a74b199fee3c",
    "wdl" : "pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl",
    "version" : "X.Y.Z"

--- a/docs/md/modules-arrays.md
+++ b/docs/md/modules-arrays.md
@@ -57,6 +57,18 @@ curl "http://localhost:8080/api/v1/workload?uuid=00000000-0000-0000-0000-0000000
      -H 'Accept: application/json'
 ```
 
+**GET /api/v1/workload/{project}**
+
+```shell
+curl "http://localhost:8080/api/v1/workload?project=(Test)%20WFL%20Local%20Testing" \
+     -H 'Accept: application/json'
+```
+
+!!! warning "Note"
+    `project` and `uuid` are optional path parameters to the `/api/v1/workload` endpoint, 
+    hitting this endpoint without them will return all workloads. However, they cannot be specified
+    together.
+
 **GET /api/v1/workload/create**
 
 ```shell


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1023

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- [x] Add a new `load-workload-for-project` implementation.
- [x] Update the spec of `/api/v1/workload` so it can optionally take `project` or `uuid` but mutually exclusively.
- [x] Add tests.
- [x] Update docs.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

Create a workload and query for it by project:

```
## Create BOGUS workload
curl -X "POST" "http://localhost:3000/api/v1/create" \
     -H "Authorization: Bearer $(gcloud auth print-access-token)" \
     -H 'Content-Type: application/json' \
     -d $'{
  "cromwell": "https://cromwell-gotc-auth.gotc-dev.broadinstitute.org",
  "project": "(Test) WFL Local Testing",
  "input": "fake-input",
  "items": [
    {
      "inputs": {
        "dst": "gs://broad-gotc-dev-zero-test/wfl-test-b17d834c-7c27-4e7a-a6df-3e2a4ef4def7/output.txt",
        "src": "gs://broad-gotc-dev-zero-test/wfl-test-b17d834c-7c27-4e7a-a6df-3e2a4ef4def7/input.txt"
      }
    }
  ],
  "output": "fake-output",
  "pipeline": "copyfile"
}'

```
then

```
## Get workloads
# Get all workloads from dev-WFL
curl "http://localhost:3000/api/v1/workload?project=(Test)%20WFL%20Local%20Testing" \
     -H "Authorization: Bearer $(gcloud auth print-access-token)"

```