### PR TITLE
[GH-1125] Don't finish unstarted workloads

### DIFF
--- a/api/src/wfl/service/postgres.clj
+++ b/api/src/wfl/service/postgres.clj
@@ -85,8 +85,9 @@
                     {:finished (OffsetDateTime/now)} ["id = ?" id]))))
 
 (defn update-workload!
-  "Use transaction TX to update WORKLOAD statuses."
+  "Use transaction TX to update WORKLOAD statuses if it has been started."
   [tx workload]
-  (do
-    (update-workflow-statuses! tx workload)
-    (update-workload-status! tx workload)))
+  (if (and (:started workload) (not (:finished workload)))
+    (do
+      (update-workflow-statuses! tx workload)
+      (update-workload-status! tx workload))))

--- a/api/src/wfl/service/postgres.clj
+++ b/api/src/wfl/service/postgres.clj
@@ -78,7 +78,7 @@
 (defn update-workload-status!
   "Use `tx` to mark `workload` finished when all `workflows` are finished."
   [tx {:keys [id items] :as _workload}]
-  (let [query (format "SELECT id FROM %%s WHERE status NOT IN %s"
+  (let [query (format "SELECT id FROM %%s WHERE status IS NULL OR status NOT IN %s"
                       (util/to-quoted-comma-separated-list finished?))]
     (when (empty? (jdbc/query tx (format query items)))
       (jdbc/update! tx :workload

--- a/api/test/wfl/integration/modules/aou_test.clj
+++ b/api/test/wfl/integration/modules/aou_test.clj
@@ -47,6 +47,13 @@
            (is (s/valid? :wfl.api.spec/append-to-aou-response response))
            (is (empty? response)))))))
 
+(deftest test-update-unstarted
+  (let [workload (->> (make-aou-workload-request)
+                      workloads/create-workload!
+                      workloads/update-workload!)]
+    (is (nil? (:finished workload)))
+    (is (nil? (:submitted workload)))))
+
 (deftest test-append-to-aou-not-started
   (with-redefs-fn {#'aou/submit-aou-workflow mock-submit-workload}
     #(is

--- a/api/test/wfl/integration/modules/arrays_test.clj
+++ b/api/test/wfl/integration/modules/arrays_test.clj
@@ -39,6 +39,13 @@
                      workloads/create-workload!)]
     (run! check-inputs (:workflows workload))))
 
+(deftest test-update-unstarted
+  (let [workload (->> (make-arrays-workload-request)
+                      workloads/create-workload!
+                      workloads/update-workload!)]
+    (is (nil? (:finished workload)))
+    (is (nil? (:submitted workload)))))
+
 (deftest test-start-arrays-workload!
   (with-redefs-fn {#'terra/create-submission mock-terra-create-submission}
     #(let [workload (-> (make-arrays-workload-request)

--- a/api/test/wfl/integration/modules/copyfile_test.clj
+++ b/api/test/wfl/integration/modules/copyfile_test.clj
@@ -27,6 +27,13 @@
         (jdbc/update! tx :workload {:version "0.3.8"} ["id = ?" id])
         id))))
 
+(deftest test-update-unstarted
+  (let [workload (->> (make-copyfile-workload-request "gs://fake/input" "gs://fake/output")
+                      workloads/create-workload!
+                      workloads/update-workload!)]
+    (is (nil? (:finished workload)))
+    (is (nil? (:submitted workload)))))
+
 (deftest test-loading-old-copyfile-workload
   (let [id       (old-create-copyfile-workload!)
         workload (workloads/load-workload-for-id id)]

--- a/api/test/wfl/integration/modules/sg_test.clj
+++ b/api/test/wfl/integration/modules/sg_test.clj
@@ -40,6 +40,13 @@
     (testing "single-sample workload-request"
       (go! (make-sg-workload-request)))))
 
+(deftest test-update-unstarted
+  (let [workload (->> (make-sg-workload-request)
+                      workloads/create-workload!
+                      workloads/update-workload!)]
+    (is (nil? (:finished workload)))
+    (is (nil? (:submitted workload)))))
+
 (deftest test-create-workload-with-common-inputs
   (let [common-inputs {:biobambam_bamtofastq.max_retries 2
                        :ref_pac "gs://fake-location/temp_references/gdc/GRCh38.d1.vd1.fa.pac"}]

--- a/api/test/wfl/integration/modules/wgs_test.clj
+++ b/api/test/wfl/integration/modules/wgs_test.clj
@@ -70,6 +70,13 @@
                   "Inputs are not at the top-level"))]
          (run! check-nesting (:workflows workload))))))
 
+(deftest test-update-unstarted
+  (let [workload (->> (make-wgs-workload-request)
+                      workloads/create-workload!
+                      workloads/update-workload!)]
+    (is (nil? (:finished workload)))
+    (is (nil? (:submitted workload)))))
+
 (defn ^:private old-create-wgs-workload! []
   (let [request (make-wgs-workload-request)]
     (jdbc/with-db-transaction [tx (fixtures/testing-db-config)]

--- a/api/test/wfl/integration/modules/xx_test.clj
+++ b/api/test/wfl/integration/modules/xx_test.clj
@@ -85,6 +85,13 @@
                       workloads/update-workload!)]
     (is (:finished workload))))
 
+(deftest test-update-unstarted
+  (let [workload (->> (make-xx-workload-request)
+                      workloads/create-workload!
+                      workloads/update-workload!)]
+    (is (nil? (:finished workload)))
+    (is (nil? (:submitted workload)))))
+
 (deftest test-submitted-workflow-inputs
   (letfn [(prefixed? [prefix key] (str/starts-with? (str key) (str prefix)))
           (strip-prefix [[k v]]


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1125

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Make the SQL query for unfinished workflows also include workflows with no status, so we correctly leave such workflows untouched if we create and then call update on it
- Make all the module integration tests catch this error

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- Integration tests check this via Ed's reproduction steps
