### PR TITLE
[GH-1071] Fix `exec`-ing an AoU workload twice fails to return the `exec`-ed workload

### DIFF
--- a/api/src/wfl/module/aou.clj
+++ b/api/src/wfl/module/aou.clj
@@ -192,7 +192,8 @@
   "Use transaction TX to start the WORKLOAD. This is simply updating the
    workload table to mark a workload as 'started' so it becomes append-able."
   [tx {:keys [id] :as workload}]
-  (when-not (:started workload)
+  (if (:started workload)
+    workload
     (let [now {:started (Timestamp/from (.toInstant (OffsetDateTime/now)))}]
       (jdbc/update! tx :workload now ["id = ?" id])
       (merge workload now))))

--- a/api/test/wfl/integration/modules/aou_test.clj
+++ b/api/test/wfl/integration/modules/aou_test.clj
@@ -65,3 +65,9 @@
          (let [workload (workloads/update-workload! workload)]
            (is (every? (comp #{"Succeeded"} :status) (:workflows workload)))
            (is (not (:finished workload))))))))
+
+(deftest test-exec-on-same-workload-request
+  "executing a workload-request twice should not create a new workload"
+  (let [request (make-aou-workload-request)]
+    (is (= (workloads/execute-workload! request)
+          (workloads/execute-workload! request)))))

--- a/api/test/wfl/integration/modules/aou_test.clj
+++ b/api/test/wfl/integration/modules/aou_test.clj
@@ -66,6 +66,7 @@
            (is (every? (comp #{"Succeeded"} :status) (:workflows workload)))
            (is (not (:finished workload))))))))
 
+;; rr: GH-1071
 (deftest test-exec-on-same-workload-request
   "executing a workload-request twice should not create a new workload"
   (let [request (make-aou-workload-request)]

--- a/api/test/wfl/tools/workloads.clj
+++ b/api/test/wfl/tools/workloads.clj
@@ -45,7 +45,7 @@
   Randomize it with IDENTIFIER for easier testing."
   [identifier]
   {:cromwell (get-in stuff [:aou-dev :cromwell :url])
-   :output   "gs://broad-gotc-dev-wfl-ptc-test-outputs/aou-test-output"
+   :output   "gs://broad-gotc-dev-wfl-ptc-test-outputs/aou-test-output/"
    :pipeline aou/pipeline
    :project  (format "(Test) %s %s" @git-branch identifier)})
 


### PR DESCRIPTION
### Purpose
See ticket.

Caused by a type error. in https://github.com/broadinstitute/wfl/pull/196, I changed the implementation from `start-workload!` from
```clojure
(defmethod workloads/start-workload!
  pipeline
  [tx {:keys [id] :as workload}]
  (do
    (start-aou-workload! tx workload)
    (workloads/load-workload-for-id tx id)))
```
to
```clojure
(defoverload workloads/start-workload! pipeline start-aou-workload!)
```
Without updating `start-aou-workload` to return the the workload if it had already been started.

Note that the changes to the test tools are required so that the test I added doesn't fail due to GH-1072. I think there should be a separate test added for that.
