### PR TITLE
[GH-1215] Rename rawls/create-snapshot -> create-snapshot-reference

### DIFF
--- a/api/src/wfl/service/rawls.clj
+++ b/api/src/wfl/service/rawls.clj
@@ -21,7 +21,7 @@
       (http/get {:headers (auth/get-auth-header)})
       util/response-body-json))
 
-(defn create-snapshot
+(defn create-snapshot-reference
   "Link a Terra Data Repo snapshot with id SNAPSHOT-ID to a fully-qualified
   Terra WORKSPACE as NAME, optionally described by DESCRIPTION."
   ([workspace snapshot-id name description]
@@ -37,7 +37,7 @@
        util/response-body-json
        :referenceId))
   ([workspace snapshot-id name]
-   (create-snapshot workspace snapshot-id name "")))
+   (create-snapshot-reference workspace snapshot-id name "")))
 
 (defn get-snapshot
   "Return the snapshot in fully-qualified Terra WORKSPACE with REFERENCE-ID."

--- a/api/test/wfl/integration/rawls_test.clj
+++ b/api/test/wfl/integration/rawls_test.clj
@@ -20,15 +20,15 @@
     (is (= snapshot-id (get-in snapshot [:reference :snapshot])))
     (is (= (:name known-snapshot-link) (:name snapshot)))))
 
-(deftest test-create-snapshot
-  (testing "Creating snapshot with same name of existing throws 409 error"
+(deftest test-create-snapshot-reference
+  (testing "Creating snapshot reference with same name of existing throws 409 error"
     (is (thrown-with-msg? ExceptionInfo #"clj-http: status 409"
-                          (rawls/create-snapshot workspace
-                                                 snapshot-id
-                                                 (:name known-snapshot-link)))))
+                          (rawls/create-snapshot-reference workspace
+                                                           snapshot-id
+                                                           (:name known-snapshot-link)))))
   (let [name (str (UUID/randomUUID))]
     (util/bracket
-     #(rawls/create-snapshot workspace snapshot-id name "wfl.rawls-test/test-create-snapshot")
+     #(rawls/create-snapshot-reference workspace snapshot-id name "wfl.rawls-test/test-create-snapshot")
      #(rawls/delete-snapshot workspace %)
      #(let [snapshot (rawls/get-snapshot workspace %)]
         (is (= "DATA_REPO_SNAPSHOT" (:referenceType snapshot)))


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1215

@rexwangcc commented in my [last PR](https://github.com/broadinstitute/wfl/pull/370) to flag `rawls/create-snapshot` naming as being confusing.  I agree: we create the snapshot in the TDR, and link to it in the workspace via Rawls.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Rename `rawls/create-snapshot -> create-snapshot-reference`: this is consistent with the [Rawls endpoint](https://rawls.dsde-dev.broadinstitute.org/#/snapshots/createDataRepoSnapshot) detailed descriptions and makes it more clear why reference IDs are being returned / passed around.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- Do we like this naming better?  Open to other suggestions, or "I like the old name".
- If using the old reference in your local development, take note.
