### PR TITLE
Snapshot creation uses datetime rather than date

### DIFF
--- a/api/src/wfl/service/datarepo.clj
+++ b/api/src/wfl/service/datarepo.clj
@@ -228,8 +228,7 @@
   (let [bq-name (bigquery-name dataset)
         query   "SELECT %s
                  FROM   `%s.%s.%s`
-                 WHERE  datarepo_ingest_date > '%s'
-                 AND    datarepo_ingest_date <= '%s'"]
+                 WHERE updated BETWEEN '%s' AND '%s'"]
     (->> (format query col-spec dataProject bq-name table start end)
          (bigquery/query-sync dataProject))))
 

--- a/api/src/wfl/service/datarepo.clj
+++ b/api/src/wfl/service/datarepo.clj
@@ -224,12 +224,12 @@
         (query-table-impl dataset table))))
 
 (defn ^:private query-table-between-impl
-  [{:keys [dataProject] :as dataset} table [start end] col-spec]
+  [{:keys [dataProject] :as dataset} table column-name [start end] col-spec]
   (let [bq-name (bigquery-name dataset)
         query   "SELECT %s
                  FROM   `%s.%s.%s`
-                 WHERE updated BETWEEN '%s' AND '%s'"]
-    (->> (format query col-spec dataProject bq-name table start end)
+                 WHERE %s BETWEEN '%s' AND '%s'"]
+    (->> (format query col-spec dataProject bq-name table column-name start end)
          (bigquery/query-sync dataProject))))
 
 (defn query-table-between
@@ -237,8 +237,8 @@
    `dataset` in the open-closed `interval` of `datarepo_ingest_date`, where
    `dataset` is a DataRepo dataset or a snapshot of a dataset. If no rows match
    the `interval`, TDR will respond with error 400."
-  ([dataset table interval]
-   (query-table-between-impl dataset table interval "*"))
-  ([dataset table interval columns]
+  ([dataset table column-name interval]
+   (query-table-between-impl dataset table column-name interval "*"))
+  ([dataset table column-name interval columns]
    (->> (util/to-comma-separated-list (map name columns))
-        (query-table-between-impl dataset table interval))))
+        (query-table-between-impl dataset table column-name interval))))

--- a/api/test/wfl/integration/datarepo_test.clj
+++ b/api/test/wfl/integration/datarepo_test.clj
@@ -88,7 +88,7 @@
         row-ids     (-> (datarepo/query-table-between
                          dataset
                          table
-                         ["2021-03-30" "2021-03-31"]
+                         ["2021-03-29 00:00:00" "2021-03-31 00:00:00"]
                          [:datarepo_row_id])
                         :rows
                         flatten)]

--- a/api/test/wfl/integration/datarepo_test.clj
+++ b/api/test/wfl/integration/datarepo_test.clj
@@ -88,6 +88,7 @@
         row-ids     (-> (datarepo/query-table-between
                          dataset
                          table
+                         "updated"
                          ["2021-03-29 00:00:00" "2021-03-31 00:00:00"]
                          [:datarepo_row_id])
                         :rows


### PR DESCRIPTION
### Purpose
The purpose of this ticket is to allow snapshot creation to use a datetime field rather than a date field for creation. 

This is for ticket https://broadinstitute.atlassian.net/browse/GH-1269

### Changes
Using datetime field instead of date field for selecting rows to use in creation of a dataset snapshot

### Review Instructions
Nothing special
