### PR TITLE
[GH-1221] import snapshots into a workspace

### DIFF
--- a/api/src/wfl/environment.clj
+++ b/api/src/wfl/environment.clj
@@ -37,7 +37,7 @@
    "WFL_COOKIE_SECRET"
    #(-> "secret/dsde/gotc/dev/zero" vault-secrets :cookie_secret)
    "WFL_TDR_URL"
-   #(-> "https://jade.datarepo-dev.broadinstitute.org/")
+   #(-> "https://jade.datarepo-dev.broadinstitute.org")
    "WFL_OAUTH2_CLIENT_ID"
    #(-> "secret/dsde/gotc/dev/zero" vault-secrets :oauth2_client_id)
    "WFL_POSTGRES_PASSWORD"

--- a/api/src/wfl/environment.clj
+++ b/api/src/wfl/environment.clj
@@ -47,7 +47,7 @@
    "WFL_POSTGRES_USERNAME"
    #(-> nil)
    "WFL_FIRECLOUD_URL"
-   #(-> "https://api.firecloud.org/")
+   #(-> "https://api.firecloud.org")
 
    ;; -- variables used in test code below this line --
    "WFL_CROMWELL_URL"

--- a/api/src/wfl/service/cromwell.clj
+++ b/api/src/wfl/service/cromwell.clj
@@ -263,13 +263,6 @@
 (defn wait-for-workflow-complete
   "Return status of workflow named by ID when it completes, given Cromwell URL."
   [url id]
-  (work-around-cromwell-fail-bug 9 url id)
-  (loop [url url id id]
-    (let [seconds 15
-          now (status url id)]
-      (if (#{"Submitted" "Running"} now)
-        (do (log/infof "%s: Sleeping %s seconds on status: %s"
-                       id seconds now)
-            (util/sleep-seconds seconds)
-            (recur url id))
-        (status url id)))))
+  (let [finished? (comp (set final-statuses) #(status url id))]
+    (work-around-cromwell-fail-bug 9 url id)
+    (util/poll finished? 15 (Integer/MAX_VALUE))))

--- a/api/src/wfl/service/datarepo.clj
+++ b/api/src/wfl/service/datarepo.clj
@@ -77,11 +77,11 @@
   (ingest
    "ingest"
    dataset-id
-    {:format          "json"
-     :load_tag        (new-load-tag)
-     :max_bad_records 0
-     :path            path
-     :table           table}))
+   {:format          "json"
+    :load_tag        (new-load-tag)
+    :max_bad_records 0
+    :path            path
+    :table           table}))
 
 (defn poll-job
   "Poll the job with `job-id` every `seconds` [default: 5] and return its
@@ -203,7 +203,7 @@
 ;; They plan to expose this name via `GET /api/repository/v1/datasets/{id}`
 ;; in a future release.
 (defn ^:private bigquery-name
-  "Get the BigQuery name of the dataset or snapshot"
+  "Return the BigQuery name of the `dataset-or-snapshot`."
   [{:keys [name] :as dataset-or-snapshot}]
   (letfn [(snapshot? [x] (util/absent? x :defaultSnapshotId))]
     (if (snapshot? dataset-or-snapshot) name (str "datarepo_" name))))
@@ -235,7 +235,7 @@
 
 (defn query-table-between
   "Query everything or optionally the `columns` in `table` in the Terra DataRepo
-   `dataset` in the closed-open `interval` of `datarepo_ingest_date`, where
+   `dataset` in the open-closed `interval` of `datarepo_ingest_date`, where
    `dataset` is a DataRepo dataset or a snapshot of a dataset. If no rows match
    the `interval`, TDR will respond with error 400."
   ([dataset table interval]

--- a/api/src/wfl/service/firecloud.clj
+++ b/api/src/wfl/service/firecloud.clj
@@ -44,6 +44,28 @@
         util/response-body-json
         :submissionId)))
 
+(defn create-workspace
+  "Create an empty Terra workspace with the fully-qualified `workspace` name,
+   granting access to the `firecloud-group`."
+  [workspace firecloud-group]
+  (let [[namespace name] (str/split workspace #"/")
+        payload {:namespace           namespace
+                 :name                name
+                 :attributes          {:description ""}
+                 :authorizationDomain [{:membersGroupName firecloud-group}]}]
+    (-> (workspace-api-url)
+        (http/post {:headers      (auth/get-auth-header)
+                    :content-type :application/json
+                    :body         (json/write-str payload)})
+        util/response-body-json)))
+
+(defn delete-workspace
+  "Delete the terra `workspace` and all data within."
+  [workspace]
+  (-> (workspace-api-url workspace)
+      (http/delete {:headers (auth/get-auth-header)})
+      util/response-body-json))
+
 (defn get-workspace
   "Get a single `workspace`'s details"
   [workspace]

--- a/api/src/wfl/service/firecloud.clj
+++ b/api/src/wfl/service/firecloud.clj
@@ -66,11 +66,6 @@
       (http/delete {:headers (auth/get-auth-header)})
       util/response-body-json))
 
-(defn get-workspace
-  "Get a single `workspace`'s details"
-  [workspace]
-  (get-workspace-json workspace))
-
 (defn get-submission
   "Return the submission in the Terra `workspace` with `submission-id`."
   [workspace submission-id]
@@ -97,6 +92,11 @@
          (filter #(= name (get-in % [:workflowEntity :entityName])))
          first
          :status)))
+
+(defn get-entities
+  "Return the entity types and their attributes in a `workspace`."
+  [workspace]
+  (get-workspace-json workspace "entities"))
 
 (defn delete-entities
   "Delete the `entities` from the Terra `workspace`.
@@ -148,8 +148,8 @@
   (letfn [(url? [s] (some #(str/starts-with? s %) ["http://" "https://"]))]
     (-> (firecloud-url "/api/womtool/v1/describe")
         (http/post {:headers   (auth/get-auth-header)
-                    :multipart (util/multipart-body
-                                (if (url? workflow)
-                                  {:workflowUrl workflow}
-                                  {:workflowSource workflow}))})
+                    :multipart (util/multipart-body {(if (url? workflow)
+                                                       :workflowUrl
+                                                       :workflowSource)
+                                                     workflow})})
         util/response-body-json)))

--- a/api/src/wfl/service/firecloud.clj
+++ b/api/src/wfl/service/firecloud.clj
@@ -12,7 +12,7 @@
     (str/join "/" (conj parts url))))
 
 (def ^:private workspace-api-url
-  (partial firecloud-url "api" "workspaces"))
+  (partial firecloud-url "api/workspaces"))
 
 (defn ^:private get-workspace-json [& parts]
   (-> (apply workspace-api-url parts)

--- a/api/src/wfl/service/firecloud.clj
+++ b/api/src/wfl/service/firecloud.clj
@@ -93,11 +93,6 @@
          first
          :status)))
 
-(defn get-entities
-  "Return the entity types and their attributes in a `workspace`."
-  [workspace]
-  (get-workspace-json workspace "entities"))
-
 (defn delete-entities
   "Delete the `entities` from the Terra `workspace`.
    Parameters

--- a/api/src/wfl/service/firecloud.clj
+++ b/api/src/wfl/service/firecloud.clj
@@ -9,7 +9,7 @@
 
 (defn ^:private firecloud-url [& parts]
   (let [url (util/de-slashify (env/getenv "WFL_FIRECLOUD_URL"))]
-    (str/join "/" (conj parts url))))
+    (str/join "/" (cons url parts))))
 
 (def ^:private workspace-api-url
   (partial firecloud-url "api/workspaces"))
@@ -30,7 +30,7 @@
   [workspace methodconfig [entity-type entity-name :as _entity]]
   (let [[mcns mcn] (str/split methodconfig #"/")]
     (-> {:method       :post
-         :url          (workspace-api-url workspace "/submissions")
+         :url          (workspace-api-url workspace "submissions")
          :headers      (auth/get-auth-header)
          :content-type :application/json
          :body         (json/write-str

--- a/api/src/wfl/service/google/bigquery.clj
+++ b/api/src/wfl/service/google/bigquery.clj
@@ -91,12 +91,12 @@
      (dump-table->tsv table \"datarepo_row\" \"dumped.tsv\")
      (dump-table->tsv table \"datarepo_row\")"
   ([table terra-data-table file]
-   (letfn [(format-header-for-terra [header]
-             (cons (format "entity:%s_id" terra-data-table) (rest header)))]
-     (let [headers  (map :name (get-in table [:schema :fields]))
-           contents (conj (:rows table) (format-header-for-terra headers))]
+   (letfn [(append-entity-type [header]
+             (cons (format "entity:%s_id" terra-data-table) header))]
+     (let [columns (map :name (get-in table [:schema :fields]))]
        (with-open [writer (io/writer file)]
-         (csv/write-csv writer contents :separator \tab)
+         (csv/write-csv writer [(append-entity-type columns)] :separator \tab)
+         (csv/write-csv writer (:rows table) :separator \tab)
          file))))
   ([table terra-data-table]
    (str (dump-table->tsv table terra-data-table (StringWriter.)))))

--- a/api/src/wfl/service/google/bigquery.clj
+++ b/api/src/wfl/service/google/bigquery.clj
@@ -75,28 +75,28 @@
   "Dump a BigQuery TABLE/view into a tsv FILE that's supported by Terra.
    Will dump the tsv contents to bytes if no FILE is provided.
 
-   The first row header must follow the format 'entity:{data_table}_id'.
-   For example, 'entity:sample_id' will upload the tsv data into a `sample`
-   table in the workspace (or create one if it does not exist). If the
-   table already contains a sample with that id, it will get overwritten.
+   The first column of the table must be the table primary key,
+   i.e. [entity-type]_id. For example, 'entity:sample_id' will upload the tsv
+   data into a `sample` table in the workspace (or create one if it does not
+   exist). If the table already contains a sample with that id, it will get
+   overwritten.
 
    Parameters
    ----------
    table            - BigQuery table/view body with the rows field flatten.
-   terra-data-table - The `table` name in the Terra workspace to import the TSV.
    file             - [optional] TSV file name to dump.
 
    Example
    -------
-     (dump-table->tsv table \"datarepo_row\" \"dumped.tsv\")
-     (dump-table->tsv table \"datarepo_row\")"
-  ([table terra-data-table file]
-   (letfn [(append-entity-type [header]
-             (cons (format "entity:%s_id" terra-data-table) header))]
+     (dump-table->tsv table \"dumped.tsv\")
+     (dump-table->tsv table)"
+  ([table file]
+   (letfn [(format-entity-type [[head & rest]]
+             (cons (format "entity:%s" head) rest))]
      (let [columns (map :name (get-in table [:schema :fields]))]
        (with-open [writer (io/writer file)]
-         (csv/write-csv writer [(append-entity-type columns)] :separator \tab)
+         (csv/write-csv writer [(format-entity-type columns)] :separator \tab)
          (csv/write-csv writer (:rows table) :separator \tab)
          file))))
-  ([table terra-data-table]
-   (str (dump-table->tsv table terra-data-table (StringWriter.)))))
+  ([table]
+   (str (dump-table->tsv table (StringWriter.)))))

--- a/api/src/wfl/util.clj
+++ b/api/src/wfl/util.clj
@@ -336,13 +336,23 @@
       (with-open [in (io/input-stream resource)] (io/copy in file))
       file)))
 
+(defn between
+  "Place the `middle` lexeme between [`first` `second`]."
+  [[first second] middle] (str first middle second))
+
+(defn to-comma-separated-list
+  "Return the sequence `xs` composed into a comma-separated list string.
+  Example:
+    (to-comma-separated-list '['x 'y 'z]) => \"(x,y,z)\""
+  [xs]
+  (between "()" (str/join "," xs)))
+
 (defn to-quoted-comma-separated-list
   "Return the sequence `xs` composed into a comma-separated list string.
   Example:
     (to-quoted-comma-separated-list '[x y z]) => \"('x','y','z')\""
   [xs]
-  (letfn [(between [[first second] x] (str first x second))]
-    (between "()" (str/join "," (map (partial between "''") xs)))))
+  (between "()" (str/join "," (map (partial between "''") xs))))
 
 (defn slashify
   "Ensure URL ends in a slash /."

--- a/api/src/wfl/util.clj
+++ b/api/src/wfl/util.clj
@@ -1,11 +1,11 @@
 (ns wfl.util
   "Some utilities shared across this program."
-  (:require [clojure.data.json :as json]
-            [clojure.java.io :as io]
-            [clojure.java.shell :as shell]
-            [clojure.string :as str]
+  (:require [clojure.data.json     :as json]
+            [clojure.java.io       :as io]
+            [clojure.java.shell    :as shell]
+            [clojure.string        :as str]
             [clojure.tools.logging :as log]
-            [wfl.wfl :as wfl])
+            [wfl.wfl               :as wfl])
   (:import [java.io File Writer IOException]
            [java.time OffsetDateTime Clock LocalDate]
            [java.time.temporal ChronoUnit]
@@ -13,7 +13,8 @@
            [java.nio.file.attribute FileAttribute]
            [java.util ArrayList Collections Random UUID]
            [java.util.zip ZipOutputStream ZipEntry]
-           [org.apache.commons.io FilenameUtils]))
+           [org.apache.commons.io FilenameUtils]
+           (java.util.concurrent TimeUnit TimeoutException)))
 
 (defmacro do-or-nil
   "Value of `body` or `nil` if it throws."
@@ -403,3 +404,25 @@
   "Append a random suffix to `string`."
   [string]
   (-> string (str (UUID/randomUUID)) (str/replace "-" "")))
+
+(defn curry
+  "Curry the function `f` such that its arguments may be supplied across two
+   applications."
+  [f]
+  (fn [x & xs] (apply partial f x xs)))
+
+(defn >>>
+  "Left-to-right function composition, ie `(= (>>> f g) (comp g f))`."
+  [f & fs]
+  (reduce #(comp %2 %1) f fs))
+
+(defn poll-while [predicate thunk]
+  (loop [attempt 1]
+    (let [x (thunk)]
+      (if (predicate x)
+        x
+        (do (when (< 3 attempt)
+              (throw (TimeoutException. "Max number of attempts exceeded")))
+            (log/debugf "Sleeping - attempt #%s" attempt)
+            (.sleep TimeUnit/MILLISECONDS 100)
+            (recur (inc attempt)))))))

--- a/api/src/wfl/util.clj
+++ b/api/src/wfl/util.clj
@@ -403,7 +403,7 @@
 (defn randomize
   "Append a random suffix to `string`."
   [string]
-  (-> string (str (UUID/randomUUID)) (str/replace "-" "")))
+  (->> (str/replace (UUID/randomUUID) "-" "") (str string)))
 
 (defn curry
   "Curry the function `f` such that its arguments may be supplied across two
@@ -419,7 +419,7 @@
 (defn poll-while [predicate thunk]
   (loop [attempt 1]
     (let [x (thunk)]
-      (if (predicate x)
+      (if-not (predicate x)
         x
         (do (when (< 3 attempt)
               (throw (TimeoutException. "Max number of attempts exceeded")))

--- a/api/src/wfl/util.clj
+++ b/api/src/wfl/util.clj
@@ -7,14 +7,14 @@
             [clojure.tools.logging :as log]
             [wfl.wfl               :as wfl])
   (:import [java.io File Writer IOException]
-           [java.time OffsetDateTime Clock LocalDate]
-           [java.time.temporal ChronoUnit]
            [java.nio.file Files]
            [java.nio.file.attribute FileAttribute]
+           [java.time OffsetDateTime Clock LocalDate]
+           [java.time.temporal ChronoUnit]
            [java.util ArrayList Collections Random UUID]
+           [java.util.concurrent TimeUnit TimeoutException]
            [java.util.zip ZipOutputStream ZipEntry]
-           [org.apache.commons.io FilenameUtils]
-           (java.util.concurrent TimeUnit TimeoutException)))
+           [org.apache.commons.io FilenameUtils]))
 
 (defmacro do-or-nil
   "Value of `body` or `nil` if it throws."
@@ -416,13 +416,19 @@
   [f & fs]
   (reduce #(comp %2 %1) f fs))
 
-(defn poll-while [predicate thunk]
-  (loop [attempt 1]
-    (let [x (thunk)]
-      (if-not (predicate x)
-        x
-        (do (when (< 3 attempt)
-              (throw (TimeoutException. "Max number of attempts exceeded")))
-            (log/debugf "Sleeping - attempt #%s" attempt)
-            (.sleep TimeUnit/MILLISECONDS 100)
-            (recur (inc attempt)))))))
+(defn poll
+  "Poll `task!` every `seconds` [default: 1], attempting at most `max-attempts`
+   [default: 3]."
+  ([task! seconds max-attempts]
+   (loop [attempt 1]
+     (if-let [result (task!)]
+       result
+       (do (when (<= max-attempts attempt)
+             (throw (TimeoutException. "Max number of attempts exceeded")))
+           (log/debugf "Sleeping - attempt #%s of %s" attempt max-attempts)
+           (.sleep TimeUnit/SECONDS seconds)
+           (recur (inc attempt))))))
+  ([task seconds]
+   (poll task seconds 3))
+  ([task]
+   (poll task 1)))

--- a/api/src/wfl/util.clj
+++ b/api/src/wfl/util.clj
@@ -398,3 +398,8 @@
    backward or forward depends on the sign of n."
   [^Integer n]
   (.plus (today) n ChronoUnit/DAYS))
+
+(defn randomize
+  "Append a random suffix to `string`."
+  [string]
+  (-> string (str (UUID/randomUUID)) (str/replace "-" "")))

--- a/api/test/resources/datasets/sarscov2-illumina-full-inputs.json
+++ b/api/test/resources/datasets/sarscov2-illumina-full-inputs.json
@@ -43,7 +43,7 @@
           },
           {
             "name": "updated",
-            "datatype": "datetime"
+            "datatype": "timestamp"
           },
           {
             "name": "extra",

--- a/api/test/resources/datasets/sarscov2-illumina-full-inputs.json
+++ b/api/test/resources/datasets/sarscov2-illumina-full-inputs.json
@@ -1,51 +1,40 @@
 {
   "name": "sarscov2_illumina_full_inputs",
-  "description": "COVID-19 sarscov2_illumina_full pipeline inputs",
+  "description": "initial flowcell values for the sarscov2_illumina_full COVID-19 surveillance pipeline",
   "defaultProfileId": "390e7a85-d47f-4531-b612-165fc977d3bd",
   "schema": {
     "tables": [
       {
-        "name": "sarscov2_illumina_full_inputs",
+        "name": "flowcell",
         "columns": [
+          {
+            "name": "authors_sbt",
+            "datatype": "fileref"
+          },
+          {
+            "name": "biosample_map",
+            "datatype": "fileref",
+            "array_of": true
+          },
           {
             "name": "flowcell_tgz",
             "datatype": "fileref"
-          },
-          {
-            "name": "reference_fasta",
-            "datatype": "fileref"
-          },
-          {
-            "name": "amplicon_bed_prefix",
-            "datatype": "string"
-          },
-          {
-            "name": "biosample_attributes",
-            "datatype": "fileref",
-            "array_of": true
           },
           {
             "name": "instrument_model",
             "datatype": "string"
           },
           {
-            "name": "sra_title",
-            "datatype": "string"
+            "name": "sample_rename_map",
+            "datatype": "fileref"
           },
           {
-            "name": "min_genome_bases",
-            "datatype": "int64"
+            "name": "samplesheets",
+            "datatype": "fileref",
+            "array_of": true
           },
           {
-            "name": "max_vadr_alerts",
-            "datatype": "int64"
-          },
-          {
-            "name": "workspace_name",
-            "datatype": "string"
-          },
-          {
-            "name": "terra_project",
+            "name": "title",
             "datatype": "string"
           },
           {
@@ -54,11 +43,11 @@
           }
         ],
         "primaryKey": [
+          "authors_sbt",
           "flowcell_tgz",
-          "reference_fasta",
-          "amplicon_bed_prefix",
           "instrument_model",
-          "sra_title"
+          "sample_rename_map",
+          "title"
         ],
         "partitionMode": "date",
         "datePartitionOptions": {

--- a/api/test/resources/datasets/sarscov2-illumina-full-inputs.json
+++ b/api/test/resources/datasets/sarscov2-illumina-full-inputs.json
@@ -17,6 +17,10 @@
             "array_of": true
           },
           {
+            "name": "flowcell_id",
+            "datatype": "string"
+          },
+          {
             "name": "flowcell_tgz",
             "datatype": "fileref"
           },
@@ -38,16 +42,22 @@
             "datatype": "string"
           },
           {
+            "name": "updated",
+            "datatype": "datetime"
+          },
+          {
             "name": "extra",
             "datatype": "string"
           }
         ],
         "primaryKey": [
           "authors_sbt",
+          "flowcell_id",
           "flowcell_tgz",
           "instrument_model",
           "sample_rename_map",
-          "title"
+          "title",
+          "updated"
         ],
         "partitionMode": "date",
         "datePartitionOptions": {

--- a/api/test/resources/workflows/sarscov2_illumina_full/dataset-from-inputs.edn
+++ b/api/test/resources/workflows/sarscov2_illumina_full/dataset-from-inputs.edn
@@ -1,7 +1,9 @@
 {:authors_sbt       "package_genbank_ftp_submission.author_template_sbt"
  :biosample_map     "biosample_attributes"
+ :flowcell_id       "$Test Flowcell"
  :flowcell_tgz      "flowcell_tgz"
  :instrument_model  "instrument_model"
  :sample_rename_map "demux_deplete.sample_rename_map"
  :samplesheets      "demux_deplete.samplesheets"
- :title             "sra_title"}
+ :title             "sra_title"
+ :updated           "$2021-03-30T16:46:18.645160251Z"}

--- a/api/test/resources/workflows/sarscov2_illumina_full/dataset-from-inputs.edn
+++ b/api/test/resources/workflows/sarscov2_illumina_full/dataset-from-inputs.edn
@@ -1,21 +1,7 @@
-{:flowcell_tgz         "flowcell_tgz",
- :reference_fasta      "reference_fasta",
- :amplicon_bed_prefix  "amplicon_bed_prefix",
- :biosample_attributes "biosample_attributes",
- :instrument_model     "instrument_model",
- :min_genome_bases     "min_genome_bases",
- :max_vadr_alerts      "max_vadr_alerts",
- :sra_title            "sra_title",
- :workspace_name       "$SARSCoV2-Illumina-Full",
- :terra_project        "$wfl-dev",
- :extra                {:demux_deplete.spikein_db                           "demux_deplete.spikein_db",
-                        :demux_deplete.samplesheets                         "demux_deplete.samplesheets",
-                        :demux_deplete.sample_rename_map                    "demux_deplete.sample_rename_map",
-                        :demux_deplete.bwaDbs                               "demux_deplete.bwaDbs",
-                        :demux_deplete.blastDbs                             "demux_deplete.blastDbs",
-                        :gisaid_meta_prep.username                          "gisaid_meta_prep.username",
-                        :gisaid_meta_prep.submitting_lab_addr               "gisaid_meta_prep.submitting_lab_addr",
-                        :gisaid_meta_prep.submitting_lab_name               "gisaid_meta_prep.submitting_lab_name",
-                        :package_genbank_ftp_submission.spuid_namespace     "package_genbank_ftp_submission.spuid_namespace",
-                        :package_genbank_ftp_submission.author_template_sbt "package_genbank_ftp_submission.author_template_sbt",
-                        :package_genbank_ftp_submission.account_name        "package_genbank_ftp_submission.account_name"}}
+{:authors_sbt       "package_genbank_ftp_submission.author_template_sbt"
+ :biosample_map     "biosample_attributes"
+ :flowcell_tgz      "flowcell_tgz"
+ :instrument_model  "instrument_model"
+ :sample_rename_map "demux_deplete.sample_rename_map"
+ :samplesheets      "demux_deplete.samplesheets"
+ :title             "sra_title"}

--- a/api/test/resources/workflows/sarscov2_illumina_full/dataset-from-inputs.edn
+++ b/api/test/resources/workflows/sarscov2_illumina_full/dataset-from-inputs.edn
@@ -6,4 +6,4 @@
  :sample_rename_map "demux_deplete.sample_rename_map"
  :samplesheets      "demux_deplete.samplesheets"
  :title             "sra_title"
- :updated           "$2021-03-30T16:46:18.645160251Z"}
+ :updated           "$2021-03-30 20:46:39+00"}

--- a/api/test/resources/workflows/sarscov2_illumina_full/dataset-from-inputs.edn
+++ b/api/test/resources/workflows/sarscov2_illumina_full/dataset-from-inputs.edn
@@ -1,6 +1,6 @@
 {:authors_sbt       "package_genbank_ftp_submission.author_template_sbt"
  :biosample_map     "biosample_attributes"
- :flowcell_id       "$Test Flowcell"
+ :flowcell_id       "$Test_Flowcell"
  :flowcell_tgz      "flowcell_tgz"
  :instrument_model  "instrument_model"
  :sample_rename_map "demux_deplete.sample_rename_map"

--- a/api/test/resources/workflows/sarscov2_illumina_full/entity-from-dataset.edn
+++ b/api/test/resources/workflows/sarscov2_illumina_full/entity-from-dataset.edn
@@ -1,0 +1,8 @@
+{:flowcell_id       "datarepo_row_id"
+ :authors_sbt       "authors_sbt"
+ :biosample_map     "biosample_map"
+ :flowcell_tgz      "flowcell_tgz"
+ :instrument_model  "instrument_model"
+ :sample_rename_map "sample_rename_map"
+ :samplesheets      "samplesheets"
+ :title             "title"}

--- a/api/test/resources/workflows/sarscov2_illumina_full/entity-from-dataset.edn
+++ b/api/test/resources/workflows/sarscov2_illumina_full/entity-from-dataset.edn
@@ -1,6 +1,6 @@
-{:flowcell_id       "datarepo_row_id"
- :authors_sbt       "authors_sbt"
+{:authors_sbt       "authors_sbt"
  :biosample_map     "biosample_map"
+ :flowcell_id       "flowcell_id"
  :flowcell_tgz      "flowcell_tgz"
  :instrument_model  "instrument_model"
  :sample_rename_map "sample_rename_map"

--- a/api/test/resources/workflows/sarscov2_illumina_full/flowcell-ingest-request.edn
+++ b/api/test/resources/workflows/sarscov2_illumina_full/flowcell-ingest-request.edn
@@ -1,10 +1,10 @@
-{:authors_sbt       "06f18b9b-a1c6-46ee-953c-7b58b2f8b8dd"
- :biosample_map     ["024efc25-f858-4276-bdbb-3b2f77cc18e0"]
- :flowcell_id       "Test Flowcell"
- :flowcell_tgz      "86c1691f-a579-4911-bc90-4c5cc7410337"
- :instrument_model  "Illumina NovaSeq 6000"
- :sample_rename_map "104f5172-eb8c-46f7-a07b-54de1b015e9a"
- :samplesheets      ["2eb0f6aa-20d7-42e9-89a3-c6603ab3705d"
-                     "2eb0f6aa-20d7-42e9-89a3-c6603ab3705d"]
- :title             "Metagenomic RNA-Seq of SARS-CoV-2 from patients"
- :updated           "2021-03-30 20:46:39.74759589"}
+{:authors_sbt "bf6f5630-c967-4fb1-9e4a-bece8da4ca55"
+ :biosample_map ["41f632af-b6b2-44a9-a874-c406a2e6ac86"]
+ :instrument_model "Illumina NovaSeq 6000"
+ :flowcell_id "Test Flowcell"
+ :flowcell_tgz "fd60edc6-e08b-4032-8b62-1e9a34bdd1b3"
+ :samplesheets ["d3cc9164-3cd0-43b3-84ac-f5daa4aba9ee"
+                "d3cc9164-3cd0-43b3-84ac-f5daa4aba9ee"]
+ :sample_rename_map "401b81ca-da3f-4f91-8cef-39297062c891"
+ :title "Metagenomic RNA-Seq of SARS-CoV-2 from patients"
+ :updated "2021-03-30 20:46:39+00"}

--- a/api/test/resources/workflows/sarscov2_illumina_full/flowcell-ingest-request.edn
+++ b/api/test/resources/workflows/sarscov2_illumina_full/flowcell-ingest-request.edn
@@ -1,0 +1,8 @@
+{:authors_sbt       "06f18b9b-a1c6-46ee-953c-7b58b2f8b8dd",
+ :biosample_map     ["024efc25-f858-4276-bdbb-3b2f77cc18e0"],
+ :flowcell_tgz      "86c1691f-a579-4911-bc90-4c5cc7410337",
+ :instrument_model  "Illumina NovaSeq 6000",
+ :sample_rename_map "104f5172-eb8c-46f7-a07b-54de1b015e9a",
+ :samplesheets      ["2eb0f6aa-20d7-42e9-89a3-c6603ab3705d"
+                     "2eb0f6aa-20d7-42e9-89a3-c6603ab3705d"],
+ :title             "Metagenomic RNA-Seq of SARS-CoV-2 from patients"}

--- a/api/test/resources/workflows/sarscov2_illumina_full/flowcell-ingest-request.edn
+++ b/api/test/resources/workflows/sarscov2_illumina_full/flowcell-ingest-request.edn
@@ -7,4 +7,4 @@
  :samplesheets      ["2eb0f6aa-20d7-42e9-89a3-c6603ab3705d"
                      "2eb0f6aa-20d7-42e9-89a3-c6603ab3705d"]
  :title             "Metagenomic RNA-Seq of SARS-CoV-2 from patients"
- :updated           "2021-03-30T16:46:18.645160251Z"}
+ :updated           "2021-03-30 20:46:39.74759589"}

--- a/api/test/resources/workflows/sarscov2_illumina_full/flowcell-ingest-request.edn
+++ b/api/test/resources/workflows/sarscov2_illumina_full/flowcell-ingest-request.edn
@@ -1,8 +1,10 @@
-{:authors_sbt       "06f18b9b-a1c6-46ee-953c-7b58b2f8b8dd",
- :biosample_map     ["024efc25-f858-4276-bdbb-3b2f77cc18e0"],
- :flowcell_tgz      "86c1691f-a579-4911-bc90-4c5cc7410337",
- :instrument_model  "Illumina NovaSeq 6000",
- :sample_rename_map "104f5172-eb8c-46f7-a07b-54de1b015e9a",
+{:authors_sbt       "06f18b9b-a1c6-46ee-953c-7b58b2f8b8dd"
+ :biosample_map     ["024efc25-f858-4276-bdbb-3b2f77cc18e0"]
+ :flowcell_id       "Test Flowcell"
+ :flowcell_tgz      "86c1691f-a579-4911-bc90-4c5cc7410337"
+ :instrument_model  "Illumina NovaSeq 6000"
+ :sample_rename_map "104f5172-eb8c-46f7-a07b-54de1b015e9a"
  :samplesheets      ["2eb0f6aa-20d7-42e9-89a3-c6603ab3705d"
-                     "2eb0f6aa-20d7-42e9-89a3-c6603ab3705d"],
- :title             "Metagenomic RNA-Seq of SARS-CoV-2 from patients"}
+                     "2eb0f6aa-20d7-42e9-89a3-c6603ab3705d"]
+ :title             "Metagenomic RNA-Seq of SARS-CoV-2 from patients"
+ :updated           "2021-03-30T16:46:18.645160251Z"}

--- a/api/test/resources/workflows/sarscov2_illumina_full/flowcell-ingest-request.edn
+++ b/api/test/resources/workflows/sarscov2_illumina_full/flowcell-ingest-request.edn
@@ -1,10 +1,11 @@
-{:authors_sbt "bf6f5630-c967-4fb1-9e4a-bece8da4ca55"
- :biosample_map ["41f632af-b6b2-44a9-a874-c406a2e6ac86"]
- :instrument_model "Illumina NovaSeq 6000"
- :flowcell_id "Test Flowcell"
- :flowcell_tgz "fd60edc6-e08b-4032-8b62-1e9a34bdd1b3"
- :samplesheets ["d3cc9164-3cd0-43b3-84ac-f5daa4aba9ee"
-                "d3cc9164-3cd0-43b3-84ac-f5daa4aba9ee"]
- :sample_rename_map "401b81ca-da3f-4f91-8cef-39297062c891"
- :title "Metagenomic RNA-Seq of SARS-CoV-2 from patients"
- :updated "2021-03-30 20:46:39+00"}
+{:authors_sbt       "96bd0bda-b7a6-4680-9a2a-caa2bb52e914"
+ :biosample_map     ["0a6c073a-f73c-4f1f-9b0c-f80a105a5a54"]
+ :flowcell_id       "Test_Flowcell"
+ :flowcell_tgz      "ae888931-7e79-488b-b5b3-a12bb81fbd65"
+ :instrument_model  "Illumina NovaSeq 6000"
+ :sample_rename_map "4c9d1a3f-739d-4524-9f58-401c6210ad1a"
+ :samplesheets
+                    ["0b3ea1d2-1d51-43cd-8de8-25d4f5482884"
+                     "0b3ea1d2-1d51-43cd-8de8-25d4f5482884"]
+ :title             "Metagenomic RNA-Seq of SARS-CoV-2 from patients"
+ :updated           "2021-03-30 20:46:39+00"}

--- a/api/test/resources/workflows/sarscov2_illumina_full/inputs-ingest-request.edn
+++ b/api/test/resources/workflows/sarscov2_illumina_full/inputs-ingest-request.edn
@@ -1,9 +1,0 @@
-{:instrument_model     "Illumina NovaSeq 6000"
- :workspace_name       "SARSCoV2-Illumina-Full"
- :terra_project        "wfl-dev"
- :flowcell_tgz         "093314e1-688e-49cb-90af-b392d104a57f"
- :sra_title            "Metagenomic RNA-Seq of SARS-CoV-2 from patients"
- :biosample_attributes ["d1830e0c-a1dc-448b-816c-b4f656c21876"]
- :amplicon_bed_prefix  "gs://pathogen-public-dbs/v1/amplicon_primers-"
- :reference_fasta      "a2599579-aa20-4f9b-a0a0-99b5043ec0b4"
- :extra                "{\"demux_deplete.spikein_db\":\"5613ae0f-7df9-460b-8cab-58b7f97f924f\",\"demux_deplete.samplesheets\":[\"7dbe165d-aef0-4a5c-bdff-d717e7a3f084\",\"7dbe165d-aef0-4a5c-bdff-d717e7a3f084\"],\"demux_deplete.sample_rename_map\":\"93b5ccd4-cf50-4dc4-9c9f-91a45afbb588\",\"demux_deplete.bwaDbs\":[\"85c66634-6c80-4133-92b1-22b955f36e42\"],\"demux_deplete.blastDbs\":[\"84d52a91-dfc6-421c-ae6f-a68118fa901d\",\"6aacab93-027a-4513-a609-c25143faef04\"],\"gisaid_meta_prep.username\":\"dpark\",\"gisaid_meta_prep.submitting_lab_addr\":\"75 Ames St, Cambridge, MA 02142, USA\",\"package_genbank_ftp_submission.spuid_namespace\":\"Broad_GCID\",\"gisaid_meta_prep.submitting_lab_name\":\"Infectious Disease Program, Broad Institute of Harvard and MIT\",\"package_genbank_ftp_submission.author_template_sbt\":\"f96db65e-668a-41d1-95cf-4e3457742500\",\"package_genbank_ftp_submission.account_name\":\"broad_gcid-srv\"}"}

--- a/api/test/wfl/integration/datarepo_test.clj
+++ b/api/test/wfl/integration/datarepo_test.clj
@@ -85,12 +85,10 @@
   (let [tdr-profile (env/getenv "WFL_TDR_DEFAULT_PROFILE")
         dataset     (datarepo/dataset testing-dataset)
         table       "flowcell"
-        from        "2021-03-30"
-        until       "2021-03-31"
         row-ids     (-> (datarepo/query-table-between
                          dataset
                          table
-                         [from until]
+                         ["2021-03-30" "2021-03-31"]
                          [:datarepo_row_id])
                         :rows
                         flatten)]
@@ -158,6 +156,6 @@
                              (util/poll-while empty?)
                              (map :name)
                              set)]
-              (doseq [[_ name] entities] (is (contains? names name))))
+              (doseq [[_ name] entities] (is (names name))))
             (finally (firecloud/delete-entities workspace entities))))))))
 

--- a/api/test/wfl/integration/datarepo_test.clj
+++ b/api/test/wfl/integration/datarepo_test.clj
@@ -112,7 +112,7 @@
   (fn [x] (partial f x)))
 
 (defn >>>
-  "Right-to-left function composition, ie `(= (>>> f g) (comp g f))`."
+  "Left-to-right function composition, ie `(= (>>> f g) (comp g f))`."
   [f & fs]
   (reduce #(comp %2 %1) f fs))
 

--- a/api/test/wfl/integration/datarepo_test.clj
+++ b/api/test/wfl/integration/datarepo_test.clj
@@ -125,8 +125,8 @@
   [from-dataset entity-type maps]
   (let [columns (vec (keys from-dataset))]
     (-> (map #(datasets/rename-gather % from-dataset) maps)
-      (maps->table columns)
-      (bigquery/dump-table->tsv entity-type))))
+        (maps->table columns)
+        (bigquery/dump-table->tsv entity-type))))
 
 (defn import-snapshot
   "Import the BigQuery table `snapshot` into the `table` in the Terra
@@ -136,8 +136,8 @@
   [workspace table primary-key snapshot from-snapshot]
   (let [maps (table->map-view snapshot)]
     (->> (make-entity-import-request-tsv from-snapshot table maps)
-      .getBytes
-      (firecloud/import-entities workspace))
+         .getBytes
+         (firecloud/import-entities workspace))
     (map (comp #(-> [table %]) #(% primary-key)) maps)))
 
 ;; not sure where this should live!

--- a/api/test/wfl/integration/datarepo_test.clj
+++ b/api/test/wfl/integration/datarepo_test.clj
@@ -147,7 +147,7 @@
   (let [dataset-table "flowcell"
         entity        "flowcell"
         from-dataset  (resources/read-resource "entity-from-dataset.edn")
-        columns       (-> (firecloud/get-entities "wfl-dev/SARSCoV2-Illumina-Full")
+        columns       (-> (firecloud/list-entity-types "wfl-dev/SARSCoV2-Illumina-Full")
                           :flowcell
                           entity-columns)]
     (fixtures/with-temporary-workspace

--- a/api/test/wfl/system/automation_test.clj
+++ b/api/test/wfl/system/automation_test.clj
@@ -22,8 +22,7 @@
 (deftest test-automate-sarscov2-illumina-full
   (let [tdr-profile (env/getenv "WFL_TDR_DEFAULT_PROFILE")]
     (fixtures/with-fixtures
-      [(fixtures/with-temporary-cloud-storage-folder
-         "broad-gotc-dev-wfl-ptc-test-inputs")
+      [(fixtures/with-temporary-cloud-storage-folder fixtures/gcs-test-bucket)
        (fixtures/with-temporary-dataset
          (datasets/unique-dataset-request
           tdr-profile

--- a/api/test/wfl/system/automation_test.clj
+++ b/api/test/wfl/system/automation_test.clj
@@ -35,20 +35,21 @@
       (fn [[temp source sink]]
         ;; TODO: create + start the workload
         ;; upload a sample
-        (let [inputs        (resources/read-resource "sarscov2_illumina_full/inputs.edn")
+        (let [;; This defines how we'll convert the inputs of the pipeline into
+              ;; a form that can be ingested as a new row in the dataset.
+              ;; I think a user would specify something like this in the initial
+              ;; workload request, one mapping for dataset to workspace entity
+              ;; names and one for outputs to dataset.
+              from-inputs   (resources/read-resource "sarscov2_illumina_full/dataset-from-inputs.edn")
+              inputs        (-> (resources/read-resource "sarscov2_illumina_full/inputs.edn")
+                                (select-keys (map keyword (vals from-inputs))))
               inputs-type   (-> "sarscov2_illumina_full.edn"
                                 resources/read-resource
                                 :inputs
                                 workflows/make-object-type)
-              table-name    "sarscov2_illumina_full_inputs"
+              table-name    "flowcell"
               unique-prefix (UUID/randomUUID)
-              table-url     (str temp "inputs.json")
-              ;; This defines how we'll convert the inputs of the pipeline into
-              ;; a form that can be ingested as a new row in the dataset.
-              ;; I think a user would specify something like this in the initial
-              ;; workload request, one mapping for dataset to inputs and one for
-              ;; outputs to dataset.
-              from-inputs (resources/read-resource "sarscov2_illumina_full/dataset-from-inputs.edn")]
+              table-url     (str temp "inputs.json")]
           (-> (->> (workflows/get-files inputs-type inputs)
                    (datasets/ingest-files tdr-profile source unique-prefix))
               (replace-urls-with-file-ids inputs-type inputs)

--- a/api/test/wfl/tools/datasets.clj
+++ b/api/test/wfl/tools/datasets.clj
@@ -1,9 +1,9 @@
 (ns wfl.tools.datasets
-  (:require [clojure.string :as str]
-            [clojure.data.json :as json]
-            [wfl.service.datarepo :as datarepo]
-            [wfl.service.google.storage :as storage])
-  (:import (java.util UUID)))
+  (:require [clojure.string             :as str]
+            [clojure.data.json          :as json]
+            [wfl.service.datarepo       :as datarepo]
+            [wfl.service.google.storage :as storage]
+            [wfl.util                   :as util]))
 
 (defn unique-dataset-request
   "Create a dataset request for a uniquely-named dataset defined by the json
@@ -12,7 +12,7 @@
   (-> (str "test/resources/datasets/" dataset-basename)
       slurp
       json/read-str
-      (update "name" #(str % (-> (UUID/randomUUID) (str/replace "-" ""))))
+      (update "name" util/randomize)
       (update "defaultProfileId" (constantly tdr-profile))))
 
 ;; TDR limits size of bulk ingest request to 1000 files. Muscles says
@@ -42,7 +42,7 @@
   (letfn [(literal? [x] (str/starts-with? x "$"))
           (go! [v]
             (cond (literal? v) (subs v 1 (count v))
-                  (string?  v) (get values (keyword v))
+                  (string?  v) (values (keyword v))
                   (map?     v) (json/write-str (rename-gather values v)
                                                :escape-slash false)
                   (coll?    v) (keep go! v)

--- a/api/test/wfl/tools/fixtures.clj
+++ b/api/test/wfl/tools/fixtures.clj
@@ -7,7 +7,8 @@
             [wfl.tools.liquibase :as liquibase]
             [wfl.jdbc :as jdbc]
             [wfl.util :as util]
-            [wfl.environment :as env])
+            [wfl.environment :as env]
+            [wfl.service.firecloud :as firecloud])
   (:import [java.util UUID]
            (java.nio.file Files)
            (org.apache.commons.io FileUtils)
@@ -195,6 +196,15 @@
   (util/bracket
    #(datarepo/create-snapshot snapshot-request)
    datarepo/delete-snapshot
+   f))
+
+(defn with-temporary-workspace
+  "Create and use a temporary Terra Workspace."
+  [f]
+  (util/bracket
+   #(doto (util/randomize "wfl-dev/test-workspace")
+      (firecloud/create-workspace "workflow-launcher-dev"))
+   firecloud/delete-workspace
    f))
 
 (defn with-temporary-environment

--- a/api/test/wfl/tools/snapshots.clj
+++ b/api/test/wfl/tools/snapshots.clj
@@ -35,16 +35,10 @@
    Note the dataset row query time range is set to (yesterday, today]
    for testing purposes for now."
   [tdr-profile dataset table]
-  (let [{:keys [dataProject]} dataset
-        table                table
-        today                (util/today)
+  (let [today                (util/today)
         yesterday            (util/days-from-today -1)
-        row-ids (->> (datarepo/make-snapshot-query dataset table yesterday today)
-                     (bigquery/query-sync dataProject)
-                     flatten)
         unique-request-batch (partial unique-snapshot-request tdr-profile dataset table)]
-    (->> (datarepo/make-snapshot-query dataset table yesterday today)
-         (bigquery/query-sync dataProject)
+    (->> (datarepo/query-table-between dataset table [yesterday today] [:datarepo_row_id])
          flatten
          (partition-all 500)
          (map unique-request-batch)

--- a/api/test/wfl/tools/snapshots.clj
+++ b/api/test/wfl/tools/snapshots.clj
@@ -10,7 +10,7 @@
                         (->> (map :name) set)
                         (conj "datarepo_row_id"))]
     (-> (datarepo/make-snapshot-request dataset columns table row-ids)
-        (update :name util/randomize)
+        #_(update :name util/randomize)
         (update :profileId (constantly tdr-profile)))))
 
 ;; Partition row IDs into batches of 500 to keep TDR happy.

--- a/api/test/wfl/tools/snapshots.clj
+++ b/api/test/wfl/tools/snapshots.clj
@@ -10,7 +10,7 @@
                         (->> (map :name) set)
                         (conj "datarepo_row_id"))]
     (-> (datarepo/make-snapshot-request dataset columns table row-ids)
-        #_(update :name util/randomize)
+        (update :name util/randomize)
         (update :profileId (constantly tdr-profile)))))
 
 ;; Partition row IDs into batches of 500 to keep TDR happy.

--- a/api/test/wfl/unit/google/bigquery_test.clj
+++ b/api/test/wfl/unit/google/bigquery_test.clj
@@ -5,7 +5,7 @@
 
 ;; mock output from bigquery/query-sync
 (def ^:private dr-view-content
-  {:schema {:fields [{:mode "NULLABLE" :name "datarepo_row_id" :type "STRING"}
+  {:schema {:fields [{:mode "NULLABLE" :name "test-name_id" :type "STRING"}
                      {:mode "NULLABLE" :name "vcf" :type "STRING"}
                      {:mode "NULLABLE" :name "id" :type "STRING"}
                      {:mode "NULLABLE" :name "vcf_index" :type "STRING"}]}
@@ -19,10 +19,8 @@
            "drs://jade.datarepo-dev.broadinstitute.org/v1_f1c765c6-5446-4aef-bdbe-c741ff09c27c_2b67ed53-ccac-49c6-8ad6-8952a1dfaf98"]]})
 
 (deftest test-dump-table->tsv
-  (let [terra-table-name "test-name"
-        contents (-> (bigquery/dump-table->tsv dr-view-content terra-table-name)
+  (let [contents (-> (bigquery/dump-table->tsv dr-view-content)
                      (csv/read-csv :separator \tab))]
     (is (= 3 (count contents)) "expect 3 rows (headers + 2 of data)")
-    (is (= 5 (count (first contents))) "first row has additional column for the entity")
-    (is (every? #(= 4 %) (map count (rest contents))) "data rows have same number of columns as fields")
-    (is (= (format "entity:%s_id" terra-table-name) (ffirst contents)) "The result TSV header is not properly formatted!")))
+    (is (every? #(= 4 %) (map count contents)) "rows have same number of columns as fields")
+    (is (= "entity:test-name_id" (ffirst contents)) "The result TSV header is not properly formatted!")))

--- a/api/test/wfl/unit/google/bigquery_test.clj
+++ b/api/test/wfl/unit/google/bigquery_test.clj
@@ -3,31 +3,28 @@
             [clojure.data.csv :as csv]
             [wfl.service.google.bigquery :as bigquery]))
 
+;; mock output from bigquery/query-sync
 (def ^:private dr-view-content
-  "Test fixture to simulate data structure from bigquery/query-sync."
-  {:kind "bigquery#queryResponse"
-   :schema {:fields [{:mode "NULLABLE" name "datarepo_row_id" :type "STRING"}
+  {:schema {:fields [{:mode "NULLABLE" :name "datarepo_row_id" :type "STRING"}
                      {:mode "NULLABLE" :name "vcf" :type "STRING"}
                      {:mode "NULLABLE" :name "id" :type "STRING"}
                      {:mode "NULLABLE" :name "vcf_index" :type "STRING"}]}
-   :jobReference {:projectId "broad-jade-dev-data" :jobId "job_Zd6Ld4uCl8kmuFkiGKsPdk5OnBNP" :location "US"}
-   :totalRows "2"
-   :rows ['("8d529c08-bc21-4ea0-9254-d99b9c12dfd2"
-            "drs://jade.datarepo-dev.broadinstitute.org/v1_f1c765c6-5446-4aef-bdbe-c741ff09c27c_f2a7d885-4fd3-4faf-bd16-06219a8eef99"
-            "wfl-test-a830fe00-7ef2-430a-9d5e-fa0c18dc99e1/"
-            "drs://jade.datarepo-dev.broadinstitute.org/v1_f1c765c6-5446-4aef-bdbe-c741ff09c27c_2b67ed53-ccac-49c6-8ad6-8952a1dfaf98")
-          '("8d529c08-bc21-4ea0-9254-d99b9c12dfd2"
-            "drs://jade.datarepo-dev.broadinstitute.org/v1_f1c765c6-5446-4aef-bdbe-c741ff09c27c_f2a7d885-4fd3-4faf-bd16-06219a8eef99"
-            "wfl-test-a830fe00-7ef2-430a-9d5e-fa0c18dc99e1/"
-            "drs://jade.datarepo-dev.broadinstitute.org/v1_f1c765c6-5446-4aef-bdbe-c741ff09c27c_2b67ed53-ccac-49c6-8ad6-8952a1dfaf98")]
-   :totalBytesProcessed "221025"
-   :jobComplete true
-   :cacheHit false})
+   :rows [["8d529c08-bc21-4ea0-9254-d99b9c12dfd2"
+           "drs://jade.datarepo-dev.broadinstitute.org/v1_f1c765c6-5446-4aef-bdbe-c741ff09c27c_f2a7d885-4fd3-4faf-bd16-06219a8eef99"
+           "wfl-test-a830fe00-7ef2-430a-9d5e-fa0c18dc99e1/"
+           "drs://jade.datarepo-dev.broadinstitute.org/v1_f1c765c6-5446-4aef-bdbe-c741ff09c27c_2b67ed53-ccac-49c6-8ad6-8952a1dfaf98"]
+          ["8d529c08-bc21-4ea0-9254-d99b9c12dfd2"
+           "drs://jade.datarepo-dev.broadinstitute.org/v1_f1c765c6-5446-4aef-bdbe-c741ff09c27c_f2a7d885-4fd3-4faf-bd16-06219a8eef99"
+           "wfl-test-a830fe00-7ef2-430a-9d5e-fa0c18dc99e1/"
+           "drs://jade.datarepo-dev.broadinstitute.org/v1_f1c765c6-5446-4aef-bdbe-c741ff09c27c_2b67ed53-ccac-49c6-8ad6-8952a1dfaf98"]]})
 
 (deftest test-dump-table->tsv
-  (testing "Dumping from BigQuery table response to TSV works"
-    (let [terra-table-name "test-name"
-          contents (-> (bigquery/dump-table->tsv dr-view-content "test-name")
-                       (csv/read-csv :separator \tab))]
-      (is (= (format "entity:%s_id" terra-table-name)
-             ((comp first first) contents)) "The result TSV header is not properly formatted!"))))
+  (let [terra-table-name "test-name"
+        contents (-> (bigquery/dump-table->tsv dr-view-content "test-name")
+                     (csv/read-csv :separator \tab)
+                     doall)]
+    (is (= 3 (count contents)) "expect 3 rows (headers + 2 of data)")
+    (is (= 5 (count (first contents))) "first row has additional column for the entity")
+    (is (every? #(= 4 %) (map count (rest contents))) "data rows have same number of columns as fields")
+    (is (= (format "entity:%s_id" terra-table-name)
+           (ffirst contents) "The result TSV header is not properly formatted!"))))

--- a/api/test/wfl/unit/google/bigquery_test.clj
+++ b/api/test/wfl/unit/google/bigquery_test.clj
@@ -20,11 +20,9 @@
 
 (deftest test-dump-table->tsv
   (let [terra-table-name "test-name"
-        contents (-> (bigquery/dump-table->tsv dr-view-content "test-name")
-                     (csv/read-csv :separator \tab)
-                     doall)]
+        contents (-> (bigquery/dump-table->tsv dr-view-content terra-table-name)
+                     (csv/read-csv :separator \tab))]
     (is (= 3 (count contents)) "expect 3 rows (headers + 2 of data)")
     (is (= 5 (count (first contents))) "first row has additional column for the entity")
     (is (every? #(= 4 %) (map count (rest contents))) "data rows have same number of columns as fields")
-    (is (= (format "entity:%s_id" terra-table-name)
-           (ffirst contents) "The result TSV header is not properly formatted!"))))
+    (is (= (format "entity:%s_id" terra-table-name) (ffirst contents)) "The result TSV header is not properly formatted!")))

--- a/api/test/wfl/unit/google/bigquery_test.clj
+++ b/api/test/wfl/unit/google/bigquery_test.clj
@@ -5,10 +5,10 @@
 
 ;; mock output from bigquery/query-sync
 (def ^:private dr-view-content
-  {:schema {:fields [{:mode "NULLABLE" :name "test-name_id" :type "STRING"}
-                     {:mode "NULLABLE" :name "vcf" :type "STRING"}
-                     {:mode "NULLABLE" :name "id" :type "STRING"}
-                     {:mode "NULLABLE" :name "vcf_index" :type "STRING"}]}
+  {:schema {:fields [{:name "test-name_id" :type "STRING" :mode "NULLABLE"}
+                     {:name "vcf"          :type "STRING" :mode "NULLABLE"}
+                     {:name "id"           :type "STRING" :mode "NULLABLE"}
+                     {:name "vcf_index"    :type "STRING" :mode "NULLABLE"}]}
    :rows [["8d529c08-bc21-4ea0-9254-d99b9c12dfd2"
            "drs://jade.datarepo-dev.broadinstitute.org/v1_f1c765c6-5446-4aef-bdbe-c741ff09c27c_f2a7d885-4fd3-4faf-bd16-06219a8eef99"
            "wfl-test-a830fe00-7ef2-430a-9d5e-fa0c18dc99e1/"


### PR DESCRIPTION
RR: https://broadinstitute.atlassian.net/browse/GH-1221
In this PR, I'm adding test demonstration code for how to import data from a TDR snapshot into a Terra Workspace. This includes:
- Querying all the rows in the specified table in the snapshot
- Selecting and renaming the columns of the table to match those of the target entity
- Importing the rows as new entities into the workspace.

The renaming works by viewing the rows of the table as a list of maps, mapping those names onto workspace names, then reconstructing the table.
Added dataset/snapshot querying utilities to the `datarepo` namespace.

Bug fixes:
- "flattening" the big-query rows didn't flatten rows of arrays