### PR TITLE
[GH-1182] fix Pub/Sub test data race

### DIFF
--- a/api/test/wfl/integration/google/pubsub_test.clj
+++ b/api/test/wfl/integration/google/pubsub_test.clj
@@ -24,14 +24,14 @@
         ;; messages to the pub/sub topic.
         ;; See https://cloud.google.com/storage/docs/reporting-changes#prereqs
         (give-project-sa-publish-access-to-topic project topic)
-        (fixtures/with-temporary-notification-configuration bucket topic
-          (fn [_]
-            (let [configs (gcs/list-notification-configurations bucket)]
-              (is (< 0 (count configs))))
-            (fixtures/with-temporary-subscription topic
-              (fn [subscription]
-                (is (== 1 (count (pubsub/list-subscriptions topic))))
-                (is (empty? (pubsub/pull-subscription subscription)))
+        (fixtures/with-temporary-subscription topic
+          (fn [subscription]
+            (is (== 1 (count (pubsub/list-subscriptions topic))))
+            (is (empty? (pubsub/pull-subscription subscription)))
+            (fixtures/with-temporary-notification-configuration bucket topic
+              (fn [_]
+                (let [configs (gcs/list-notification-configurations bucket)]
+                  (is (< 0 (count configs))))
                 (fixtures/with-temporary-cloud-storage-folder bucket
                   (fn [url]
                     (let [dest (str url "input.txt")]


### PR DESCRIPTION
The test naively assumed that no files would be updated between the point the notification configuration was added to the bucket and when the subscription was pulled.
To fix this, we can simply swap the order of events: make sure the queue is empty and then add the notification config.
