### PR TITLE
[GH-1145] Add AppSec Github Trivy Action

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -16,6 +16,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # The Dockerfile copies this, so it needs
+      # to exist for the build to succeed
+      # (even though it's not scanned)
+      - run: |
+          mkdir target
+          touch target/wfl-api.jar
+
       - uses: broadinstitute/dsp-appsec-trivy-action@v1
         with:
           context: ${{ matrix.context }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # The Dockerfile copies this, so it needs
+      # API Dockerfile copies this, so it needs
       # to exist for the build to succeed
       # (even though it's not scanned)
       - working-directory: ${{ matrix.context }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,21 @@
+name: dsp-appsec-trivy
+on: [pull_request]
+
+jobs:
+  appsec-trivy:
+    # Parse Dockerfile and build, scan image if a "blessed" base image is not used
+    name: DSP AppSec Trivy check
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        context:
+        - api
+        - ui
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: broadinstitute/dsp-appsec-trivy-action@v1
+        with:
+          context: ${{ matrix.context }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -19,7 +19,8 @@ jobs:
       # The Dockerfile copies this, so it needs
       # to exist for the build to succeed
       # (even though it's not scanned)
-      - run: |
+      - working-directory: ${{ matrix.context }}
+        run: |
           mkdir target
           touch target/wfl-api.jar
 


### PR DESCRIPTION
### Purpose
As part of the initial integration of this repo into the Terra ecosystem, this change adds [Trivy](https://github.com/aquasecurity/trivy) security scan for the Docker images.

The scan will run as a GitHub Action on every PR and give you feedback if the Docker image contains Critical OS vulnerabilities. One can then either:

* fix the issue (usually just by updating the packages in the Dockerfile, or the base image itself), or
* ignore it, and document the reason with AppSec. Our compliance process has a timeline of 14 days for patching Critical vulnerabilities, or documenting why they are ignored.

As an alternative, [AppSec "blessed" base images](https://github.com/broadinstitute/dsp-appsec-blessed-images) can be used to skip over this check.

More info:
https://github.com/broadinstitute/dsp-appsec-trivy-action
https://github.com/broadinstitute/dsp-appsec-blessed-images

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- New GitHub workflow: [.github/workflows/trivy.yml](.github/workflows/trivy.yml)

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.

Thanks!
