### PR TITLE
[GH-1070] dont serialise empty workflow options if none are specified

### DIFF
--- a/api/src/wfl/module/copyfile.clj
+++ b/api/src/wfl/module/copyfile.clj
@@ -37,8 +37,9 @@
 (defn create-copyfile-workload!
   "Use transaction TX to add the workload described by REQUEST."
   [tx {:keys [items common] :as request}]
-  (letfn [(merge-to-json [shared specific]
-            (json/write-str (util/deep-merge shared specific)))
+  (letfn [(nil-if-empty [x] (if (empty? x) nil x))
+          (merge-to-json [shared specific]
+            (json/write-str (nil-if-empty (util/deep-merge shared specific))))
           (serialize [workflow id]
             (-> workflow
               (assoc :id id)

--- a/api/src/wfl/module/wgs.clj
+++ b/api/src/wfl/module/wgs.clj
@@ -123,10 +123,12 @@
 (defn create-wgs-workload!
   "Use transaction TX to add the workload described by REQUEST."
   [tx {:keys [items output common] :as request}]
-  (letfn [(serialize [workflow id]
+  (letfn [(nil-if-empty [x] (if (empty? x) nil x))
+          (serialize [workflow id]
             (-> (assoc workflow :id id)
               (update :options
-                #(json/write-str (util/deep-merge (:options common) %)))
+                #(json/write-str
+                   (nil-if-empty (util/deep-merge (:options common) %))))
               (update :inputs
                 #(json/write-str
                    (normalize-reference-fasta

--- a/api/src/wfl/module/xx.clj
+++ b/api/src/wfl/module/xx.clj
@@ -108,8 +108,9 @@
 
 (defn create-xx-workload!
   [tx {:keys [common items output] :as request}]
-  (letfn [(merge-to-json [shared specific]
-            (json/write-str (util/deep-merge shared specific)))
+  (letfn [(nil-if-empty [x] (if (empty? x) nil x))
+          (merge-to-json [shared specific]
+            (json/write-str (nil-if-empty (util/deep-merge shared specific))))
           (serialize [item id]
             (-> item
               (assoc :id id)

--- a/api/test/wfl/integration/modules/copyfile_test.clj
+++ b/api/test/wfl/integration/modules/copyfile_test.clj
@@ -80,3 +80,11 @@
               #(update % :inputs
                  (fn [xs] (merge xs {:supports_inputs true :overwritten true})))))
           workloads/execute-workload!)))))
+
+(deftest test-empty-workflow-options
+  (letfn [(go! [workflow] (is (util/absent? workflow :options)))]
+    (run! go! (-> (make-copyfile-workload-request "in" "out")
+                (assoc-in [:common :options] {})
+                (update :items (partial map #(assoc % :options {})))
+                workloads/create-workload!
+                :workflows))))

--- a/api/test/wfl/integration/modules/wgs_test.clj
+++ b/api/test/wfl/integration/modules/wgs_test.clj
@@ -157,3 +157,11 @@
           workloads/execute-workload!
           :workflows
           (->> (map (comp verify-workflow-options :options))))))))
+
+(deftest test-empty-workflow-options
+  (letfn [(go! [workflow] (is (util/absent? workflow :options)))]
+    (run! go! (-> (make-wgs-workload-request)
+                (assoc-in [:common :options] {})
+                (update :items (partial map #(assoc % :options {})))
+                workloads/create-workload!
+                :workflows))))

--- a/api/test/wfl/integration/modules/xx_test.clj
+++ b/api/test/wfl/integration/modules/xx_test.clj
@@ -134,3 +134,11 @@
           workloads/execute-workload!
           :workflows
           (->> (map (comp verify-workflow-options :options))))))))
+
+(deftest test-empty-workflow-options
+  (letfn [(go! [workflow] (is (absent? workflow :options)))]
+    (run! go! (-> (make-xx-workload-request)
+                (assoc-in [:common :options] {})
+                (update :items (partial map #(assoc % :options {})))
+                workloads/create-workload!
+                :workflows))))


### PR DESCRIPTION
### Purpose
This fixes the difference in behaviour for when a user specified `nil` as the workflow `options` or `{}`.
Now, the options are returned if they're not empty or nil.

Example: 
```bash
curl -X POST 'https://dev-wfl.gotc-dev.broadinstitute.org/api/v1/create' \
  -H 'Authorization: Bearer '$(gcloud auth print-access-token) \
  -H 'Content-Type: application/json' -d '{ 
    "cromwell": "https://cromwell-gotc-auth.gotc-dev.broadinstitute.org",
    "output": "gs://broad-gotc-dev-wfl-ptc-test-outputs/wgs-test-output/",
    "pipeline": "ExternalWholeGenomeReprocessing",
    "project": "hornet bash",
    "common": {
      "options": {}
    },
    "items": [ {
      "inputs": {
        "input_cram": "gs://broad-gotc-dev-wfl-ptc-test-inputs/single_sample/plumbing/truth/develop/20k/NA12878_PLUMBING.cram" 
      }
    }
  ]
}'
```
now returns: 
```json
{
  "creator" : "ehigham@broadinstitute.org",
  "pipeline" : "ExternalWholeGenomeReprocessing",
  "cromwell" : "https://cromwell-gotc-auth.gotc-dev.broadinstitute.org",
  "release" : "ExternalWholeGenomeReprocessing_v1.1.1",
  "created" : "2020-11-17T17:50:52Z",
  "output" : "gs://broad-gotc-dev-wfl-ptc-test-outputs/wgs-test-output/",
  "workflows" : [ {
    "inputs" : {
      "input_cram" : "gs://broad-gotc-dev-wfl-ptc-test-inputs/single_sample/plumbing/truth/develop/20k/NA12878_PLUMBING.cram",
      "destination_cloud_path" : "gs://broad-gotc-dev-wfl-ptc-test-outputs/wgs-test-output/single_sample/plumbing/truth/develop/20k/",
      "sample_name" : "NA12878_PLUMBING",
      "base_file_name" : "NA12878_PLUMBING",
      "final_gvcf_base_name" : "NA12878_PLUMBING",
      "unmapped_bam_suffix" : ".unmapped.bam"
    }
  } ],
  "project" : "hornet bash",
  "commit" : "c710ee1de7d281e1683c88aa91bf9d57a7f2aa68",
  "wdl" : "pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.wdl",
  "uuid" : "1580faea-9f8b-4da2-9d85-ec4d3d5910b6",
  "version" : "0.4.0"
}
```