### PR TITLE
GH-1226 Support entity set creation when creating submissions.

### DIFF
--- a/api/src/wfl/service/firecloud.clj
+++ b/api/src/wfl/service/firecloud.clj
@@ -49,21 +49,21 @@
 ;; Third pass: consolidate to single method supporting 1+ entities.
 
 (defn create-submissions
-  "First pass:
-  Creates one submission in `workspace` for each element of `_entities` using the specified
-  `methodconfig`.
+  "
+  First pass:
+  Creates one submission in `workspace` for each of the specified `entities` using `methodconfig`.
+  Throws an `AssertionError` if no entities specified.
+  Returns a sequence of submission-ids for the newly-created submissions.
 
-  QUESTIONS:
-  Should we enforce entity count > 0?
-  Is `entity` a reserved word?
-  Should I hang tight for Ed's PR to be merged?
-  Does FireCloud support submission creation with multiple entities?
-
-  TODO:
-  Add specifications for inputs, usage examples"
-  [workspace methodconfig & _entities]
-  {:pre [(seq _entities)]} ; Checks for at least one entity specified.  Desired?
-  (for [_entity _entities] (create-submission workspace methodconfig _entity)))
+  Parameters
+  ----------
+  workspace    - Fully-qualified Terra Workspace in which the submissions will be created.
+  methodconfig - Fully-qualified method configuration.
+  entities     - [optional] Pairs of the form [Type Name]
+  "
+  [workspace methodconfig & entities]
+  {:pre [(seq entities)]}
+  (for [entity entities] (create-submission workspace methodconfig entity)))
 
 ;; OLIVIA END
 

--- a/api/src/wfl/service/firecloud.clj
+++ b/api/src/wfl/service/firecloud.clj
@@ -38,6 +38,29 @@
         util/response-body-json
         :submissionId)))
 
+;; OLIVIA START
+;; Second pass: creates one submission in a workspace encompassing all specified entities (1+).
+;; Third pass: consolidate to single method supporting 1+ entities.
+
+(defn create-submissions
+  "First pass:
+  Creates one submission in `workspace` for each element of `_entities` using the specified
+  `methodconfig`.
+
+  QUESTIONS:
+  Should we enforce entity count > 0?
+  Is `entity` a reserved word?
+  Should I hang tight for Ed's PR to be merged?
+  Does FireCloud support submission creation with multiple entities?
+
+  TODO:
+  Add specifications for inputs, usage examples"
+  [workspace methodconfig & _entities]
+  {:pre [(seq _entities)]} ; Checks for at least one entity specified.  Desired?
+  (for [_entity _entities] (create-submission workspace methodconfig _entity)))
+
+;; OLIVIA END
+
 (defn get-submission
   "Return the submission in the Terra `workspace` with `submission-id`."
   [workspace submission-id]

--- a/api/src/wfl/util.clj
+++ b/api/src/wfl/util.clj
@@ -435,29 +435,12 @@
   ([task]
    (poll task 1)))
 
-(defn columns-rows->tsv
-  "
-  Writes COLUMNS and ROWS to a .tsv named FILE, or to bytes if FILE not specified.
-
-  Examples
-  --------
-    (columns-rows->tsv [c1 c2 c3] [[x1 x2 x3] [y1 y2 y3] ...])
-    (columns-rows->tsv [c1 c2 c3] [[x1 x2 x3] [y1 y2 y3] ...] \"destination.tsv\")
-  "
-  ([columns rows file]
-   (with-open [writer (io/writer file)]
-     (csv/write-csv writer columns :separator \tab)
-     (csv/write-csv writer rows :separator \tab)
-     file))
-  ([columns rows]
-   (str (columns-rows->tsv columns rows (StringWriter.)))))
-
 "A set of all mutually supported TSV file types (by FireCloud and WFL)"
 (s/def ::tsv-type #{:entity :membership})
 
 (defn terra-id
   "
-  Generates a Terra-compatible primary key column name for the specified TSV-TYPE and base COL.
+  Generate a Terra-compatible primary key column name for the specified TSV-TYPE and base COL.
 
   The first column of the table must be its primary key, and named accordingly:
     entity:[entity-type]_id
@@ -483,14 +466,29 @@
   "
   [tsv-type col]
   {:pre [(s/valid? ::tsv-type tsv-type)]}
-  (let [stripped-col (-> (unsuffix col "_id")
-                         (unsuffix "_set"))
-        maybe-set (if (= :membership tsv-type) "_set" "")]
-    (format "%s:%s%s_id" (name tsv-type) stripped-col maybe-set)))
+  (let [stripped (-> (unsuffix col "_id") (unsuffix "_set"))]
+    (str (name tsv-type) ":" stripped (when (= :membership tsv-type) "_set") "_id")))
+
+(defn columns-rows->tsv
+  "
+  Write COLUMNS and ROWS to a .tsv named FILE, or to bytes if FILE not specified.
+
+  Examples
+  --------
+    (columns-rows->tsv [c1 c2 c3] [[x1 x2 x3] [y1 y2 y3] ...])
+    (columns-rows->tsv [c1 c2 c3] [[x1 x2 x3] [y1 y2 y3] ...] \"destination.tsv\")
+  "
+  ([columns rows file]
+   (with-open [writer (io/writer file)]
+     (csv/write-csv writer columns :separator \tab)
+     (csv/write-csv writer rows :separator \tab)
+     file))
+  ([columns rows]
+   (str (columns-rows->tsv columns rows (StringWriter.)))))
 
 (defn columns-rows->terra-tsv
   "
-  Writes COLUMNS and ROWS to a .tsv named FILE in a Terra-compatible format
+  Write COLUMNS and ROWS to a .tsv named FILE in a Terra-compatible format
   as dictated by TSV-TYPE, or to bytes if FILE not specified.
 
   Parameters

--- a/api/src/wfl/util.clj
+++ b/api/src/wfl/util.clj
@@ -1,12 +1,14 @@
 (ns wfl.util
   "Some utilities shared across this program."
-  (:require [clojure.data.json     :as json]
+  (:require [clojure.data.csv      :as csv]
+            [clojure.data.json     :as json]
             [clojure.java.io       :as io]
             [clojure.java.shell    :as shell]
+            [clojure.spec.alpha    :as s]
             [clojure.string        :as str]
             [clojure.tools.logging :as log]
             [wfl.wfl               :as wfl])
-  (:import [java.io File Writer IOException]
+  (:import [java.io File IOException StringWriter Writer]
            [java.nio.file Files]
            [java.nio.file.attribute FileAttribute]
            [java.time OffsetDateTime Clock LocalDate]
@@ -432,3 +434,81 @@
    (poll task seconds 3))
   ([task]
    (poll task 1)))
+
+(defn columns-rows->tsv
+  "
+  Writes COLUMNS and ROWS to a .tsv named FILE, or to bytes if FILE not specified.
+
+  Examples
+  --------
+    (columns-rows->tsv [c1 c2 c3] [[x1 x2 x3] [y1 y2 y3] ...])
+    (columns-rows->tsv [c1 c2 c3] [[x1 x2 x3] [y1 y2 y3] ...] \"destination.tsv\")
+  "
+  ([columns rows file]
+   (with-open [writer (io/writer file)]
+     (csv/write-csv writer columns :separator \tab)
+     (csv/write-csv writer rows :separator \tab)
+     file))
+  ([columns rows]
+   (str (columns-rows->tsv columns rows (StringWriter.)))))
+
+"A set of all mutually supported TSV file types (by FireCloud and WFL)"
+(s/def ::tsv-type #{:entity :membership})
+
+(defn terra-id
+  "
+  Generates a Terra-compatible primary key column name for the specified TSV-TYPE and base COL.
+
+  The first column of the table must be its primary key, and named accordingly:
+    entity:[entity-type]_id
+    membership:[entity-type]_set_id
+
+  For tsv-type :entity, 'entity:sample_id' will upload the .tsv data into a `sample` table
+  in the workspace (or create one if it does not exist).
+  If the table already contains a sample with that id, it will get overwritten.
+
+  For tsv-type :membership, 'membership:sample_set_id' will append sample names to a `sample_set` table
+  in the workspace (or create one if it does not exist).
+  If the table already contains a sample set with that id, it will be appended to and not overwritten.
+
+  Parameters
+  ----------
+    tsv-type - A member of ::tsv-type
+    col      - Entity name or primary key column base
+
+  Examples
+  --------
+    (terra_id :entity \"flowcell\")
+    (terra_id :membership \"flowcell\")
+  "
+  [tsv-type col]
+  {:pre [(s/valid? ::tsv-type tsv-type)]}
+  (let [stripped-col (-> (unsuffix col "_id")
+                         (unsuffix "_set"))
+        maybe-set (if (= :membership tsv-type) "_set" "")]
+    (format "%s:%s%s_id" (name tsv-type) stripped-col maybe-set)))
+
+(defn columns-rows->terra-tsv
+  "
+  Writes COLUMNS and ROWS to a .tsv named FILE in a Terra-compatible format
+  as dictated by TSV-TYPE, or to bytes if FILE not specified.
+
+  Parameters
+  ----------
+    tsv-type - A member of ::tsv-type
+    columns  - Column names (first will be formatted as primary key identifier)
+    rows     - Rows with element counts matching the column count
+    file     - [optional] TSV file name to dump
+
+  Examples
+  --------
+    (columns-rows->terra-tsv :entity [c1 c2 c3] [[x1 x2 x3] [y1 y2 y3] ...])
+    (columns-rows->terra-tsv :membership [c1 c2 c3] [[x1 x2 x3] [y1 y2 y3] ...] \"dest.tsv\")
+  "
+  ([tsv-type columns rows file]
+   {:pre [(s/valid? ::tsv-type tsv-type)]}
+   (letfn [(format-entity-type [[head & rest]]
+             (cons (terra-id tsv-type head) rest))]
+     (columns-rows->tsv [(format-entity-type columns)] rows file)))
+  ([tsv-type columns rows]
+   (str (columns-rows->terra-tsv tsv-type columns rows (StringWriter.)))))

--- a/api/test/wfl/integration/firecloud_test.clj
+++ b/api/test/wfl/integration/firecloud_test.clj
@@ -2,7 +2,8 @@
   (:require [clojure.test :refer [deftest is testing]]
             [wfl.service.cromwell :as cromwell]
             [wfl.service.firecloud :as firecloud]
-            [wfl.util :as util]))
+            [wfl.util :as util])
+  (:import [java.util UUID]))
 
 ;; Of the form NAMESPACE/NAME
 (def workspace "wfl-dev/Illumina-Genotyping-Array")
@@ -12,6 +13,7 @@
 
 ;; An entity is a pair [Type Name]
 (def entity ["sample" "NA12878"])
+(def entity-set-type (str (first entity) "_set"))
 
 ;; A submission that was manually created
 (def well-known-submission "12ea8b91-737d-4838-972e-05f3c80f3881")
@@ -24,40 +26,6 @@
       (is (empty? rest))
       (is (= well-known-workflow (:workflowId workflow)))
       (is (#{"Succeeded"} (:status workflow))))))
-
-(deftest test-create-submissions-for-entity-set-no-entities
-  (is (thrown? AssertionError (firecloud/create-submission-for-entity-set workspace method-configuration))))
-
-(deftest test-create-submissions-for-entity-set-one-entity
-  (util/bracket
-   #(firecloud/create-submission-for-entity-set workspace method-configuration entity)
-   #(firecloud/abort-submission workspace %)
-   #(let [workflow (-> (firecloud/get-submission workspace %) :workflows first)]
-      (is (= (second entity) (get-in workflow [:workflowEntity :entityName])))
-      (is (#{"Queued" "Submitted"}
-            ;; GH-1212: `get-submission` can return the workflow before it has
-            ;; been queued. In such cases :status is nil so try again
-           (or (:status workflow) (-> (firecloud/get-submission workspace %)
-                                      :workflows
-                                      first
-                                      :status)))))))
-
-;; TODO: tests for import-entity-set, consolidate-entities-to-set, submission creation for >1 entity.
-;; TODO: consolidate tests for single method in a single test.
-
-(deftest test-create-submission
-  (util/bracket
-   #(firecloud/create-submission workspace method-configuration entity)
-   #(firecloud/abort-submission workspace %)
-   #(let [workflow (-> (firecloud/get-submission workspace %) :workflows first)]
-      (is (= (second entity) (get-in workflow [:workflowEntity :entityName])))
-      (is (#{"Queued" "Submitted"}
-            ;; GH-1212: `get-submission` can return the workflow before it has
-            ;; been queued. In such cases :status is nil so try again
-           (or (:status workflow) (-> (firecloud/get-submission workspace %)
-                                      :workflows
-                                      first
-                                      :status)))))))
 
 (deftest test-create-submission
   (util/bracket
@@ -72,6 +40,55 @@
                                       :workflows
                                       first
                                       :status)))))))
+
+(deftest test-create-submissions-for-entity-set
+  (testing "Empty entity list throws AssertionError"
+    (is (thrown? AssertionError
+                 (firecloud/create-submission-for-entity-set workspace
+                                                             method-configuration
+                                                             []))))
+  (doseq [entity-count (range 1 4)]
+    (testing (str "Submission with " entity-count " matching entit(ies) yields 1 workflow")
+      (let [entity-set-name (str (UUID/randomUUID))]
+        (util/bracket
+         #(firecloud/create-submission-for-entity-set
+           workspace method-configuration (repeat entity-count entity) entity-set-name)
+         #((firecloud/abort-submission workspace %)
+           (firecloud/delete-entities workspace [[entity-set-type entity-set-name]]))
+         #(let [[workflow & rest] (-> (firecloud/get-submission workspace %) :workflows)]
+            (is (empty? rest))
+            (is (= (second entity) (get-in workflow [:workflowEntity :entityName])))
+            (is (#{"Queued" "Submitted"}
+                ;; GH-1212: `get-submission` can return the workflow before it has
+                ;; been queued. In such cases :status is nil so try again
+                 (or (:status workflow) (-> (firecloud/get-submission workspace %)
+                                            :workflows
+                                            first
+                                            :status))))))))))
+
+(defn ^:private with-entity?
+  "Check if entity name is found in HTTP response."
+  [name] (fn [response] (= (:name response) name)))
+
+(defn ^:private matches-entity?
+  "Check if entity reference [Type Name] matches item from HTTP response."
+  [[ref-type ref-name]] (fn [{response-type :entityType response-name :entityName}]
+                          (and (= ref-type response-type) (= ref-name response-name))))
+
+(deftest test-import-entity-set
+  (doseq [entity-count (range 1 4)]
+    (testing (str "Import entity set with " entity-count " matching entit(ies)")
+      (let [entity-set-name (str (UUID/randomUUID))]
+        (util/bracket
+         #(-> (firecloud/import-entity-set workspace entity-set-name (repeat entity-count entity))
+              :body)
+         #(firecloud/delete-entities workspace [[% entity-set-name]])
+         #(let [[entity-response & rest] (->> (firecloud/list-entities workspace %)
+                                              (filter (with-entity? entity-set-name)))
+                items (get-in entity-response [:attributes :samples :items])]
+            (is (empty? rest))
+            (is (= entity-count (count items)))
+            (is (every? (matches-entity? entity) items))))))))
 
 (defmacro ^:private using-assemble-refbased-workflow-bindings
   "Define a set of workflow bindings for use in `body`. The values refer to a

--- a/api/test/wfl/integration/firecloud_test.clj
+++ b/api/test/wfl/integration/firecloud_test.clj
@@ -32,28 +32,29 @@
    #(let [workflow (-> (firecloud/get-submission workspace %) :workflows first)]
       (is (= (second entity) (get-in workflow [:workflowEntity :entityName])))
       (is (#{"Queued" "Submitted"}
-            ;; GH-1212: `get-submission` can return the workflow before it has
-            ;; been queued. In such cases :status is nil so try again
+           ;; GH-1212: `get-submission` can return the workflow before it has
+           ;; been queued. In such cases :status is nil so try again
            (or (:status workflow) (-> (firecloud/get-submission workspace %)
                                       :workflows
                                       first
                                       :status)))))))
+
 ;; TODO: tests for 0 and 1 entities.
 (deftest test-create-submissions
   (util/bracket
-    #(firecloud/create-submissions workspace method-configuration entity entity entity)
-    #(doseq [submission-id %]
-       (firecloud/abort-submission workspace submission-id))
-    #(doseq [submission-id %]
-       (let [workflow (-> (firecloud/get-submission workspace submission-id) :workflows first)]
-         (is (= (second entity) (get-in workflow [:workflowEntity :entityName])))
-         (is (#{"Queued" "Submitted"}
-              ;; GH-1212: `get-submission` can return the workflow before it has
-              ;; been queued. In such cases :status is nil so try again
-              (or (:status workflow) (-> (firecloud/get-submission workspace submission-id)
-                                         :workflows
-                                         first
-                                         :status))))))))
+   #(firecloud/create-submissions workspace method-configuration entity entity entity)
+   #(doseq [submission-id %]
+      (firecloud/abort-submission workspace submission-id))
+   #(doseq [submission-id %]
+      (let [workflow (-> (firecloud/get-submission workspace submission-id) :workflows first)]
+        (is (= (second entity) (get-in workflow [:workflowEntity :entityName])))
+        (is (#{"Queued" "Submitted"}
+             ;; GH-1212: `get-submission` can return the workflow before it has
+             ;; been queued. In such cases :status is nil so try again
+             (or (:status workflow) (-> (firecloud/get-submission workspace submission-id)
+                                        :workflows
+                                        first
+                                        :status))))))))
 
 (defmacro ^:private using-assemble-refbased-workflow-bindings
   "Define a set of workflow bindings for use in `body`. The values refer to a

--- a/api/test/wfl/unit/utils_test.clj
+++ b/api/test/wfl/unit/utils_test.clj
@@ -1,7 +1,8 @@
 (ns wfl.unit.utils-test
   (:require [clojure.test :refer [deftest is testing]]
             [wfl.util :as util]
-            [clojure.java.io :as io])
+            [clojure.java.io :as io]
+            [clojure.spec.alpha :as s])
   (:import [java.io IOException]
            [org.apache.commons.io FileUtils]))
 
@@ -60,3 +61,17 @@
 (deftest test-assoc-when
   (is (= {:a 2} (util/assoc-when {:a 1} contains? :a 2)))
   (is (= {:a 1} (util/assoc-when {:a 1} (constantly false) :a 2))))
+
+(deftest test-terra-id
+  (is (thrown? AssertionError (util/terra-id "not-in-tsv-type-spec" "flowcell")))
+  (letfn [(go [[first second expected]]
+              (is (= expected (util/terra-id first second))))]
+    (let [entity "entity:flowcell_id"
+          membership "membership:flowcell_set_id"
+          parameters [[:entity "flowcell" entity]
+                      [:entity "flowcell_id" entity]
+                      [:membership "flowcell" membership]
+                      [:membership "flowcell_id" membership]
+                      [:membership "flowcell_set" membership]
+                      [:membership "flowcell_set_id" membership]]]
+      (run! go parameters))))


### PR DESCRIPTION
### Purpose
https://broadinstitute.atlassian.net/browse/GH-1226

To support submission creation for >1 entity, we must submit the entity references to FireCloud as an entity set (see [`TsvTypes.MEMBERSHIP`](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/src/main/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupport.scala#L13-L20
) in `firecloud-orchestration`).  The resulting entity set is itself a single entity which can be used in submission creation.

FireCloud's [membership type import code](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala#L140-L162) shows us that if we've specified the tsv type correctly, then we can specify one entity reference per line and the upload will group them by their id into lists.

For entity set imports, FireCloud expects a tsv like this (note that the samples don't need to match, in my example we were working with a single entity):
```
membership:sample_set_id\tsample
930360b9-cdc5-446e-b13a-a47b45d9ca4a\tNA12878
930360b9-cdc5-446e-b13a-a47b45d9ca4a\tNA12878
```

Result following entity set creation:
<img width="1147" alt="Screen Shot 2021-04-08 at 11 05 48 AM" src="https://user-images.githubusercontent.com/79769153/114050799-93daca00-985a-11eb-9eb2-a38cf0d8c76b.png">

When creating a submission for an entity set, note the following expectations for an entity set comprised of `sample` type entities.  I assume that that your method is meant to run on a single entity (not an entity set) and that the desired behavior when specifying an entity set during submission creation is that one workflow be kicked off for each entity in the set.
- Within the Terra UI, the method configuration's root entity type should be unchanged, i.e. remain set to `sample` and not changed to `sample_set`.
- The FireCloud submission creation request should also specify `expression=this.samples`, which will be evaluated to resolve entity references to the entities themselves.  Otherwise your submission will fail immediately.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Introduced `firecloud/create-submission-for-entity-set` to consolidate entities into a single entity before creating submission
- Now require `expression=this.<entity-type>s` specification in submission creation request when creating submissions with an entity set
- Refactored `bigquery/dump-file->tsv`, pulling out code now common with `firecloud` for Terra-compatible tsv generation
- Now require specification of tsv type when generating a Terra-compatible tsv (previously we only supported `:entity` tsvs)
- Added new integration and unit tests

### TODO
- Likely in a separate PR, refactor existing `firecloud/create-submission` to support multiple entity specification.
- Would like to be able to run integration tests for submission creation off of an entity set with >1 distinct entities, to confirm that multiple workflows are triggered (I observed this manually).

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

Entry point: `firecloud/create-submission-for-entity-set`.

- Successfully run new tests off of feature branch.
- Verify that BigQuery file dump to TSV behavior remains as expected.
- Verify that existing submission creation behavior (for a single entity) remains as expected.
- `firecloud/import-entity-set` should create a new entry in `<entity-type>_set` table.  Entity references should resolve as a list and indicate their source table.
- `firecloud/create-submission-for-entity-set` should create a single submission with one workflow triggered for each *distinct* member of the entity set.