### PR TITLE
[GH-1079] Fix WFL's exception logging

### DIFF
--- a/api/src/wfl/api/routes.clj
+++ b/api/src/wfl/api/routes.clj
@@ -125,11 +125,7 @@
                          :exception (str (.getClass exception))
                          :data (ex-data exception)
                          :uri (:uri request)}}]
-    (if (< (:status response) 500)
-      (log/warnf "Client %s error - %s occurred at %s"
-                 (:status response)
-                 (:message (:body response))
-                 (:uri (:body response)))
+    (if (>= (:status response) 500)
       (do
         (log/errorf "Server %s error at occurred at %s :"
                     (:status response)

--- a/api/src/wfl/api/routes.clj
+++ b/api/src/wfl/api/routes.clj
@@ -161,13 +161,13 @@
        ;; :exception pretty/exception
      :data {:coercion   reitit.coercion.spec/coercion
             :muuntaja   muuntaja-core/instance
-            :middleware [;; query-params & form-params
+            :middleware [exception-middleware
+                         ;; query-params & form-params
                          parameters/parameters-middleware
                            ;; content-negotiation
                          muuntaja/format-negotiate-middleware
                            ;; encoding response body
                          muuntaja/format-response-middleware
-                         exception-middleware
                            ;; decoding request body
                          muuntaja/format-request-middleware
                            ;; coercing response bodys

--- a/api/src/wfl/api/routes.clj
+++ b/api/src/wfl/api/routes.clj
@@ -139,12 +139,7 @@
        ;; handle clj-http Slingshot stone exceptions
      :clj-http.client/unexceptional-status (partial ex-handler 400 "HTTP Error on request")
        ;; override the default handler
-     ::exception/default                   (partial ex-handler 500 "Internal Server Error")
-       ;; print stack-traces for all exceptions in logs
-     ::exception/wrap                      (fn [handler e request]
-                                             (log/errorf e "EXCEPTION ROSE TO MIDDLEWARE (%s)" (:uri request))
-                                             (logr/error request)
-                                             (handler e request))})))
+     ::exception/default                   (partial ex-handler 500 "Internal Server Error")})))
 
 (def routes
   (ring/ring-handler

--- a/api/src/wfl/api/routes.clj
+++ b/api/src/wfl/api/routes.clj
@@ -120,17 +120,20 @@
   "Top level exception handler. Prefer to use status and message
    from EXCEPTION and fallback to the provided STATUS and MESSAGE."
   [status message exception request]
-  (let [response {:status (or (:status (ex-data exception)) status)
-                  :body {:message (or (.getMessage exception) message)
-                         :exception (str (.getClass exception))
-                         :data (ex-data exception)
-                         :uri (:uri request)}}]
-    (if (>= (:status response) 500)
-      (do
-        (log/errorf "Server %s error at occurred at %s :"
-                    (:status response)
-                    (:uri (:body response)))
-        (logr/error exception (:body response))))
+  {:status (or (:status (ex-data exception)) status)
+   :body {:message (or (.getMessage exception) message)
+          :exception (str (.getClass exception))
+          :data (ex-data exception)
+          :uri (:uri request)}})
+
+(defn unexpected-ex-handler
+  "Like [[ex-handler]] but also logs information about the exception."
+  [status message exception request]
+  (let [response (ex-handler status message exception request)]
+    (log/errorf "Server %s error at occurred at %s :"
+                (:status response)
+                (:uri (:body response)))
+    (logr/error exception (:body response))
     response))
 
 (def exception-middleware
@@ -141,12 +144,12 @@
     {;; ex-data with :type :wfl/exception
      ::workloads/invalid-pipeline          (partial ex-handler 400 "")
      ::workloads/workload-not-found        (partial ex-handler 404 "")
-       ;; SQLException and all it's child classes
-     SQLException                          (partial ex-handler 500 "SQL Error")
+       ;; SQLException and all its child classes
+     SQLException                          (partial unexpected-ex-handler 500 "SQL Error")
        ;; handle clj-http Slingshot stone exceptions
      :clj-http.client/unexceptional-status (partial ex-handler 400 "HTTP Error on request")
        ;; override the default handler
-     ::exception/default                   (partial ex-handler 500 "Internal Server Error")})))
+     ::exception/default                   (partial unexpected-ex-handler 500 "Internal Server Error")})))
 
 (def routes
   (ring/ring-handler

--- a/api/src/wfl/api/routes.clj
+++ b/api/src/wfl/api/routes.clj
@@ -130,9 +130,7 @@
   "Like [[ex-handler]] but also logs information about the exception."
   [status message exception request]
   (let [response (ex-handler status message exception request)]
-    (log/errorf "Server %s error at occurred at %s :"
-                (:status response)
-                (:uri (:body response)))
+    (log/errorf "Server %s error at occurred at %s :" (:status response) (:uri request))
     (logr/error exception (:body response))
     response))
 

--- a/api/src/wfl/api/workloads.clj
+++ b/api/src/wfl/api/workloads.clj
@@ -36,8 +36,9 @@
   (try
     (load-workload-impl tx workload)
     (catch Throwable cause
-      (throw (ex-info "Error loading workload"
-                      {:workload workload} cause)))))
+      (throw (ex-info (str "Error loading workload - " (.getMessage cause))
+                      (util/deep-merge {:workload workload} (ex-data cause))
+                      cause)))))
 
 (defn load-workload-for-uuid
   "Use transaction `tx` to load `workload` with `uuid`."
@@ -100,8 +101,8 @@
   (try
     (start-workload! tx (create-workload! tx workload-request))
     (catch Throwable cause
-      (throw (ex-info "Error executing workload request"
-                      {:workload-request workload-request} cause)))))
+      (throw (ex-info (str "Error executing workload request - " (.getMessage cause))
+                      (ex-data cause) cause)))))
 
 (defmethod update-workload!
   :default
@@ -110,8 +111,9 @@
     (postgres/update-workload! tx workload)
     (load-workload-for-id tx (:id workload))
     (catch Throwable cause
-      (throw (ex-info "Error updating workload"
-                      {:workload workload} cause)))))
+      (throw (ex-info (str "Error updating workload - " (.getMessage cause))
+                      (util/deep-merge {:workload workload} (ex-data cause))
+                      cause)))))
 
 (defn default-load-workload-impl
   [tx workload]
@@ -126,8 +128,9 @@
            (assoc workload :workflows)
            unnilify)
       (catch Throwable cause
-        (throw (ex-info "Error loading workload"
-                        {:workload workload} cause))))))
+        (throw (ex-info (str "Error loading workload - " (.getMessage cause))
+                        (util/deep-merge {:workload workload} (ex-data cause))
+                        cause))))))
 
 (defoverload load-workload-impl :default default-load-workload-impl)
 

--- a/api/src/wfl/api/workloads.clj
+++ b/api/src/wfl/api/workloads.clj
@@ -37,7 +37,7 @@
     (load-workload-impl tx workload)
     (catch Throwable cause
       (throw (ex-info (str "Error loading workload - " (.getMessage cause))
-                      (util/deep-merge {:workload workload} (ex-data cause))
+                      (assoc (ex-data cause) :workload workload)
                       cause)))))
 
 (defn load-workload-for-uuid

--- a/api/test/wfl/system/v1_endpoint_test.clj
+++ b/api/test/wfl/system/v1_endpoint_test.clj
@@ -144,7 +144,7 @@
 (deftest test-bad-pipeline
   (let [request (-> (workloads/copyfile-workload-request "gs://fake/in" "gs://fake/out")
                     (assoc :pipeline "geoff"))]
-    (testing "create-workload! fails with bad request"
-      (is (thrown? ExceptionInfo (endpoints/create-workload request))))
-    (testing "create-workload! fails with bad request"
-      (is (thrown? ExceptionInfo (endpoints/exec-workload request))))))
+    (testing "create-workload! fails (400) with bad request"
+      (is (thrown-with-msg? ExceptionInfo #"clj-http: status 400" (endpoints/create-workload request))))
+    (testing "exec-workload! fails (400) with bad request"
+      (is (thrown-with-msg? ExceptionInfo #"clj-http: status 400" (endpoints/exec-workload request))))))

--- a/api/test/wfl/unit/workloads_test.clj
+++ b/api/test/wfl/unit/workloads_test.clj
@@ -47,5 +47,5 @@
         (is (= workload (workloads/execute-workload! nil workload)))))
     (testing "illegal pipeline"
       (let [workload {:pipeline "geoff"}]
-        (is (thrown-with-msg? Exception #"Error executing workload request"
+        (is (thrown-with-msg? Exception #"Failed to create workload - no such pipeline"
                               (workloads/execute-workload! nil workload)))))))


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1079

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Make catch/throws in `wfl.api.workloads` not clobber `ex-data` (/exec was clobbering exception types from /create or /start, etc)
  - This means that the correct response codes get sent to the user
- Make server logs more concise
  - Don't print that huge gob of text anymore
  - If the error is 400-series, nothing gets printed
  - If the error is 500-series, print out an error, request in EDN format, and stacktrace
- Make error responses to the user pure JSON (was slightly out of spec before by trying to write in a raw class object)
- Make error responses to the user pretty-printed
- Adjust system test to get some coverage on this (explanation in [commit message](https://github.com/broadinstitute/wfl/commit/beee62b265430a7dbdb2c6d484e59790966cd65d))


### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- System tests cover the client-facing behavior.
- To check the backend behavior you can follow the ticket's reproduction steps.
  - Examples below are also basically a runbook of stuff to try and look at if you're interested

### Examples for the curious

<details>
<summary>Example behavior</summary>

## 400-series
If you submit:

```bash
curl -X POST 'http://localhost:3000/api/v1/exec' \
-H "Authorization: Bearer $(gcloud auth print-access-token)" \
-H 'Content-Type: application/json' \
-d  '{ "pipeline": "foo", "output": "gs://fake/output", "project": "fun", "items":[], "cromwell": ""  }'
```

You'll get back a 400 error code and a pretty-printed response:

```json
{
  "message" : "Error executing workload request - Failed to create workload - no such pipeline",
  "exception" : "class clojure.lang.ExceptionInfo",
  "data" : {
    "cause" : {
      "creator" : "jwarren@broadinstitute.org",
      "pipeline" : "foo",
      "cromwell" : "",
      "output" : "gs://fake/output",
      "project" : "fun",
      "items" : [ ]
    },
    "type" : "wfl.api.workloads/invalid-pipeline"
  },
  "uri" : "/api/v1/exec"
}
```

Nothing appears in the logs.

### 500-series

> **Just for this demo I made it so that `no such pipeline` errors are 500s**

The user-facing behavior is the same, you get a pretty-printed response no matter what with the right error code.

Meanwhile, in the logs:

```
12:58:56 ERROR wfl.api.routes - Server 500 error at occurred at /api/v1/exec :
12:58:56 ERROR wfl.api.routes - {:message "Error executing workload request - Failed to create workload - no such pipeline", :exception "class clojure.lang.ExceptionInfo", :data {:cause {:creator "jwarren@broadinstitute.org", :pipeline "foo", :cromwell "", :output "gs://fake/output", :project "fun", :items []}, :type :wfl.api.workloads/invalid-pipeline}, :uri "/api/v1/exec"}
clojure.lang.ExceptionInfo: Error executing workload request - Failed to create workload - no such pipeline
        at wfl.api.workloads$eval12612$fn__12613.invoke(workloads.clj:104) ~[?:?]
        at clojure.lang.MultiFn.invoke(MultiFn.java:234) ~[clojure-1.10.1.jar:?]
        at wfl.api.handlers$post_exec$fn__25377.invoke(handlers.clj:125) ~[?:?]
        at clojure.java.jdbc$db_transaction_STAR_.invokeStatic(jdbc.clj:789) ~[?:?]
        at clojure.java.jdbc$db_transaction_STAR_.invoke(jdbc.clj:759) ~[?:?]
        at clojure.java.jdbc$db_transaction_STAR_.invokeStatic(jdbc.clj:824) ~[?:?]
        at clojure.java.jdbc$db_transaction_STAR_.invoke(jdbc.clj:759) ~[?:?]
        at clojure.java.jdbc$db_transaction_STAR_.invokeStatic(jdbc.clj:772) ~[?:?]
        at clojure.java.jdbc$db_transaction_STAR_.invoke(jdbc.clj:759) ~[?:?]
        at wfl.api.handlers$post_exec.invokeStatic(handlers.clj:118) ~[?:?]
        at wfl.api.handlers$post_exec.invoke(handlers.clj:115) ~[?:?]
        at reitit.ring.coercion$fn__24416$fn__24418$fn__24419.invoke(coercion.cljc:40) ~[?:?]
        at reitit.ring.coercion$fn__24426$fn__24428$fn__24429.invoke(coercion.cljc:64) ~[?:?]
        at muuntaja.middleware$wrap_format_request$fn__24607.invoke(middleware.clj:114) ~[?:?]
        at muuntaja.middleware$wrap_format_response$fn__24611.invoke(middleware.clj:132) ~[?:?]
        at muuntaja.middleware$wrap_format_negotiate$fn__24604.invoke(middleware.clj:96) ~[?:?]
        at ring.middleware.params$wrap_params$fn__15035.invoke(params.clj:67) ~[?:?]
        at reitit.ring.middleware.exception$wrap$fn__24481$fn__24482.invoke(exception.clj:49) ~[?:?]
        at reitit.ring$ring_handler$fn__24258.invoke(ring.cljc:326) ~[?:?]
        at clojure.lang.AFn.applyToHelper(AFn.java:154) ~[clojure-1.10.1.jar:?]
        at clojure.lang.AFn.applyTo(AFn.java:144) ~[clojure-1.10.1.jar:?]
        at clojure.lang.AFunction$1.doInvoke(AFunction.java:31) ~[clojure-1.10.1.jar:?]
        at clojure.lang.RestFn.invoke(RestFn.java:408) ~[clojure-1.10.1.jar:?]
        at clojure.lang.Var.invoke(Var.java:384) ~[clojure-1.10.1.jar:?]
        at ring.middleware.reload$wrap_reload$fn__15929.invoke(reload.clj:39) ~[?:?]
        at ring.middleware.params$wrap_params$fn__15035.invoke(params.clj:67) ~[?:?]
        at ring.middleware.session$wrap_session$fn__14609.invoke(session.clj:108) ~[?:?]
        at ring.middleware.keyword_params$wrap_keyword_params$fn__14655.invoke(keyword_params.clj:53) ~[?:?]
        at ring.middleware.params$wrap_params$fn__15035.invoke(params.clj:67) ~[?:?]
        at ring.middleware.absolute_redirects$wrap_absolute_redirects$fn__15221.invoke(absolute_redirects.clj:47) ~[?:?]
        at ring.middleware.content_type$wrap_content_type$fn__15169.invoke(content_type.clj:34) ~[?:?]
        at ring.middleware.default_charset$wrap_default_charset$fn__15193.invoke(default_charset.clj:31) ~[?:?]
        at ring.middleware.not_modified$wrap_not_modified$fn__15135.invoke(not_modified.clj:61) ~[?:?]
        at ring.middleware.ssl$wrap_forwarded_scheme$fn__15239.invoke(ssl.clj:35) ~[?:?]
        at ring.middleware.proxy_headers$wrap_forwarded_remote_addr$fn__15277.invoke(proxy_headers.clj:20) ~[?:?]
        at wfl.server$wrap_internal_error$fn__25624.invoke(server.clj:54) ~[?:?]
        at ring.middleware.json$wrap_json_response$fn__15378.invoke(json.clj:139) ~[?:?]
        at ring.adapter.jetty$proxy_handler$fn__14263.invoke(jetty.clj:27) ~[?:?]
        at ring.adapter.jetty.proxy$org.eclipse.jetty.server.handler.AbstractHandler$ff19274a.handle(Unknown Source) ~[?:?]
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127) ~[jetty-server-9.4.31.v20200723.jar:9.4.31.v20200723]
        at org.eclipse.jetty.server.Server.handle(Server.java:501) ~[jetty-server-9.4.31.v20200723.jar:9.4.31.v20200723]
        at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:383) ~[jetty-server-9.4.31.v20200723.jar:9.4.31.v20200723]
        at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:556) [jetty-server-9.4.31.v20200723.jar:9.4.31.v20200723]
        at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:375) [jetty-server-9.4.31.v20200723.jar:9.4.31.v20200723]
        at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:273) [jetty-server-9.4.31.v20200723.jar:9.4.31.v20200723]
        at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311) [jetty-io-9.4.31.v20200723.jar:9.4.31.v20200723]
        at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105) [jetty-io-9.4.31.v20200723.jar:9.4.31.v20200723]
        at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104) [jetty-io-9.4.31.v20200723.jar:9.4.31.v20200723]
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:806) [jetty-util-9.4.31.v20200723.jar:9.4.31.v20200723]
        at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:938) [jetty-util-9.4.31.v20200723.jar:9.4.31.v20200723]
        at java.lang.Thread.run(Thread.java:832) [?:?]
Caused by: clojure.lang.ExceptionInfo: Failed to create workload - no such pipeline
        at wfl.api.workloads$eval12604$fn__12605.invoke(workloads.clj:86) ~[?:?]
        at clojure.lang.MultiFn.invoke(MultiFn.java:234) ~[clojure-1.10.1.jar:?]
        at wfl.api.workloads$eval12612$fn__12613.invoke(workloads.clj:102) ~[?:?]
        ... 50 more
```

Note that the second line is the response back to the user (contains their original request), it is printed using `logr` so it is as close to EDN format as possible. We can copy/paste that into REPLs or formatters or whatever.

</details>
