### PR TITLE
[GH-1111] Update AOU cloud fn to handle paths with or without env prefix

### DIFF
--- a/functions/aou/main.py
+++ b/functions/aou/main.py
@@ -48,9 +48,11 @@ def get_manifest_path(object_name):
 
 
 def get_or_create_workload(headers, environment):
+    output = f'{OUTPUT_BUCKET}/{environment.lower()}' \
+        if environment else OUTPUT_BUCKET
     payload = {
         'cromwell': CROMWELL_URL,
-        'output': f'{OUTPUT_BUCKET}/{environment.lower()}' if environment else OUTPUT_BUCKET,
+        'output': output,
         'pipeline': 'AllOfUsArrays',
         'project': WFL_ENVIRONMENT
     }

--- a/functions/aou/tests/unit_tests.py
+++ b/functions/aou/tests/unit_tests.py
@@ -8,9 +8,15 @@ file_name = "dev/chip_name/chipwell_barcode/analysis_version/arrays/metadata/fil
 event_data = {'bucket': bucket_name, 'name': file_name}
 
 
-def test_get_manifest_path_from_uploaded_file():
+def test_get_manifest_path_from_uploaded_file_with_environment_prefix():
     uploaded_file = "dev/chip_name/chipwell_barcode/analysis_version/arrays/metadata/file.txt"
     manifest_file = "dev/chip_name/chipwell_barcode/analysis_version/ptc.json"
+    result = main.get_manifest_path(uploaded_file)
+    assert result == manifest_file
+
+def test_get_manifest_path_from_uploaded_file():
+    uploaded_file = "chip_name/chipwell_barcode/analysis_version/arrays/metadata/file.txt"
+    manifest_file = "chip_name/chipwell_barcode/analysis_version/ptc.json"
     result = main.get_manifest_path(uploaded_file)
     assert result == manifest_file
 


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

https://broadinstitute.atlassian.net/browse/GH-1111

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

Update the AOU cloud function to handle both the old/existing input file paths and the "new" file paths that will be prefixed with the mercury environment. This will allow us to re-deploy the cloud function without stopping PTC/having to coordinate with BITS.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
