### PR TITLE
[GH-1129] Avoid NPE in /exec by properly renaming keys

### DIFF
--- a/api/src/wfl/api/handlers.clj
+++ b/api/src/wfl/api/handlers.clj
@@ -111,10 +111,10 @@
 (defn post-exec
   "Create and start workload described in BODY of REQUEST"
   [request]
-  (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
-    (let [workload-request (-> (:body-params request)
-                               (rename-keys {:cromwell :executor}))]
-      (logr/info "post-exec endpoint called: " workload-request)
+  (let [workload-request (-> (:body-params request)
+                             (rename-keys {:cromwell :executor}))]
+    (logr/info "post-exec endpoint called: " workload-request)
+    (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
       (->>
        (gcs/userinfo request)
        :email

--- a/api/src/wfl/api/handlers.clj
+++ b/api/src/wfl/api/handlers.clj
@@ -62,17 +62,17 @@
            succeed))))
 
 (defn post-create
-  "Create the workload described in BODY of REQUEST."
-  [{:keys [parameters] :as request}]
-  (let [{:keys [body]} parameters
-        {:keys [email]} (gcs/userinfo request)]
-    (logr/infof "post-create endpoint called: body=%s" body)
+  "Create the workload described in REQUEST."
+  [request]
+  (let [workload-request (-> (:body-params request)
+                             (rename-keys {:cromwell :executor}))
+        {:keys [email]}  (gcs/userinfo request)]
+    (logr/info "post-create endpoint called: " workload-request)
     (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
-      (succeed
-       (strip-internals
-        (workloads/create-workload! tx (-> body
-                                           (assoc :creator email)
-                                           (rename-keys {:cromwell :executor}))))))))
+      (->> (assoc workload-request :creator email)
+           (workloads/create-workload! tx)
+           strip-internals
+           succeed))))
 
 (defn get-workload!
   "List all workloads or the workload(s) with UUID or PROJECT in REQUEST."
@@ -118,8 +118,9 @@
   "Create and start workload described in BODY of REQUEST"
   [request]
   (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
-    (let [workload-request (:body-params request)]
-      (logr/info "executing workload-request: " workload-request)
+    (let [workload-request (-> (:body-params request)
+                               (rename-keys {:cromwell :executor}))]
+      (logr/info "post-exec endpoint called: " workload-request)
       (->>
        (gcs/userinfo request)
        :email

--- a/api/test/wfl/system/v1_endpoint_test.clj
+++ b/api/test/wfl/system/v1_endpoint_test.clj
@@ -127,6 +127,10 @@
 
 (deftest ^:parallel test-exec-wgs-workload
   (test-exec-workload (workloads/wgs-workload-request (UUID/randomUUID))))
+(deftest ^:parallel test-exec-wgs-workload-specifying-cromwell
+  ;; All modules make use of the same code/behavior here, no need to spam Cromwell
+  (test-exec-workload (-> (workloads/wgs-workload-request (UUID/randomUUID))
+                          (rename-keys {:executor :cromwell}))))
 (deftest ^:parallel test-exec-aou-workload
   (test-exec-workload (workloads/aou-workload-request (UUID/randomUUID))))
 (deftest ^:parallel test-exec-arrays-workload


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1129

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Also rename keys in /exec
- Make /create and /exec look more similar\
- Add a test to catch this

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- Reproduction steps [are here](https://broadinstitute.atlassian.net/browse/GH-1129), against a local instance of this branch it'll not throw a NPE.
- This is my bad, I just didn't get how exec worked--I thought it delegated higher up the chain and it doesn't, so we have to rename the keys in both cases. I tried to make the functions a bit more similar to highlight this fact in the future, since they do actually have to do the same thing.
