### PR TITLE
[GH-1119] Get vault_token_path from AOU inputs

### DIFF
--- a/api/src/wfl/module/aou.clj
+++ b/api/src/wfl/module/aou.clj
@@ -89,7 +89,9 @@
                         ;; arbitrary path to be used by BAFRegress
                         :minor_allele_frequency_file
                         ;; some message-specified environment to override WFL's
-                        :environment]
+                        :environment
+                        ;; some message-specified vault token path to override WFL's
+                        :vault_token_path]
         mandatory      (select-keys inputs mandatory-keys)
         optional       (select-keys inputs optional-keys)
         missing        (vec (keep (fn [k] (when (nil? (k mandatory)) k)) mandatory-keys))]
@@ -105,6 +107,7 @@
              other-inputs
              (env-inputs environment)
              (get-per-sample-inputs per-sample-inputs))
+      (update :environment str/lower-case)
       (util/prefix-keys :Arrays)))
 
 ;; visible for testing


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

https://broadinstitute.atlassian.net/browse/GH-1119

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Use the `vault_token_path` from the AOU inputs, since it will differ based on the mercury environment.
- Lowercase the environment variable (the WDL uses the environment input to construct a vault path, so if the environment is "Staging" instead of "staging", it will not find a value)

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
