### PR TITLE
[GH-757] Grab deployment keys from Vault, not secrets

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -47,13 +47,67 @@ jobs:
         with:
           python-version: '3.8' # Version range or exact version of a Python version to use, using SemVer's version range syntax
 
-      - name: Configure SSH Keys
+        # Get secret from vault
+      - name: Authenticate to GCloud
+        id: gcloud
+        env:
+          ROLE_ID: ${{ secrets.ROLE_ID }}
+          SECRET_ID: ${{ secrets.SECRET_ID }}
+          VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
         run: |
+          # get vault token using role-id and secret-id
+          VAULT_TOKEN=$(curl \
+              --request POST \
+              --data "{\"role_id\":\"${ROLE_ID}\",\"secret_id\":\"${SECRET_ID}\"}" \
+              ${VAULT_ADDR}/v1/auth/approle/login | jq -r .auth.client_token)
+          if [ -z "${VAULT_TOKEN}" ] ; then
+            echo "Vault authentication failed!"
+            exit 1
+          fi
+          echo ::add-mask::${VAULT_TOKEN}
+          echo "VAULT_TOKEN=${VAULT_TOKEN}" >> $GITHUB_ENV
+          echo ${VAULT_TOKEN} > ~/.vault-token
+
+          # use vault token to read secret - service account json
+          curl --silent -H "X-Vault-Token: ${VAULT_TOKEN}" -X GET \
+              ${VAULT_ADDR}/v1/secret/dsde/gotc/dev/wfl/wfl-non-prod-service-account.json \
+              | jq .data > sa.json
+          if [ ! -s sa.json ] ; then
+            echo "Retrieval of Gcloud SA credentials failed"
+            exit 1
+          fi
+          # auth as service account
+          gcloud auth activate-service-account --key-file=sa.json
+          if [ $? -ne 0 ] ; then
+            echo "Gcloud auth failed!"
+            exit 1
+          fi
+
+          # get bearer token and set it to a specific env var that
+          #   subsequent steps expect.  bearer token good for 1 hour
+          GOOGLE_OAUTH_ACCESS_TOKEN=$(gcloud auth print-access-token)
+          if [ -z "${GOOGLE_OAUTH_ACCESS_TOKEN}" ] ; then
+            echo "Generating Gcloud access token failed"
+            exit 1
+          fi
+          echo ::add-mask::${GOOGLE_OAUTH_ACCESS_TOKEN}
+          echo "GOOGLE_OAUTH_ACCESS_TOKEN=${GOOGLE_OAUTH_ACCESS_TOKEN}" >> $GITHUB_ENV
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$(find `pwd` -maxdepth 1 -name sa.json)" >> $GITHUB_ENV
+
+          # use vault token to get SSH private keys
           mkdir -p ~/.ssh
 
-          echo "${{ secrets.pipeline_config_deploy_key }}" > ~/.ssh/pipeline_config_deploy_key
-          echo "${{ secrets.warp_deploy_key }}" > ~/.ssh/warp_deploy_key
-          echo "${{ secrets.wfl_deploy_key }}" > ~/.ssh/wfl_deploy_key
+          curl --silent -H "X-Vault-Token: ${VAULT_TOKEN}" -X GET \
+              ${VAULT_ADDR}/v1/secret/dsde/gotc/dev/ci/wfl_deploy_keys \
+              | jq -r '.data."pipeline-config-deployment_private_key"' > ~/.ssh/pipeline_config_deploy_key
+
+          curl --silent -H "X-Vault-Token: ${VAULT_TOKEN}" -X GET \
+              ${VAULT_ADDR}/v1/secret/dsde/gotc/dev/ci/wfl_deploy_keys \
+              | jq -r '.data."warp-deployment_private_key"' > ~/.ssh/warp_deploy_key
+
+          curl --silent -H "X-Vault-Token: ${VAULT_TOKEN}" -X GET \
+              ${VAULT_ADDR}/v1/secret/dsde/gotc/dev/ci/wfl_deploy_keys \
+              | jq -r '.data."wfl-deployment_private_key"' > ~/.ssh/wfl_deploy_key
 
           chmod 600 ~/.ssh/pipeline_config_deploy_key
           chmod 600 ~/.ssh/warp_deploy_key
@@ -90,51 +144,6 @@ jobs:
 
       - name: Build
         run: make ${MODULES} TARGET=build
-
-        # Get secret from vault
-      - name: Authenticate to GCloud
-        id: gcloud
-        env:
-          ROLE_ID: ${{ secrets.ROLE_ID }}
-          SECRET_ID: ${{ secrets.SECRET_ID }}
-          VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
-        run: |
-          # get vault token using role-id and secret-id
-          VAULT_TOKEN=$(curl \
-              --request POST \
-              --data "{\"role_id\":\"${ROLE_ID}\",\"secret_id\":\"${SECRET_ID}\"}" \
-              ${VAULT_ADDR}/v1/auth/approle/login | jq -r .auth.client_token)
-          if [ -z "${VAULT_TOKEN}" ] ; then
-            echo "Vault authentication failed!"
-            exit 1
-          fi
-          echo ::add-mask::${VAULT_TOKEN}
-          echo "VAULT_TOKEN=${VAULT_TOKEN}" >> $GITHUB_ENV
-          echo ${VAULT_TOKEN} > ~/.vault-token
-          # use vault token to read secret - service account json
-          curl --silent -H "X-Vault-Token: ${VAULT_TOKEN}" -X GET \
-              ${VAULT_ADDR}/v1/secret/dsde/gotc/dev/wfl/wfl-non-prod-service-account.json \
-              | jq .data > sa.json
-          if [ ! -s sa.json ] ; then
-            echo "Retrieval of Gcloud SA credentials failed"
-            exit 1
-          fi
-          # auth as service account
-          gcloud auth activate-service-account --key-file=sa.json
-          if [ $? -ne 0 ] ; then
-            echo "Gcloud auth failed!"
-            exit 1
-          fi
-          # get bearer token and set it to a specific env var that
-          #   subsequent steps expect.  bearer token good for 1 hour
-          GOOGLE_OAUTH_ACCESS_TOKEN=$(gcloud auth print-access-token)
-          if [ -z "${GOOGLE_OAUTH_ACCESS_TOKEN}" ] ; then
-            echo "Generating Gcloud access token failed"
-            exit 1
-          fi
-          echo ::add-mask::${GOOGLE_OAUTH_ACCESS_TOKEN}
-          echo "GOOGLE_OAUTH_ACCESS_TOKEN=${GOOGLE_OAUTH_ACCESS_TOKEN}" >> $GITHUB_ENV
-          echo "GOOGLE_APPLICATION_CREDENTIALS=$(find `pwd` -maxdepth 1 -name sa.json)" >> $GITHUB_ENV
 
       - name: Unit Test
         run: make ${MODULES} TARGET=unit

--- a/.github/workflows/release_latest_version.yml
+++ b/.github/workflows/release_latest_version.yml
@@ -58,13 +58,67 @@ jobs:
         with:
           cli: '1.10.1.739'
 
-      - name: Configure SSH Keys
+        # Get secret from vault
+      - name: Authenticate to GCloud
+        id: gcloud
+        env:
+          ROLE_ID: ${{ secrets.ROLE_ID }}
+          SECRET_ID: ${{ secrets.SECRET_ID }}
+          VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
         run: |
+          # get vault token using role-id and secret-id
+          VAULT_TOKEN=$(curl \
+              --request POST \
+              --data "{\"role_id\":\"${ROLE_ID}\",\"secret_id\":\"${SECRET_ID}\"}" \
+              ${VAULT_ADDR}/v1/auth/approle/login | jq -r .auth.client_token)
+          if [ -z "${VAULT_TOKEN}" ] ; then
+            echo "Vault authentication failed!"
+            exit 1
+          fi
+          echo ::add-mask::${VAULT_TOKEN}
+          echo "VAULT_TOKEN=${VAULT_TOKEN}" >> $GITHUB_ENV
+          echo ${VAULT_TOKEN} > ~/.vault-token
+
+          # use vault token to read secret - service account json
+          curl --silent -H "X-Vault-Token: ${VAULT_TOKEN}" -X GET \
+              ${VAULT_ADDR}/v1/secret/dsde/gotc/dev/wfl/wfl-non-prod-service-account.json \
+              | jq .data > sa.json
+          if [ ! -s sa.json ] ; then
+            echo "Retrieval of Gcloud SA credentials failed"
+            exit 1
+          fi
+          # auth as service account
+          gcloud auth activate-service-account --key-file=sa.json
+          if [ $? -ne 0 ] ; then
+            echo "Gcloud auth failed!"
+            exit 1
+          fi
+
+          # get bearer token and set it to a specific env var that
+          #   subsequent steps expect.  bearer token good for 1 hour
+          GOOGLE_OAUTH_ACCESS_TOKEN=$(gcloud auth print-access-token)
+          if [ -z "${GOOGLE_OAUTH_ACCESS_TOKEN}" ] ; then
+            echo "Generating Gcloud access token failed"
+            exit 1
+          fi
+          echo ::add-mask::${GOOGLE_OAUTH_ACCESS_TOKEN}
+          echo "GOOGLE_OAUTH_ACCESS_TOKEN=${GOOGLE_OAUTH_ACCESS_TOKEN}" >> $GITHUB_ENV
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$(find `pwd` -maxdepth 1 -name sa.json)" >> $GITHUB_ENV
+
+          # use vault token to get SSH private keys
           mkdir -p ~/.ssh
 
-          echo "${{ secrets.pipeline_config_deploy_key }}" > ~/.ssh/pipeline_config_deploy_key
-          echo "${{ secrets.warp_deploy_key }}" > ~/.ssh/warp_deploy_key
-          echo "${{ secrets.wfl_deploy_key }}" > ~/.ssh/wfl_deploy_key
+          curl --silent -H "X-Vault-Token: ${VAULT_TOKEN}" -X GET \
+              ${VAULT_ADDR}/v1/secret/dsde/gotc/dev/ci/wfl_deploy_keys \
+              | jq -r '.data."pipeline-config-deployment_private_key"' > ~/.ssh/pipeline_config_deploy_key
+
+          curl --silent -H "X-Vault-Token: ${VAULT_TOKEN}" -X GET \
+              ${VAULT_ADDR}/v1/secret/dsde/gotc/dev/ci/wfl_deploy_keys \
+              | jq -r '.data."warp-deployment_private_key"' > ~/.ssh/warp_deploy_key
+
+          curl --silent -H "X-Vault-Token: ${VAULT_TOKEN}" -X GET \
+              ${VAULT_ADDR}/v1/secret/dsde/gotc/dev/ci/wfl_deploy_keys \
+              | jq -r '.data."wfl-deployment_private_key"' > ~/.ssh/wfl_deploy_key
 
           chmod 600 ~/.ssh/pipeline_config_deploy_key
           chmod 600 ~/.ssh/warp_deploy_key
@@ -92,50 +146,6 @@ jobs:
           docker login \
             --username "${{ secrets.dockerhub_username }}" \
             --password "${{ secrets.dockerhub_password }}"
-
-        # Get secret from vault
-      - name: Authenticate to GCloud
-        id: gcloud
-        env:
-          ROLE_ID: ${{ secrets.ROLE_ID }}
-          SECRET_ID: ${{ secrets.SECRET_ID }}
-          VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
-        run: |
-          # get vault token using role-id and secret-id
-          VAULT_TOKEN=$(curl \
-              --request POST \
-              --data "{\"role_id\":\"${ROLE_ID}\",\"secret_id\":\"${SECRET_ID}\"}" \
-              ${VAULT_ADDR}/v1/auth/approle/login | jq -r .auth.client_token)
-          if [ -z "${VAULT_TOKEN}" ] ; then
-            echo "Vault authentication failed!"
-            exit 1
-          fi
-          echo ::add-mask::${VAULT_TOKEN}
-          echo "VAULT_TOKEN=${VAULT_TOKEN}" >> $GITHUB_ENV
-          echo ${VAULT_TOKEN} > ~/.vault-token
-          # use vault token to read secret - service account json
-          curl --silent -H "X-Vault-Token: ${VAULT_TOKEN}" -X GET \
-              ${VAULT_ADDR}/v1/secret/dsde/gotc/dev/wfl/wfl-non-prod-service-account.json \
-              | jq .data > sa.json
-          if [ ! -s sa.json ] ; then
-            echo "Retrieval of Gcloud SA credentials failed"
-            exit 1
-          fi
-          # auth as service account
-          gcloud auth activate-service-account --key-file=sa.json
-          if [ $? -ne 0 ] ; then
-            echo "Gcloud auth failed!"
-            exit 1
-          fi
-          # get bearer token and set it to a specific env var that
-          #   subsequent steps expect.  bearer token good for 1 hour
-          GOOGLE_OAUTH_ACCESS_TOKEN=$(gcloud auth print-access-token)
-          if [ -z "${GOOGLE_OAUTH_ACCESS_TOKEN}" ] ; then
-            echo "Generating Gcloud access token failed"
-            exit 1
-          fi
-          echo ::add-mask::${GOOGLE_OAUTH_ACCESS_TOKEN}
-          echo "GOOGLE_OAUTH_ACCESS_TOKEN=${GOOGLE_OAUTH_ACCESS_TOKEN}" >> $GITHUB_ENV
 
       - name: Pre-Build
         run: USER='Automated Release Action' make ${MODULES} TARGET=prebuild


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-757

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Grabs deployment keys from Vault

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- The same thing is done in both deployment and the PR tests, so hopefully the test here passes
- **Question: should the dockerhub creedentials used for deployment also be replaced with ones from Vault? That's slightly higher risk**
- After merging this ticket there's a few secrets that we can safely delete, see the ticket for details