### PR TITLE
[GH-1111] Handle Mercury staging messages for AOU

### DIFF
--- a/functions/aou/main.py
+++ b/functions/aou/main.py
@@ -42,10 +42,10 @@ def get_manifest_path(object_name):
     return '/'.join(segments)
 
 
-def get_or_create_workload(headers):
+def get_or_create_workload(headers, environment):
     payload = {
         'cromwell': CROMWELL_URL,
-        'output': OUTPUT_BUCKET,
+        'output': f'{OUTPUT_BUCKET}/{environment}',
         'pipeline': 'AllOfUsArrays',
         'project': WFL_ENVIRONMENT
     }
@@ -117,7 +117,8 @@ def submit_aou_workload(event, context):
     chip_well_barcode = notification.get('chip_well_barcode')
     analysis_version = notification.get('analysis_version_number')
     print(f'Upload complete for {chip_well_barcode}-{analysis_version}')
-    workload_uuid = get_or_create_workload(headers)
+    environment = notification.get('environment')
+    workload_uuid = get_or_create_workload(headers, environment)
     print(f'Updating workload: {workload_uuid}')
     workflow_ids = update_workload(headers, workload_uuid, input_data)
     print(

--- a/functions/aou/main.py
+++ b/functions/aou/main.py
@@ -117,7 +117,7 @@ def submit_aou_workload(event, context):
     chip_well_barcode = notification.get('chip_well_barcode')
     analysis_version = notification.get('analysis_version_number')
     print(f'Upload complete for {chip_well_barcode}-{analysis_version}')
-    environment = notification.get('environment')
+    environment = notification.get('environment').lower()
     workload_uuid = get_or_create_workload(headers, environment)
     print(f'Updating workload: {workload_uuid}')
     workflow_ids = update_workload(headers, workload_uuid, input_data)

--- a/functions/aou/main.py
+++ b/functions/aou/main.py
@@ -37,7 +37,7 @@ def get_auth_headers():
 
 
 def get_manifest_path(object_name):
-    segments = object_name.strip('/').split('/', maxsplit=3)[:3]
+    segments = object_name.strip('/').split('/', maxsplit=4)[:4]
     segments.append('ptc.json')
     return '/'.join(segments)
 

--- a/functions/aou/tests/unit_tests.py
+++ b/functions/aou/tests/unit_tests.py
@@ -4,13 +4,13 @@ from aou import main
 
 
 bucket_name = "test_bucket"
-file_name = "chip_name/chipwell_barcode/analysis_version/arrays/metadata/file.txt"
+file_name = "dev/chip_name/chipwell_barcode/analysis_version/arrays/metadata/file.txt"
 event_data = {'bucket': bucket_name, 'name': file_name}
 
 
 def test_get_manifest_path_from_uploaded_file():
-    uploaded_file = "chip_name/chipwell_barcode/analysis_version/arrays/metadata/file.txt"
-    manifest_file = "chip_name/chipwell_barcode/analysis_version/ptc.json"
+    uploaded_file = "dev/chip_name/chipwell_barcode/analysis_version/arrays/metadata/file.txt"
+    manifest_file = "dev/chip_name/chipwell_barcode/analysis_version/ptc.json"
     result = main.get_manifest_path(uploaded_file)
     assert result == manifest_file
 

--- a/functions/aou/tests/unit_tests.py
+++ b/functions/aou/tests/unit_tests.py
@@ -32,7 +32,7 @@ def test_manifest_file_not_uploaded(mock_headers, mock_download, mock_get_worklo
 @mock.patch("aou.main.get_auth_headers")
 def test_input_file_not_uploaded(mock_headers, mock_download, mock_get_blob, mock_get_workload, mock_update_workload):
     client = mock.create_autospec(storage.Client())
-    mock_download.return_value = '{"notifications": [{"file": "gs://test_bucket/file.txt"}]}'
+    mock_download.return_value = '{"notifications": [{"file": "gs://test_bucket/file.txt", "environment": "dev"}]}'
     mock_get_blob.return_value = None
     main.submit_aou_workload(event_data, None)
     assert not mock_get_workload.called
@@ -47,7 +47,7 @@ def test_wfl_called_when_sample_upload_completes(mock_headers, mock_download, mo
     client = mock.create_autospec(storage.Client())
     mock_download.return_value = '{"cromwell": "http://cromwell.broadinstitute.org", ' \
                                  '"sample_alias": "test_sample", ' \
-                                 '"notifications": [{"file": "gs://test_bucket/file.txt"}]}'
+                                 '"notifications": [{"file": "gs://test_bucket/file.txt", "environment": "dev"}]}'
     mock_get_blob.return_value = "blob"
     main.submit_aou_workload(event_data, None)
     assert mock_get_workload.called


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

https://broadinstitute.atlassian.net/browse/GH-1111

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Update how the cloud function parses the file paths, since [this change in PTC](https://github.com/broadinstitute/push-to-cloud-service/pull/61) will include an `environment` directory 
- Include the `environment` in the output directory path (this will make WFL create different workloads for staging and dev messages)

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
