### PR TITLE
util/do-or-nil-silently should move to build.clj

### DIFF
--- a/api/build/build.clj
+++ b/api/build/build.clj
@@ -13,11 +13,11 @@
            [java.time.temporal ChronoUnit]))
 
 (defmacro do-or-nil-silently
-          "Value of `body` or `nil` if it throws, without logging exceptions.
-          See also [[wfl.util/do-or-nil]]."
-          [& body]
-          `(try (do ~@body)
-                (catch Exception x#)))
+  "Value of `body` or `nil` if it throws, without logging exceptions.
+  See also [[wfl.util/do-or-nil]]."
+  [& body]
+  `(try (do ~@body)
+        (catch Exception x#)))
 
 ;; Java chokes on colons in the version string of the jarfile manifest.
 ;; And GAE chokes on everything else.

--- a/api/build/build.clj
+++ b/api/build/build.clj
@@ -12,6 +12,13 @@
   (:import [java.time OffsetDateTime]
            [java.time.temporal ChronoUnit]))
 
+(defmacro do-or-nil-silently
+          "Value of `body` or `nil` if it throws, without logging exceptions.
+          See also [[wfl.util/do-or-nil]]."
+          [& body]
+          `(try (do ~@body)
+                (catch Exception x#)))
+
 ;; Java chokes on colons in the version string of the jarfile manifest.
 ;; And GAE chokes on everything else.
 ;;
@@ -25,7 +32,7 @@
           committed (->> commit
                          (util/shell! "git" "show" "-s" "--format=%cI")
                          OffsetDateTime/parse .toInstant .toString)
-          clean?    (util/do-or-nil-silently
+          clean?    (do-or-nil-silently
                      (util/shell! "git" "diff-index" "--quiet" "HEAD"))]
       (into
        {:version          (or (System/getenv "WFL_VERSION") "devel")

--- a/api/src/wfl/util.clj
+++ b/api/src/wfl/util.clj
@@ -23,13 +23,6 @@
         (catch Exception x#
           (log/warn x# "Swallowed exception and returned nil in wfl.util/do-or-nil"))))
 
-(defmacro do-or-nil-silently
-  "Value of `body` or `nil` if it throws, without logging exceptions.
-  See also [[do-or-nil]]."
-  [& body]
-  `(try (do ~@body)
-        (catch Exception x#)))
-
 ;; Parsers that will not throw.
 ;;
 (defn parse-int [s] (do-or-nil (Integer/parseInt s)))


### PR DESCRIPTION
### Purpose
https://broadinstitute.atlassian.net/browse/GH-1273

To discourage the use of `util/do-or-nil-silently`, moved this macro to `build.clj`.  Interested developers should instead use `util/do-or-nil` in their applications.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- As described above.
 
### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- Build should complete successfully.
