### PR TITLE
GH-1095: Batch submit workflows to Cromwell

### DIFF
--- a/api/src/wfl/module/wgs.clj
+++ b/api/src/wfl/module/wgs.clj
@@ -167,11 +167,11 @@
       (let [workflows (group-by #(skip-workflow? env workload %) (:workflows workload))
             skipped-workflows (get workflows true)]
         (concat (map
-               #(assoc % :uuid util/uuid-nil
-                       :status "skipped"
-                       :updated (OffsetDateTime/now))
-               skipped-workflows)
-              (mapcat submit-batch! (group-by :options  (get workflows nil))))))))
+                 #(assoc % :uuid util/uuid-nil
+                         :status "skipped"
+                         :updated (OffsetDateTime/now))
+                 skipped-workflows)
+                (mapcat submit-batch! (group-by :options  (get workflows nil))))))))
 
 (defoverload workloads/create-workload! pipeline create-wgs-workload!)
 

--- a/api/src/wfl/service/cromwell.clj
+++ b/api/src/wfl/service/cromwell.clj
@@ -241,12 +241,12 @@
   standard JSON files for Cromwell.  LABELS is a {:key value} map."
   [environment wdl imports-zip inputs options labels]
   (:id (post-workflow (api environment)
-                 (assoc (partify-workflow wdl
-                                          imports-zip
-                                          inputs
-                                          options
-                                          labels)
-                        :workflowOnHold "true"))))
+                      (assoc (partify-workflow wdl
+                                               imports-zip
+                                               inputs
+                                               options
+                                               labels)
+                             :workflowOnHold "true"))))
 
 (defn submit-workflow
   "Submit a workflow to run WDL with IMPORTS-ZIP, INPUTS,

--- a/api/src/wfl/service/cromwell.clj
+++ b/api/src/wfl/service/cromwell.clj
@@ -188,7 +188,7 @@
       (into counts [[:total total]]))))
 
 (defn make-workflow-labels
-  "Return the workflow labels from ENVIRONMENT, WDL, and INPUTS."
+  "Return workflow labels for WDL."
   [wdl]
   (letfn [(key-for [suffix] (keyword (str wfl/the-name "-" (name suffix))))]
     (let [the-version   (wfl/get-the-version)
@@ -218,7 +218,7 @@
   (into {} (map (fn [[k v]] [k (str v)]) m)))
 
 (defn partify-workflow
-  "Return a map describing a workflow named WF to run in ENVIRONMENT
+  "Return a map describing a workflow named WF to run
    with DEPENDENCIES, INPUTS, OPTIONS, and LABELS."
   [wf dependencies inputs options labels]
   (letfn [(jsonify [edn] (when edn (json/write-str edn :escape-slash false)))
@@ -283,7 +283,7 @@
                          options
                          labels)
        (post-workflow (str (api environment) "/batch"))
-       (mapv #(:id %))))
+       (mapv :id)))
 
 (defn work-around-cromwell-fail-bug
   "Wait 2 seconds and ignore up to N times a bogus failure response from

--- a/api/test/wfl/integration/modules/wgs_test.clj
+++ b/api/test/wfl/integration/modules/wgs_test.clj
@@ -6,7 +6,7 @@
             [wfl.tools.endpoints :as endpoints]
             [wfl.tools.fixtures :as fixtures]
             [wfl.tools.workloads :as workloads]
-            [wfl.module.wgs :as wgs :refer [skip-workflow?]]
+            [wfl.module.wgs :as wgs]
             [wfl.jdbc :as jdbc]
             [wfl.module.all :as all]
             [wfl.util :as util]
@@ -131,8 +131,7 @@
                (verify-workflow-inputs (into {} (map strip-prefix in)))
                (UUID/randomUUID))
              inputs))]
-    (with-redefs-fn {#'submit-workflows verify-submitted-inputs
-                     #'skip-workflow? (constantly false)}
+    (with-redefs-fn {#'submit-workflows verify-submitted-inputs}
       (fn []
         (->
          (make-wgs-workload-request)
@@ -162,8 +161,7 @@
             (let [request (-> (make-wgs-workload-request)
                               (assoc :items [{:inputs {key value}}]))]
               (testing (str "default inputs when given only " key)
-                (with-redefs-fn {#'submit-workflows verify-submitted-inputs
-                                 #'skip-workflow? (constantly false)}
+                (with-redefs-fn {#'submit-workflows verify-submitted-inputs}
                   #(workloads/execute-workload! request)))))]
     (test-with-input :input_bam (:input_cram workloads/wgs-inputs))
     (test-with-input :input_cram (:input_cram workloads/wgs-inputs))))
@@ -178,8 +176,7 @@
               (verify-workflow-options options)
               (is (= defaults (select-keys options (keys defaults))))
               (map (fn [_] (UUID/randomUUID)) inputs)))]
-    (with-redefs-fn {#'submit-workflows verify-submitted-options
-                     #'skip-workflow? (constantly false)}
+    (with-redefs-fn {#'submit-workflows verify-submitted-options}
       (fn []
         (->
          (make-wgs-workload-request)

--- a/api/test/wfl/integration/modules/wgs_test.clj
+++ b/api/test/wfl/integration/modules/wgs_test.clj
@@ -102,10 +102,10 @@
             (is (contains? labels :workload)))
           (verify-inputs [env _ _ inputs options labels]
             (map
-              (fn [inputs]
-                (verify-use_input_bam! (into {} inputs) labels)
-                [env _ _ inputs options labels])
-              inputs))]
+             (fn [inputs]
+               (verify-use_input_bam! (into {} inputs) labels)
+               [env _ _ inputs options labels])
+             inputs))]
     (with-redefs-fn
       {#'submit-workflows
        (comp mock-submit-workflows verify-inputs)}
@@ -125,11 +125,11 @@
             (is (not-empty (-> inputs :references (dissoc :reference_fasta)))))
           (verify-submitted-inputs [_ _ _ inputs _ _]
             (map
-              (fn [in]
-                (is (every? #(prefixed? :ExternalWholeGenomeReprocessing %) (keys in)))
-                (verify-workflow-inputs (into {} (map strip-prefix in)))
-                (UUID/randomUUID))
-              inputs))]
+             (fn [in]
+               (is (every? #(prefixed? :ExternalWholeGenomeReprocessing %) (keys in)))
+               (verify-workflow-inputs (into {} (map strip-prefix in)))
+               (UUID/randomUUID))
+             inputs))]
     (with-redefs-fn {#'submit-workflows verify-submitted-inputs
                      #'skip-workflow? (constantly nil)}
       (fn []

--- a/api/test/wfl/integration/modules/wgs_test.clj
+++ b/api/test/wfl/integration/modules/wgs_test.clj
@@ -153,8 +153,11 @@
                                     :final_gvcf_base_name
                                     :destination_cloud_path]))
           (verify-submitted-inputs [_ _ _ inputs _ _]
-            (verify-workflow-inputs (into {} (map strip-prefix inputs)))
-            (UUID/randomUUID))
+            (map
+             (fn [in]
+               (verify-workflow-inputs (into {} (map strip-prefix in)))
+               (UUID/randomUUID))
+             inputs))
           (test-with-input [key value]
             (let [request (-> (make-wgs-workload-request)
                               (assoc :items [{:inputs {key value}}]))]

--- a/api/test/wfl/integration/modules/wgs_test.clj
+++ b/api/test/wfl/integration/modules/wgs_test.clj
@@ -92,12 +92,12 @@
             (is (:updated workflow)))
           (use-input_bam [items]
             (mapv
-              (fn [item]
-                (update item :inputs
-                        #(-> %
-                             (dissoc :input_cram)
-                             (assoc :input_bam "gs://inputs/fake.bam"))))
-              items))
+             (fn [item]
+               (update item :inputs
+                       #(-> %
+                            (dissoc :input_cram)
+                            (assoc :input_bam "gs://inputs/fake.bam"))))
+             items))
           (verify-use_input_bam! [inputs labels]
             (is (contains? inputs :input_bam))
             (is (util/absent? inputs :input_cram))

--- a/api/test/wfl/integration/modules/wgs_test.clj
+++ b/api/test/wfl/integration/modules/wgs_test.clj
@@ -159,7 +159,7 @@
             (let [request (-> (make-wgs-workload-request)
                               (assoc :items [{:inputs {key value}}]))]
               (testing (str "default inputs when given only " key)
-                (with-redefs-fn {#'submit-workflow verify-submitted-inputs
+                (with-redefs-fn {#'submit-workflows verify-submitted-inputs
                                  #'skip-workflow? (constantly false)}
                   #(workloads/execute-workload! request)))))]
     (test-with-input :input_bam (:input_cram workloads/wgs-inputs))

--- a/api/test/wfl/integration/modules/wgs_test.clj
+++ b/api/test/wfl/integration/modules/wgs_test.clj
@@ -132,7 +132,7 @@
                (UUID/randomUUID))
              inputs))]
     (with-redefs-fn {#'submit-workflows verify-submitted-inputs
-                     #'skip-workflow? (constantly nil)}
+                     #'skip-workflow? (constantly false)}
       (fn []
         (->
          (make-wgs-workload-request)
@@ -176,7 +176,7 @@
               (is (= defaults (select-keys options (keys defaults))))
               (map (fn [_] (UUID/randomUUID)) inputs)))]
     (with-redefs-fn {#'submit-workflows verify-submitted-options
-                     #'skip-workflow? (constantly nil)}
+                     #'skip-workflow? (constantly false)}
       (fn []
         (->
          (make-wgs-workload-request)

--- a/api/test/wfl/integration/modules/xx_test.clj
+++ b/api/test/wfl/integration/modules/xx_test.clj
@@ -3,6 +3,7 @@
             [clojure.string :as str]
             [wfl.environments :as env]
             [wfl.module.xx :as xx]
+            [wfl.module.batch :as batch]
             [wfl.service.cromwell :refer [wait-for-workflow-complete submit-workflows]]
             [wfl.tools.endpoints :as endpoints]
             [wfl.tools.fixtures :as fixtures]
@@ -18,7 +19,7 @@
       workloads/xx-workload-request
       (assoc :creator (:email @endpoints/userinfo))))
 
-(defn mock-submit-workload [{:keys [workflows]}]
+(defn mock-submit-workload [{:keys [workflows]} _ _ _ _]
   (let [now       (OffsetDateTime/now)
         do-submit #(assoc % :uuid (UUID/randomUUID)
                           :status "Submitted"
@@ -56,7 +57,7 @@
             (is (:uuid workflow))
             (is (:status workflow))
             (is (:updated workflow)))]
-    (with-redefs-fn {#'xx/submit-workload! mock-submit-workload}
+    (with-redefs-fn {#'batch/submit-workload! mock-submit-workload}
       #(-> (make-xx-workload-request)
            workloads/create-workload!
            workloads/start-workload!

--- a/api/test/wfl/system/v1_endpoint_test.clj
+++ b/api/test/wfl/system/v1_endpoint_test.clj
@@ -81,7 +81,7 @@
       (verify-internal-properties-removed workload)
       (workloads/when-done verify-succeeded-workload workload))))
 
-(deftest test-start-wgs-workload
+(deftest ^:parallel test-start-wgs-workload
   (test-start-workload (create-wgs-workload)))
 (deftest ^:parallel test-start-aou-workload
   (test-start-workload (create-aou-workload)))
@@ -113,7 +113,7 @@
       (verify-internal-properties-removed workload)
       (workloads/when-done verify-succeeded-workload workload))))
 
-(deftest test-exec-wgs-workload
+(deftest ^:parallel test-exec-wgs-workload
   (test-exec-workload (workloads/wgs-workload-request (UUID/randomUUID))))
 (deftest ^:parallel test-exec-aou-workload
   (test-exec-workload (workloads/aou-workload-request (UUID/randomUUID))))


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

https://broadinstitute.atlassian.net/browse/GH-1095

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Start/exec all items in a XX or WGS workload to Cromwell using the batch endpoint, instead of sending a request for each item. The batch endpoint will apply the same labels to every workflow, so item-specific labels were removed.
- Move `submit-workload!` to the batch module
- Remove WGS module skip workflow functionality

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
