### PR TITLE
Update v0.4.1 patch release change log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Release 0.4.1
+- disable failing test for v0.4.1 ([#242](https://github.com/broadinstitute/wfl/pull/242))
+- [GH-1074] Changelog from branches ([#241](https://github.com/broadinstitute/wfl/pull/241)) ([#243](https://github.com/broadinstitute/wfl/pull/241))
+- [GH-1072] Standardize AoU output bucket in DB ([#236](https://github.com/broadinstitute/wfl/pull/236)) ([#237](https://github.com/broadinstitute/wfl/pull/236))
+- [GH-1071] Fix `exec`-ing an AoU workload twice fails to return the `exec`-ed workload ([#234](https://github.com/broadinstitute/wfl/pull/234)) ([#235](https://github.com/broadinstitute/wfl/pull/234))
+- set patch version
+
 # Release 0.4.0
 - create release candidate for v0.4.0 ([#231](https://github.com/broadinstitute/wfl/pull/231))
 - graphic updates ([#230](https://github.com/broadinstitute/wfl/pull/230))
@@ -36,4 +43,3 @@
 - [GH-1034] Fix reference_fasta function ([#194](https://github.com/broadinstitute/wfl/pull/194))
 - [GH-771] WGS updates ([#191](https://github.com/broadinstitute/wfl/pull/191))
 - [GH-819] External Exome Reprocessing ([#139](https://github.com/broadinstitute/wfl/pull/139))
-


### PR DESCRIPTION
### Purpose
Add change log ahead of 0.4.1 patch release
I had to manually create this due to https://broadinstitute.atlassian.net/browse/GH-1074 - I checked it and it seems ok!