### PR TITLE
[GH-1071] Fix `exec`-ing an AoU workload twice fails to return the `e…

### DIFF
--- a/api/src/wfl/module/aou.clj
+++ b/api/src/wfl/module/aou.clj
@@ -192,7 +192,8 @@
   "Use transaction TX to start the WORKLOAD. This is simply updating the
    workload table to mark a workload as 'started' so it becomes append-able."
   [tx {:keys [id] :as workload}]
-  (when-not (:started workload)
+  (if (:started workload)
+    workload
     (let [now {:started (Timestamp/from (.toInstant (OffsetDateTime/now)))}]
       (jdbc/update! tx :workload now ["id = ?" id])
       (merge workload now))))

--- a/api/test/wfl/integration/modules/aou_test.clj
+++ b/api/test/wfl/integration/modules/aou_test.clj
@@ -65,3 +65,10 @@
          (let [workload (workloads/update-workload! workload)]
            (is (every? (comp #{"Succeeded"} :status) (:workflows workload)))
            (is (not (:finished workload))))))))
+
+;; rr: GH-1071
+(deftest test-exec-on-same-workload-request
+  "executing a workload-request twice should not create a new workload"
+  (let [request (make-aou-workload-request)]
+    (is (= (workloads/execute-workload! request)
+          (workloads/execute-workload! request)))))

--- a/api/test/wfl/tools/workloads.clj
+++ b/api/test/wfl/tools/workloads.clj
@@ -45,7 +45,7 @@
   Randomize it with IDENTIFIER for easier testing."
   [identifier]
   {:cromwell (get-in stuff [:aou-dev :cromwell :url])
-   :output   "gs://broad-gotc-dev-wfl-ptc-test-outputs/aou-test-output"
+   :output   "gs://broad-gotc-dev-wfl-ptc-test-outputs/aou-test-output/"
    :pipeline aou/pipeline
    :project  (format "(Test) %s %s" @git-branch identifier)})
 


### PR DESCRIPTION
Double submit of https://github.com/broadinstitute/wfl/pull/234

* return the workload ifs already :started

* add test for GH-1071. Exposes GH-1072

* add related record to test