### PR TITLE
[GH-1215] Add wfl.service/rawls.clj for interacting directly with Rawls API

### DIFF
--- a/api/src/wfl/environment.clj
+++ b/api/src/wfl/environment.clj
@@ -48,6 +48,8 @@
    #(-> nil)
    "WFL_FIRECLOUD_URL"
    #(-> "https://api.firecloud.org")
+   "WFL_RAWLS_URL"
+   #(-> "https://rawls.dsde-dev.broadinstitute.org")
 
    ;; -- variables used in test code below this line --
    "WFL_CROMWELL_URL"

--- a/api/src/wfl/service/rawls.clj
+++ b/api/src/wfl/service/rawls.clj
@@ -1,0 +1,52 @@
+(ns wfl.service.rawls
+  "Analyze data in Terra using the Rawls API.
+  Note that Firecloud is built on top of Rawls:
+  Rawls may expose functionality that hasn't yet been promoted to Firecloud."
+  (:require [clj-http.client :as http]
+            [clojure.data.json :as json]
+            [clojure.string :as str]
+            [wfl.auth :as auth]
+            [wfl.environment :as env]
+            [wfl.util :as util]))
+
+(defn ^:private rawls-url [& parts]
+  (let [url (util/de-slashify (env/getenv "WFL_RAWLS_URL"))]
+    (str/join "/" (cons url parts))))
+
+(def ^:private workspace-api-url
+  (partial rawls-url "api/workspaces"))
+
+(defn ^:private get-workspace-json [& parts]
+  (-> (apply workspace-api-url parts)
+      (http/get {:headers (auth/get-auth-header)})
+      util/response-body-json))
+
+(defn create-snapshot
+  "Link a Terra Data Repo snapshot with id SNAPSHOT-ID to a fully-qualified
+  Terra WORKSPACE as NAME, optionally described by DESCRIPTION."
+  ([workspace snapshot-id name description]
+   (-> {:method       :post
+        :url          (workspace-api-url workspace "snapshots")
+        :headers      (auth/get-auth-header)
+        :content-type :application/json
+        :body         (json/write-str {:snapshotId snapshot-id
+                                       :name name
+                                       :description description}
+                                      :escape-slash false)}
+       http/request
+       util/response-body-json
+       :referenceId))
+  ([workspace snapshot-id name]
+   (create-snapshot workspace snapshot-id name "")))
+
+(defn get-snapshot
+  "Return the snapshot in fully-qualified Terra WORKSPACE with REFERENCE-ID."
+  [workspace reference-id]
+  (get-workspace-json workspace "snapshots" reference-id))
+
+(defn delete-snapshot
+  "Delete the snapshot in fully-qualified Terra WORKSPACE with REFERENCE-ID."
+  [workspace reference-id]
+  (-> (workspace-api-url workspace "snapshots" reference-id)
+      (http/delete {:headers (auth/get-auth-header)})
+      util/response-body-json))

--- a/api/test/wfl/integration/rawls_test.clj
+++ b/api/test/wfl/integration/rawls_test.clj
@@ -1,0 +1,36 @@
+(ns wfl.integration.rawls-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [wfl.service.rawls :as rawls]
+            [wfl.util :as util])
+  (:import [clojure.lang ExceptionInfo]
+           [java.util UUID]))
+
+;; Of the form NAMESPACE/NAME
+(def workspace "general-dev-billing-account/test-snapshots")
+
+;; A known Terra Data Repository snapshot's ID...
+(def snapshot-id "7cb392d8-949b-419d-b40b-d039617d2fc7")
+
+;; And a known link to the above TDR snapshot in the workspace.
+(def known-snapshot-link {:name "snapshot" :referenceId "2d15f9bd-ecb9-46b3-bb6c-f22e20235232"})
+
+(deftest test-get-snapshot
+  (let [snapshot (rawls/get-snapshot workspace (:referenceId known-snapshot-link))]
+    (is (= "DATA_REPO_SNAPSHOT" (:referenceType snapshot)))
+    (is (= snapshot-id (get-in snapshot [:reference :snapshot])))
+    (is (= (:name known-snapshot-link) (:name snapshot)))))
+
+(deftest test-create-snapshot
+  (testing "Creating snapshot with same name of existing throws 409 error"
+    (is (thrown-with-msg? ExceptionInfo #"clj-http: status 409"
+                          (rawls/create-snapshot workspace
+                                                 snapshot-id
+                                                 (:name known-snapshot-link)))))
+  (let [name (str (UUID/randomUUID))]
+    (util/bracket
+     #(rawls/create-snapshot workspace snapshot-id name "wfl.rawls-test/test-create-snapshot")
+     #(rawls/delete-snapshot workspace %)
+     #(let [snapshot (rawls/get-snapshot workspace %)]
+        (is (= "DATA_REPO_SNAPSHOT" (:referenceType snapshot)))
+        (is (= snapshot-id (get-in snapshot [:reference :snapshot])))
+        (is (= name (:name snapshot)))))))


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->
- https://broadinstitute.atlassian.net/browse/GH-1215

TDR = Terra Data Repository
TW = Terra Workspace

For my ticket shared above as well as other COVID tickets to do and in progress, we will want to communicate directly with the Rawls API to interact with snapshots from TDR.

The general relationship between values in snapshot-land:
- An existing snapshot in TDR will be identified by a **snapshot-id**.
- When we link it in a TW, we will supply a **name**: subsequent attempts to import a snapshot with the same name will fail with a 409.
- When the snapshot is linked, we will get back a **reference-id**, the linked snapshot's unique ID within the TW.  This is the value Rawls expects when we fetch snapshot information or delete the snapshot from its TW.  Note that I couldn't see the reference-id exposed within the Terra UI, you have to dig a bit to find it if you don't have it from snapshot creation.

This PR does not close out my ticket, but as I'll be out through 4/21 please feel free to add to it and / or merge if it would be helpful for your own development in the space.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- New `wfl.service/rawls.clj` with initial support for snapshot fetch, creation, and deletion.
- New integration tests.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- On this FB, can use new integration tests as a guide for how to interact with new endpoints.
- Note that if the following snapshot is altered or deleted, integration test(s) may fail:
<img width="1050" alt="Screen Shot 2021-04-16 at 5 25 00 PM" src="https://user-images.githubusercontent.com/79769153/115085575-c038bb00-9ed8-11eb-9f31-e340c68fa7fc.png">

