### PR TITLE
[GH-1097] Fix empty append_to_aou response

### DIFF
--- a/api/src/wfl/module/aou.clj
+++ b/api/src/wfl/module/aou.clj
@@ -256,7 +256,7 @@
     (let [environment       (get-cromwell-environment! workload)
           submitted-samples (map (partial submit! environment)
                                  (remove-existing-samples notifications
-                                   (get-existing-samples tx items notifications)))]
+                                                          (get-existing-samples tx items notifications)))]
       (jdbc/insert-multi! tx items submitted-samples)
       submitted-samples)))
 

--- a/api/src/wfl/module/aou.clj
+++ b/api/src/wfl/module/aou.clj
@@ -256,8 +256,9 @@
     (let [environment       (get-cromwell-environment! workload)
           submitted-samples (map (partial submit! environment)
                                  (remove-existing-samples notifications
-                                                          (get-existing-samples tx items notifications)))]
-      (jdbc/insert-multi! tx items submitted-samples))))
+                                   (get-existing-samples tx items notifications)))]
+      (jdbc/insert-multi! tx items submitted-samples)
+      submitted-samples)))
 
 (defmethod workloads/create-workload!
   pipeline

--- a/api/test/wfl/integration/modules/aou_test.clj
+++ b/api/test/wfl/integration/modules/aou_test.clj
@@ -34,9 +34,7 @@
            (is (s/valid? :wfl.api.spec/append-to-aou-response response))
            (is (count=1? response))))
        (testing "appending the same sample to the workload does nothing"
-         (let [response (append-to-workload! [workloads/aou-sample])]
-           (is (empty? response) "Expected no workloads to be started")
-           (is (some? response) "Expected the response to be non-nil")))
+         (is (= () (append-to-workload! [workloads/aou-sample]))))
        (testing "incrementing analysis_version_number starts a new workload"
          (is (count=1? (append-to-workload! [(inc-version workloads/aou-sample)]))))
        (testing "only one workflow is started when there are multiple duplicates"

--- a/api/test/wfl/integration/modules/aou_test.clj
+++ b/api/test/wfl/integration/modules/aou_test.clj
@@ -34,7 +34,9 @@
            (is (s/valid? :wfl.api.spec/append-to-aou-response response))
            (is (count=1? response))))
        (testing "appending the same sample to the workload does nothing"
-         (is (empty? (append-to-workload! [workloads/aou-sample]))))
+         (let [response (append-to-workload! [workloads/aou-sample])]
+           (is (empty? response) "Expected no workloads to be started")
+           (is (some? response) "Expected the response to be non-nil")))
        (testing "incrementing analysis_version_number starts a new workload"
          (is (count=1? (append-to-workload! [(inc-version workloads/aou-sample)]))))
        (testing "only one workflow is started when there are multiple duplicates"


### PR DESCRIPTION
### Purpose
https://broadinstitute.atlassian.net/browse/GH-1097

As Jack observed, when you send a sample to workflow launcher that has been (or in the process of being) processed, workflow-launcher skips it. If no samples are processed, I thought I was returning an empty list. I even wrote a test for this. The problem is that Clojure treats `nil` to mean empty, meaning that the integration test I wrote wasn’t that useful.

The solution was to explicitly return the list I created, not the list returned by `jdbc/insert` - I thought they were the same, turns out not.
