### PR TITLE
[GH-1278] Fix SG update-workload! implementation from updating Clio multiple times

### DIFF
--- a/api/src/wfl/module/sg.clj
+++ b/api/src/wfl/module/sg.clj
@@ -191,6 +191,7 @@
 
 ;; visible for testing
 (defn register-workload-in-clio
+  "Register `_workload` outputs with Clio."
   [{:keys [executor output workflows] :as _workload}]
   (run! (partial register-workflow-in-clio executor output) workflows))
 

--- a/api/test/wfl/integration/modules/sg_test.clj
+++ b/api/test/wfl/integration/modules/sg_test.clj
@@ -309,16 +309,11 @@
    :bam_path                 ".bam"
    :insert_size_metrics_path ".insert_size_metrics"})
 
-;; First workloads/update-workload! makes workflow status "Succeeded".
-;; Second workloads/update-workload! may registers outputs with Clio.
-;;
 (defn ^:private test-clio-updates
   []
   (let [{:keys [items] :as request} (the-sg-workload-request)]
     (-> request
-        workloads/create-workload!
-        workloads/start-workload!
-        workloads/update-workload!
+        workloads/execute-workload!
         workloads/update-workload!
         (as-> workload
               (let [{:keys [finished pipeline workflows]} workload]
@@ -382,11 +377,14 @@
     (run! update! workflows)))
 
 (deftest test-workload-state-transition
-  (with-redefs-fn
-    {#'cromwell/submit-workflows                mock-cromwell-submit-workflows
-     #'postgres/batch-update-workflow-statuses! mock-batch-update-workflow-statuses!
-     #'sg/register-workload-in-clio             (fn [x _] x)}
-    #(shared/run-workload-state-transition-test! (the-sg-workload-request))))
+  (let [count           (atom 0)
+        increment-count (fn [_] (swap! count inc))]
+    (with-redefs-fn
+      {#'cromwell/submit-workflows                mock-cromwell-submit-workflows
+       #'postgres/batch-update-workflow-statuses! mock-batch-update-workflow-statuses!
+       #'sg/register-workload-in-clio             increment-count}
+      #(shared/run-workload-state-transition-test! (the-sg-workload-request)))
+    (is (= 1 @count) "Clio was updated more than once")))
 
 (deftest test-stop-workload-state-transition
   (shared/run-stop-workload-state-transition-test! (the-sg-workload-request)))

--- a/api/test/wfl/integration/modules/sg_test.clj
+++ b/api/test/wfl/integration/modules/sg_test.clj
@@ -384,7 +384,7 @@
        #'postgres/batch-update-workflow-statuses! mock-batch-update-workflow-statuses!
        #'sg/register-workload-in-clio             increment-count}
       #(shared/run-workload-state-transition-test! (the-sg-workload-request)))
-    (is (= 1 @count) "Clio was updated more than once")))
+    (is (== 1 @count) "Clio was updated more than once")))
 
 (deftest test-stop-workload-state-transition
   (shared/run-stop-workload-state-transition-test! (the-sg-workload-request)))


### PR DESCRIPTION
[GH-1278] Fix SG update-workload! implementation from trying to update clio BAM records for each Succeeded workflow repeatedly by restoring the :finished guard for register-workload-in-clio.
Introducted in [GH-1277].


[GH-1278]: https://broadinstitute.atlassian.net/browse/GH-1278

[GH-1277]: https://broadinstitute.atlassian.net/browse/GH-1277