### PR TITLE
[GH-1176] partition by `datarepo_ingest_data` in assemble_refbased schema

### DIFF
--- a/api/test/resources/datasets/assemble-refbased-outputs.json
+++ b/api/test/resources/datasets/assemble-refbased-outputs.json
@@ -11,10 +11,6 @@
             "datatype": "string"
           },
           {
-            "name": "daterepo_ingest_date",
-            "datatype": "date"
-          },
-          {
             "name": "assembly_fasta",
             "datatype": "fileref"
           },
@@ -160,7 +156,7 @@
         ],
         "partitionMode": "date",
         "datePartitionOptions": {
-          "column": "daterepo_ingest_date"
+          "column": "datarepo_ingest_date"
         }
       }
     ]


### PR DESCRIPTION
Update the schema to reflect Ruchi's suggestion of partitioning by "datarepo_ingest_date"