### PR TITLE
[GH-1106] `final_gvcf_base_name` and `base_file_name` should be the same as the `sample_name`

### DIFF
--- a/api/src/wfl/module/wgs.clj
+++ b/api/src/wfl/module/wgs.clj
@@ -85,7 +85,7 @@
   [out-gs inputs]
   (let [sample (some inputs [:input_bam :input_cram])
         [_ base _] (all/bam-or-cram? sample)
-        leaf   (util/basename base)
+        leaf   (util/leafname base)
         [_ out-dir] (gcs/parse-gs-url (util/unsuffix base leaf))]
     (-> inputs
         (util/assoc-when util/absent? :base_file_name leaf)

--- a/api/src/wfl/module/xx.clj
+++ b/api/src/wfl/module/xx.clj
@@ -74,15 +74,16 @@
 
 ;; visible for testing
 (defn make-inputs-to-save [output-url inputs]
-  (let [sample-name (fn [basename] (first (str/split basename #"\.")))
-        [_ path] (gcs/parse-gs-url (some inputs [:input_bam :input_cram]))
-        basename    (or (:base_file_name inputs) (util/basename path))]
+  (let [sample (some inputs [:input_bam :input_cram])
+        [_ base _] (all/bam-or-cram? sample)
+        leaf   (util/basename base)
+        [_ out-dir] (gcs/parse-gs-url base)]
     (-> inputs
-        (assoc :base_file_name basename)
-        (util/assoc-when util/absent? :sample_name (sample-name basename))
-        (util/assoc-when util/absent? :final_gvcf_base_name basename)
+        (util/assoc-when util/absent? :base_file_name leaf)
+        (util/assoc-when util/absent? :sample_name leaf)
+        (util/assoc-when util/absent? :final_gvcf_base_name leaf)
         (util/assoc-when util/absent? :destination_cloud_path
-                         (str (all/slashify output-url) (util/dirname path))))))
+                         (str (all/slashify output-url) (util/dirname out-dir))))))
 
 ;; visible for testing
 (defn submit-workload! [{:keys [uuid workflows] :as workload}]

--- a/api/src/wfl/module/xx.clj
+++ b/api/src/wfl/module/xx.clj
@@ -76,7 +76,7 @@
 (defn make-inputs-to-save [output-url inputs]
   (let [sample (some inputs [:input_bam :input_cram])
         [_ base _] (all/bam-or-cram? sample)
-        leaf   (util/basename base)
+        leaf   (util/leafname base)
         [_ out-dir] (gcs/parse-gs-url base)]
     (-> inputs
         (util/assoc-when util/absent? :base_file_name leaf)

--- a/api/src/wfl/util.clj
+++ b/api/src/wfl/util.clj
@@ -98,8 +98,8 @@ vault.client.http/http-client                               ; Keep :clint eastwo
     (subs filename 0 idx)
     filename))
 
-(defn basename
-  "Strip directory and suffix from `filename`."
+(defn leafname
+  "Strip directory from `filename`."
   [filename]
   (if (= "/" filename)
     filename

--- a/api/test/wfl/unit/modules/all_test.clj
+++ b/api/test/wfl/unit/modules/all_test.clj
@@ -6,7 +6,7 @@
             [wfl.module.wgs :as wgs]
             [wfl.module.xx :as xx]
             [wfl.wfl :as wfl]
-            [wfl.util :refer [basename]]))
+            [wfl.util :refer [leafname]]))
 
 (deftest test-cromwell-environments
   (let [url (get-in env/gotc-dev [:cromwell :url])]
@@ -20,7 +20,7 @@
 
 (deftest test-version-edn-contains-wdl-version
   (let [edn          (wfl/get-the-version)
-        has-version? #(= (:release %) (-> % :top basename edn))]
+        has-version? #(= (:release %) (-> % :top leafname edn))]
     (is (every? has-version? [aou/workflow-wdl
                               wgs/workflow-wdl
                               xx/workflow-wdl]))))

--- a/api/test/wfl/unit/modules/xx_test.clj
+++ b/api/test/wfl/unit/modules/xx_test.clj
@@ -9,8 +9,8 @@
         inputs (xx/make-inputs-to-save output-url {:input_cram sample})]
     (is (= sample (:input_cram inputs)))
     (is (= "sample" (:sample_name inputs)))
-    (is (= "sample.cram" (:base_file_name inputs)))
-    (is (= "sample.cram" (:final_gvcf_base_name inputs)))
+    (is (= "sample" (:base_file_name inputs)))
+    (is (= "sample" (:final_gvcf_base_name inputs)))
     (is (= (str output-url "folder") (:destination_cloud_path inputs)))))
 
 (deftest test-make-inputs-from-bam
@@ -18,8 +18,8 @@
         inputs (xx/make-inputs-to-save output-url {:input_bam sample})]
     (is (= sample (:input_bam inputs)))
     (is (= "sample" (:sample_name inputs)))
-    (is (= "sample.bam" (:base_file_name inputs)))
-    (is (= "sample.bam" (:final_gvcf_base_name inputs)))
+    (is (= "sample" (:base_file_name inputs)))
+    (is (= "sample" (:final_gvcf_base_name inputs)))
     (is (= (str output-url "folder") (:destination_cloud_path inputs)))))
 
 (deftest test-specifying-destination_cloud_path

--- a/api/test/wfl/unit/utils_test.clj
+++ b/api/test/wfl/unit/utils_test.clj
@@ -17,8 +17,8 @@
   (fn [[input expected]]
     (is (= expected (transform input)))))
 
-(deftest test-basename
-  (let [go         (testing-equality-on util/basename)
+(deftest test-leafname
+  (let [go         (testing-equality-on util/leafname)
         parameters [["" ""]
                     ["/" "/"]
                     ["foo" "foo"]


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1106

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Just copies the logic from WGS
  - Not exactly, because there's some small behavior differences, like WGS including the unmapped bam suffix or XX not having a slash after the destination cloud path, that I thought it would be good to keep. Not wanting to make this a bigger change

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- Unit tests cover this, see the test in changed files to see exactly what this change does
