### PR TITLE
Updating AppVersion to the latest tag (0.5.1)

### DIFF
--- a/helm/wfl/Chart.yaml
+++ b/helm/wfl/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 version: 0.3.3
 
 home: https://github.com/broadinstitute/wfl
-appVersion: 0.5.0
+appVersion: 0.5.1
 keywords:
 - clojure
 - cloud

--- a/helm/wfl/Chart.yaml
+++ b/helm/wfl/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploy WorkFlow Launcher on Kubernetes
 
 type: application
 
-version: 0.3.3
+version: 0.3.4
 
 home: https://github.com/broadinstitute/wfl
 appVersion: 0.5.1


### PR DESCRIPTION
### Purpose
The latest tag of WFL is 0.5.1. However the AppVersion was set to 0.5.0. They should be the same

### Changes
Updating the AppVersion in the Chart.yaml file

### Review Instructions
Verify that this is the correct version to be on
