### PR TITLE
[GH-1063] Remove Serialisation Internals from Workload Responses

### DIFF
--- a/api/src/wfl/api/handlers.clj
+++ b/api/src/wfl/api/handlers.clj
@@ -43,9 +43,10 @@
           query {:includeSubworkflows false :start start :end end}]
       (succeed {:results (cromwell/query env query)}))))
 
-(defn strip-internals [workload]
+(defn strip-internals
   "Strip internal properties from the `workload` and its `workflows`."
-  (let [prune #(apply dissoc % [:id])]
+  [workload]
+  (let [prune #(apply dissoc % [:id :items])]
     (prune (update workload :workflows (partial mapv prune)))))
 
 (defn append-to-aou-workload

--- a/api/src/wfl/api/handlers.clj
+++ b/api/src/wfl/api/handlers.clj
@@ -81,11 +81,10 @@
                 (workloads/update-workload! tx workload))))]
     (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
       (succeed
-        (strip-internals
-          (mapv (partial go! tx)
-            (if-let [uuid (-> request :parameters :query :uuid)]
-              [(workloads/load-workload-for-uuid tx uuid)]
-              (workloads/load-workloads tx))))))))
+        (mapv (comp strip-internals (partial go! tx))
+          (if-let [uuid (-> request :parameters :query :uuid)]
+            [(workloads/load-workload-for-uuid tx uuid)]
+            (workloads/load-workloads tx)))))))
 
 (defn post-start
   "Start the workload with UUID in REQUEST."

--- a/api/src/wfl/api/handlers.clj
+++ b/api/src/wfl/api/handlers.clj
@@ -46,9 +46,7 @@
 (defn strip-internals [workload]
   "Strip internal properties from the `workload` and its `workflows`."
   (let [prune #(apply dissoc % [:id])]
-    (prune
-      (update workload :workflows
-        (partial mapv #(update % :inputs prune))))))
+    (prune (update workload :workflows (partial mapv prune)))))
 
 (defn append-to-aou-workload
   "Append new workflows to an existing started AoU workload describe in BODY of REQUEST."

--- a/api/test/wfl/integration/modules/wgs_test.clj
+++ b/api/test/wfl/integration/modules/wgs_test.clj
@@ -1,11 +1,12 @@
 (ns wfl.integration.modules.wgs-test
   (:require [clojure.set :refer [rename-keys]]
             [clojure.test :refer [deftest testing is] :as clj-test]
-            [wfl.service.cromwell :refer [wait-for-workflow-complete submit-workflow]]
+            [wfl.service.cromwell :refer [wait-for-workflow-complete
+                                          submit-workflow]]
             [wfl.tools.endpoints :as endpoints]
             [wfl.tools.fixtures :as fixtures]
             [wfl.tools.workloads :as workloads]
-            [wfl.module.wgs :as wgs]
+            [wfl.module.wgs :as wgs :refer [skip-workflow?]]
             [wfl.jdbc :as jdbc]
             [wfl.module.all :as all]
             [wfl.util :as util]
@@ -120,7 +121,8 @@
             (is (every? #(prefixed? :ExternalWholeGenomeReprocessing %) (keys inputs)))
             (verify-workflow-inputs (into {} (map strip-prefix inputs)))
             (UUID/randomUUID))]
-    (with-redefs-fn {#'submit-workflow verify-submitted-inputs}
+    (with-redefs-fn {#'submit-workflow verify-submitted-inputs
+                     #'skip-workflow? (constantly false)}
       (fn []
         (->
           (make-wgs-workload-request)
@@ -142,7 +144,8 @@
               (verify-workflow-options options)
               (is (= defaults (select-keys options (keys defaults))))
               (UUID/randomUUID)))]
-    (with-redefs-fn {#'submit-workflow verify-submitted-options}
+    (with-redefs-fn {#'submit-workflow verify-submitted-options
+                     #'skip-workflow? (constantly false)}
       (fn []
         (->
           (make-wgs-workload-request)

--- a/api/test/wfl/system/v1_endpoint_test.clj
+++ b/api/test/wfl/system/v1_endpoint_test.clj
@@ -28,7 +28,7 @@
 (defn- verify-succeeded-workload [workload]
   (run! verify-succeeded-workflow (:workflows workload)))
 
-(defn ^:private verify-missing-internals [workload]
+(defn ^:private verify-internal-properties-removed [workload]
   (letfn [(go! [key]
             (is (util/absent? workload key)
               (format "workload should not contain %s" key))
@@ -53,7 +53,7 @@
       (is (not (:started workload)) "hasn't been started in cromwell")
       (let [include [:pipeline :cromwell :project]]
         (is (= (select-keys request include) (select-keys workload include))))
-      (verify-missing-internals workload))))
+      (verify-internal-properties-removed workload))))
 
 (deftest test-create-wgs-workload
   (test-create-workload (workloads/wgs-workload-request (UUID/randomUUID))))
@@ -75,7 +75,7 @@
       (let [{:keys [workflows]} workload]
         (is (every? :updated workflows))
         (is (every? :uuid workflows)))
-      (verify-missing-internals workload)
+      (verify-internal-properties-removed workload)
       (workloads/when-done verify-succeeded-workload workload))))
 
 (deftest test-start-wgs-workload
@@ -105,7 +105,7 @@
       (let [{:keys [workflows]} workload]
         (is (every? :updated workflows))
         (is (every? :uuid workflows)))
-      (verify-missing-internals workload)
+      (verify-internal-properties-removed workload)
       (workloads/when-done verify-succeeded-workload workload))))
 
 (deftest test-exec-wgs-workload

--- a/api/test/wfl/system/v1_endpoint_test.clj
+++ b/api/test/wfl/system/v1_endpoint_test.clj
@@ -34,7 +34,7 @@
               (format "workload should not contain %s" key))
             (is (every? #(util/absent? % key) (:workflows workload))
               (format "workflows should not contain %s" key)))]
-    (run! go! [:id])))
+    (run! go! [:id :items])))
 
 (deftest test-oauth2-endpoint
   (testing "The `oauth2_id` endpoint indeed provides an ID"

--- a/api/test/wfl/system/v1_endpoint_test.clj
+++ b/api/test/wfl/system/v1_endpoint_test.clj
@@ -31,9 +31,9 @@
 (defn ^:private verify-missing-internals [workload]
   (letfn [(go! [key]
             (is (util/absent? workload key)
-              (format "workload should not contain %" key))
+              (format "workload should not contain %s" key))
             (is (every? #(util/absent? % key) (:workflows workload))
-              (format "workflows should not contain %" key)))]
+              (format "workflows should not contain %s" key)))]
     (run! go! [:id])))
 
 (deftest test-oauth2-endpoint

--- a/api/test/wfl/system/v1_endpoint_test.clj
+++ b/api/test/wfl/system/v1_endpoint_test.clj
@@ -5,7 +5,8 @@
             [wfl.tools.endpoints :as endpoints]
             [wfl.tools.fixtures :refer [with-temporary-gcs-folder temporary-postgresql-database]]
             [wfl.tools.workloads :as workloads]
-            [wfl.service.cromwell :as cromwell])
+            [wfl.service.cromwell :as cromwell]
+            [wfl.util :as util])
   (:import (java.util UUID)
            (clojure.lang ExceptionInfo)))
 
@@ -27,13 +28,20 @@
 (defn- verify-succeeded-workload [workload]
   (run! verify-succeeded-workflow (:workflows workload)))
 
+(defn ^:private verify-missing-internals [workload]
+  (letfn [(go! [key]
+            (is (util/absent? workload key)
+              (format "workload should not contain %" key))
+            (is (every? #(util/absent? % key) (:workflows workload))
+              (format "workflows should not contain %" key)))]
+    (run! go! [:id])))
+
 (deftest test-oauth2-endpoint
   (testing "The `oauth2_id` endpoint indeed provides an ID"
     (let [response (endpoints/get-oauth2-id)]
       (is (= (count response) 2))
       (is (some #(= % :oauth2-client-id) response))
       (is (some #(str/includes? % "apps.googleusercontent.com") response)))))
-
 
 (defn ^:private test-create-workload
   [{:keys [pipeline] :as request}]
@@ -44,7 +52,8 @@
       (is (= (:email @endpoints/userinfo) (:creator workload)) "creator inferred from auth token")
       (is (not (:started workload)) "hasn't been started in cromwell")
       (let [include [:pipeline :cromwell :project]]
-        (is (= (select-keys request include) (select-keys workload include)))))))
+        (is (= (select-keys request include) (select-keys workload include))))
+      (verify-missing-internals workload))))
 
 (deftest test-create-wgs-workload
   (test-create-workload (workloads/wgs-workload-request (UUID/randomUUID))))
@@ -66,6 +75,7 @@
       (let [{:keys [workflows]} workload]
         (is (every? :updated workflows))
         (is (every? :uuid workflows)))
+      (verify-missing-internals workload)
       (workloads/when-done verify-succeeded-workload workload))))
 
 (deftest test-start-wgs-workload
@@ -95,6 +105,7 @@
       (let [{:keys [workflows]} workload]
         (is (every? :updated workflows))
         (is (every? :uuid workflows)))
+      (verify-missing-internals workload)
       (workloads/when-done verify-succeeded-workload workload))))
 
 (deftest test-exec-wgs-workload

--- a/api/test/wfl/unit/api_handlers_test.clj
+++ b/api/test/wfl/unit/api_handlers_test.clj
@@ -5,6 +5,9 @@
 
 (deftest test-strip-internals
   (let [workload  (handlers/strip-internals
-                    {:id 0 :workflows [{:id 0} {:id 1}]})]
+                    {:id 0
+                     :items "ExampleTable_0000001"
+                     :workflows [{:id 0} {:id 1}]})]
     (is (wfl.util/absent? workload :id))
+    (is (wfl.util/absent? workload :items))
     (is (every? #(wfl.util/absent? % :id) (:workflows workload)))))

--- a/api/test/wfl/unit/api_handlers_test.clj
+++ b/api/test/wfl/unit/api_handlers_test.clj
@@ -1,41 +1,10 @@
 (ns wfl.unit.api-handlers-test
-  (:require [clojure.test :refer [deftest testing is use-fixtures]]
-            [wfl.api.workloads :refer [create-workload! start-workload! execute-workload!]]
-            [wfl.tools.fixtures :refer [method-overload-fixture]]))
+  (:require [clojure.test :refer [deftest is]]
+            [wfl.api.handlers :as handlers]))
 
-(def dummy-pipeline "unittest")
-(defn dummy-handler [_ x] x)
 
-(use-fixtures :once
-  (method-overload-fixture create-workload! dummy-pipeline dummy-handler)
-  (method-overload-fixture start-workload! dummy-pipeline dummy-handler))
-
-(deftest test-create-workload!
-  (testing "create-workload! pipeline entry points are correctly called"
-    (testing "dummy pipeline"
-      (let [workload {:pipeline dummy-pipeline}]
-        (is (= workload (create-workload! nil workload)))))
-    (testing "illegal pipeline"
-      (let [workload {:pipeline "geoff"}]
-        (is (thrown-with-msg? Exception #"Failed to create workload - no such pipeline"
-                              (create-workload! nil workload)))))))
-
-(deftest test-start-workload!
-  (testing "start-workload! pipeline entry points are correctly called"
-    (testing "dummy pipeline"
-      (let [workload {:pipeline dummy-pipeline}]
-        (is (= workload (start-workload! nil workload)))))
-    (testing "illegal pipeline"
-      (let [workload {:pipeline "geoff"}]
-        (is (thrown-with-msg? Exception #"Failed to start workload - no such pipeline"
-                              (start-workload! nil workload)))))))
-
-(deftest test-exec-workload!
-  (testing "execute-workload! pipeline entry points are correctly called"
-    (testing "dummy pipeline"
-      (let [workload {:pipeline dummy-pipeline}]
-        (is (= workload (execute-workload! nil workload)))))
-    (testing "illegal pipeline"
-      (let [workload {:pipeline "geoff"}]
-        (is (thrown-with-msg? Exception #"Error executing workload request"
-                              (execute-workload! nil workload)))))))
+(deftest test-strip-internals
+  (let [workload  (handlers/strip-internals
+                    {:id 0 :workflows [{:id 0} {:id 1}]})]
+    (is (wfl.util/absent? workload :id))
+    (is (every? #(wfl.util/absent? % :id) (:workflows workload)))))

--- a/api/test/wfl/unit/workloads_test.clj
+++ b/api/test/wfl/unit/workloads_test.clj
@@ -1,6 +1,7 @@
 (ns wfl.unit.workloads-test
   (:require [clojure.test :refer :all]
-            [wfl.api.workloads :as workloads])
+            [wfl.api.workloads :as workloads]
+            [wfl.tools.fixtures :refer [method-overload-fixture]])
   (:import (clojure.lang ExceptionInfo)))
 
 (deftest test-saved-before?
@@ -12,4 +13,39 @@
   (is (workloads/saved-before? "0.4.0" {:version "0.0.0"}))
   (is (thrown? ExceptionInfo (workloads/saved-before? "0.4" {:version "0.0.0"}))))
 
+(def dummy-pipeline "unittest")
+(defn dummy-handler [_ x] x)
 
+(use-fixtures :once
+  (method-overload-fixture workloads/create-workload! dummy-pipeline dummy-handler)
+  (method-overload-fixture workloads/start-workload! dummy-pipeline dummy-handler))
+
+(deftest test-create-workload!
+  (testing "create-workload! pipeline entry points are correctly called"
+    (testing "dummy pipeline"
+      (let [workload {:pipeline dummy-pipeline}]
+        (is (= workload (workloads/create-workload! nil workload)))))
+    (testing "illegal pipeline"
+      (let [workload {:pipeline "geoff"}]
+        (is (thrown-with-msg? Exception #"Failed to create workload - no such pipeline"
+              (workloads/create-workload! nil workload)))))))
+
+(deftest test-start-workload!
+  (testing "start-workload! pipeline entry points are correctly called"
+    (testing "dummy pipeline"
+      (let [workload {:pipeline dummy-pipeline}]
+        (is (= workload (workloads/start-workload! nil workload)))))
+    (testing "illegal pipeline"
+      (let [workload {:pipeline "geoff"}]
+        (is (thrown-with-msg? Exception #"Failed to start workload - no such pipeline"
+              (workloads/start-workload! nil workload)))))))
+
+(deftest test-exec-workload!
+  (testing "execute-workload! pipeline entry points are correctly called"
+    (testing "dummy pipeline"
+      (let [workload {:pipeline dummy-pipeline}]
+        (is (= workload (workloads/execute-workload! nil workload)))))
+    (testing "illegal pipeline"
+      (let [workload {:pipeline "geoff"}]
+        (is (thrown-with-msg? Exception #"Error executing workload request"
+              (workloads/execute-workload! nil workload)))))))


### PR DESCRIPTION
### Purpose
During the hOps demo, it became clear that the `:id` property of a workload (and it's workflows) caused confusion. In this change, I propose to purge this property from the workload responses.
The `:items` table in workloads is an internal detail and we should not be sending that back either.