### PR TITLE
[GH-1105] Add update loop plumbing

### DIFF
--- a/api/src/wfl/main.clj
+++ b/api/src/wfl/main.clj
@@ -43,7 +43,6 @@
           (namify [ns] (last (str/split (name ns) #"\.")))]
     (let [namespaces '[wfl.dx
                        wfl.metadata
-                       wfl.module.wgs
                        wfl.server]]
       (assoc (zipmap (map namify namespaces) (map varify namespaces))
              "help"         #'help

--- a/api/src/wfl/server.clj
+++ b/api/src/wfl/server.clj
@@ -80,7 +80,7 @@
     (log/info "starting workload update loop")
     (update-workloads!)
     (future
-      (while [true]
+      (while true
         (update-workloads!)
         (.sleep TimeUnit/SECONDS 20)))))
 

--- a/api/src/wfl/server.clj
+++ b/api/src/wfl/server.clj
@@ -104,9 +104,12 @@
 
 (defn ^:private await-some [& futures]
   (loop []
-    (when-not (some future-done? futures)
-      (.sleep TimeUnit/SECONDS 1)
-      (recur))))
+    (let [fs (filter future-done? futures)]
+      (if (not-empty fs)
+        @(first fs)
+        (do
+          (.sleep TimeUnit/SECONDS 1)
+          (recur))))))
 
 (defn run
   "Run child server in ENVIRONMENT on PORT."

--- a/api/src/wfl/server.clj
+++ b/api/src/wfl/server.clj
@@ -14,8 +14,7 @@
             [wfl.api.routes :as routes]
             [wfl.util :as util]
             [wfl.wfl :as wfl])
-  (:import [org.eclipse.jetty.util.log Log Logger]
-           (java.util.concurrent TimeUnit)))
+  (:import (java.util.concurrent TimeUnit)))
 
 (def description
   "The purpose of this command."
@@ -72,23 +71,9 @@
       wrap-internal-error
       (wrap-json-response {:pretty true})))
 
-(defn stfu-jetty
-  "Set up a stub logger to shut Jetty up."
-  []
-  (Log/setLog
-   (proxy [Logger] []
-     (debug ([thrown]) ([msg & args]))
-     (getLogger [name] this)
-     (getName [] "JettyStfu")
-     (ignore [ignored])
-     (info ([thrown]) ([msg & args]))
-     (isDebugEnabled [] false)
-     (setDebugEnabled [enabled])
-     (warn ([thrown]) ([msg & args])))))
-
 (defn ^:private start-workload-manager []
   (letfn [(update-workloads! [])] ;; todo
-    (pprint "starting workload update loop")
+    (log/info "starting workload update loop")
     (update-workloads!)
     (future
       (loop []
@@ -98,8 +83,7 @@
 
 (defn ^:private start-server [args]
   (let [port {:port (util/is-non-negative! (first args))}]
-    (pprint [wfl/the-name port])
-    (stfu-jetty)
+    (log/info wfl/the-name port)
     (future (jetty/run-jetty app port))))
 
 (defn ^:private await-some [& futures]
@@ -114,6 +98,6 @@
 (defn run
   "Run child server in ENVIRONMENT on PORT."
   [& args]
-  (pprint (into ["Run:" wfl/the-name "server"] args))
+  (log/info "Run:" wfl/the-name "server" args)
   (let [manager (start-workload-manager)]
     (await-some manager (start-server args))))

--- a/api/src/wfl/server.clj
+++ b/api/src/wfl/server.clj
@@ -14,7 +14,7 @@
             [wfl.api.routes :as routes]
             [wfl.util :as util]
             [wfl.wfl :as wfl])
-  (:import (java.util.concurrent TimeUnit Future)))
+  (:import (java.util.concurrent Future TimeUnit)))
 
 (def description
   "The purpose of this command."
@@ -92,9 +92,9 @@
   (log/infof "starting jetty webserver on port %s" port)
   (let [server    (jetty/run-jetty app {:port port :join? false})]
     (reify Future
-      (cancel [_ _] (.stop server))
+      (cancel [_ _] (throw (UnsupportedOperationException.)))
       (get [_] (.join server))
-      (get [_ _ _] (.join server))
+      (get [_ _ _] (throw (UnsupportedOperationException.)))
       (isCancelled [_] false)
       (isDone [_] (.isStopped server)))))
 


### PR DESCRIPTION
### Purpose
In this change, I'm adding the plumbing for the update loop + whatever task that needs to be done periodically. I've left the actual update function empty as I want the plumbing reviewed rather than the update code itself.

I'm using futures for the jetty server and the update loop because if either fail, I want the entire service to come down. I also wanted to tie their lifetimes somehow. Unfortunately, This means I'm using 2 extra threads. I could use the main thread to poll the status of the jetty server, but I thought that this approach was simpler for now.

### Review Instructions
What do people think of this approach? It's pretty straightforward but are there other designs people have thought about?
