### PR TITLE
[GH-1020] Import arrays module in handlers

### DIFF
--- a/api/src/wfl/api/handlers.clj
+++ b/api/src/wfl/api/handlers.clj
@@ -5,6 +5,7 @@
             [ring.util.http-response :as response]
             [wfl.api.workloads :as workloads]
             [wfl.module.aou :as aou]
+            [wfl.module.arrays]
             [wfl.module.copyfile]
             [wfl.module.wgs]
             [wfl.module.xx]

--- a/api/src/wfl/api/handlers.clj
+++ b/api/src/wfl/api/handlers.clj
@@ -1,5 +1,5 @@
 (ns wfl.api.handlers
-  "Define handlers for API endpoints"
+  "Define handlers for API endpoints. Note that pipeline modules MUST be required here."
   (:require [clojure.tools.logging :as log]
             [clojure.tools.logging.readable :as logr]
             [ring.util.http-response :as response]


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

Fixes the failing system test for the arrays module.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

Import arrays module in handlers, otherwise WFL will complain that the pipeline is invalid when trying to create a new `GPArrays` workload.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
