### PR TITLE
[Snack] Version the docs

### DIFF
--- a/.github/workflows/doc-site.yml
+++ b/.github/workflows/doc-site.yml
@@ -37,3 +37,4 @@ jobs:
         with:
           personal_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: derived/docs/site
+          keep_files: true

--- a/.github/workflows/release_latest_version.yml
+++ b/.github/workflows/release_latest_version.yml
@@ -27,7 +27,7 @@ jobs:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
     env:
-      MODULES: api ui functions/aou functions/sg
+      MODULES: api ui functions/aou functions/sg docs
 
     steps:
       - name: prepare sources
@@ -170,3 +170,29 @@ jobs:
 
       - name: tag-and-push-images
         run: ./ops/cli.py tag-and-push-images
+
+      - name: Read Version Data
+        id: version
+        run: |
+          echo "::set-output name=VERSION::v$(cat version)"
+          echo "::set-output name=CHANGELOG::$(sed -n '1d;/$#/!p;//q' CHANGELOG.md)"
+
+      - name: Deploy Docs
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          personal_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: derived/docs/site
+          keep_files: true
+          destination_dir: ${{ steps.version.outputs.VERSION }}
+
+      - name: Add Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.version.outputs.VERSION }}
+          body: |
+            Docs available at [broadinstitute.github.io/wfl/${{ steps.version.outputs.VERSION }}](https://broadinstitute.github.io/wfl/${{ steps.version.outputs.VERSION }})
+
+            [Changes](https://github.com/broadinstitute/wfl/blob/${{ steps.version.outputs.VERSION }}/CHANGELOG.md):
+            ${{ steps.version.outputs.CHANGELOG }}


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- Ed mentioned that it is weird that we don't version docs at all, I think it is a good point

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Enabled "keep_files" on our GH Pages deploy action so it doesn't delete things not replicated in the last build, because...
- ...release actions now deploy the docs into a subfolder, so https://broadinstitute.github.io/wfl/v0.5.0 or whatever
- No one would know about that link so now we add a note to the release [here](https://github.com/broadinstitute/wfl/releases)
  - While we're at it, inject the most recent changelog section into those notes
- **TL;DR: current docs stay the same, but now we also get versioned docs linked to from the release for free**

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- I had a touch of free time and figured I might be able to tackle this. Just an idea, not beholden to it at all
