### PR TITLE
[GH-1215] Import snapshots within COVID workload

### DIFF
--- a/api/src/wfl/module/covid.clj
+++ b/api/src/wfl/module/covid.clj
@@ -11,6 +11,7 @@
             [wfl.service.firecloud :as firecloud]
             [wfl.service.google.storage :as gcs]
             [wfl.service.postgres :as postgres]
+            [wfl.service.rawls :as rawls]
             [wfl.util :as util]
             [wfl.wfl :as wfl]))
 
@@ -26,6 +27,51 @@
 (defn start-covid-workload!
   [])
 
+(defn ^:private snapshot-imported?
+  "Check if TDR snapshot has been imported to Terra Workspace.
+
+  TODOs / QUESTIONS:
+  - Do we need additional / altered arguments?
+  - Should we have access to loaded workload from outer scope (I think so),
+    or should every check in the update loop load the workload anew?
+  - Do we check workload for presence of snapshot ID? How?
+    (I think it could be related to items per aou. items = table name?)
+  - Could one workload be associated with many snapshots?  Are we checking
+    for all if so, or only for a specified snapshot?
+  "
+  [tx {:keys [id] :as workload}]
+  (let [loaded (workloads/load-workload-for-id tx id)]
+    (:snapshot_reference_id loaded)))
+
+(defn ^:private import-snapshot!
+  "Import TDR snapshot to Terra Workspace.
+
+  TODOs / QUESTIONS:
+  - Do we need additional / altered arguments?
+  - How should we name the snapshot reference?
+  - Where do we get workspace and snapshot ID? From workload?
+    From an element within the workload?
+  - How do we store new reference ID in our transaction recording?
+    Associated with the workload, or something else?
+  - Is this a JDBC update or insert?
+  - Error handling?
+  "
+  [tx {:keys [id] :as workload}]
+  (let [name (util/randomize "placeholder-snapshot-ref-name")
+        workspace "workspace from workload?"
+        snapshot-id (:snapshot_id workload) ;; Is this correct, or need to go deeper?
+        reference-id (rawls/create-snapshot-reference workspace snapshot-id name)]
+    (jdbc/update! tx :workload {:snapshot_reference_id reference-id} ["id = ?" id])))
+
+(comment "Proposed workload update loop as described in Spike doc for reference"
+         (cond
+           (workflow-finished?) (mark-as-done!)
+           (submission-launched?) (monitor-workflow!)
+           (snapshot-imported?) (launch-submission!)
+           (snapshot-created?) (import-snapshot!)
+           (snapshot-creation-job-exist?) (monitor-snapshot-status!)
+           :else (check-for-new-data-in-TDR!)))
+
 ;; TODO: implement progressive (private) functions inside this update loop
 (defn update-covid-workload!
   "Use transaction `tx` to batch-update `workload` statuses."
@@ -33,6 +79,11 @@
   (letfn [(update! [{:keys [id] :as workload}]
             (postgres/batch-update-workflow-statuses! tx workload)
             (postgres/update-workload-status! tx workload)
+            ;; Do we wish to save this loaded workload for our
+            ;; to-be-defined workload update loop?
+            ;; All of the checkers want to look at a loaded
+            ;; workflow, and the update loop conditional makes it
+            ;; such that we only do one task per round.
             (workloads/load-workload-for-id tx id))]
     (if (and started (not finished)) (update! workload) workload)))
 

--- a/api/src/wfl/module/covid.clj
+++ b/api/src/wfl/module/covid.clj
@@ -62,12 +62,10 @@
   Use transaction TX to update ITEMS table with resulting reference id."
   [tx {:keys [executor items] :as workload} {:keys [id snapshot_id] :as record}]
   (let [workspace (:workspace executor)
-        name (util/randomize "placeholder-snapshot-ref-name")
-        reference-id (rawls/create-snapshot-reference workspace snapshot_id name)]
+        reference-id (rawls/create-snapshot-reference workspace snapshot_id)]
     (when (nil? reference-id)
       (throw (ex-info "Rawls unable to create snapshot reference"
-                      (util/deep-merge (snapshot-error-map workload record)
-                                       {:name name}))))
+                      (snapshot-error-map workload record))))
     (jdbc/update! tx items {:snapshot_reference_id reference-id} ["id = ?" id])))
 
 (comment "Proposed workload update loop as described in Spike doc for reference"

--- a/api/src/wfl/service/rawls.clj
+++ b/api/src/wfl/service/rawls.clj
@@ -7,6 +7,7 @@
             [clojure.string :as str]
             [wfl.auth :as auth]
             [wfl.environment :as env]
+            [wfl.service.datarepo :as datarepo]
             [wfl.util :as util]))
 
 (defn ^:private rawls-url [& parts]
@@ -23,7 +24,8 @@
 
 (defn create-snapshot-reference
   "Link a Terra Data Repo snapshot with id SNAPSHOT-ID to a fully-qualified
-  Terra WORKSPACE as NAME, optionally described by DESCRIPTION."
+  Terra WORKSPACE as NAME (with the snapshot name as its base if unspecified),
+  optionally described by DESCRIPTION."
   ([workspace snapshot-id name description]
    (-> (workspace-api-url workspace "snapshots")
        (http/post {:headers      (auth/get-auth-header)
@@ -34,7 +36,10 @@
                                                  :escape-slash false)})
        util/response-body-json))
   ([workspace snapshot-id name]
-   (create-snapshot-reference workspace snapshot-id name "")))
+   (create-snapshot-reference workspace snapshot-id name ""))
+  ([workspace snapshot-id]
+   (let [name (util/randomize (:name (datarepo/snapshot snapshot-id)))]
+     (create-snapshot-reference workspace snapshot-id name))))
 
 (defn get-snapshot-reference
   "Return the snapshot reference in fully-qualified Terra WORKSPACE with REFERENCE-ID."

--- a/api/src/wfl/service/rawls.clj
+++ b/api/src/wfl/service/rawls.clj
@@ -23,9 +23,8 @@
       util/response-body-json))
 
 (defn create-snapshot-reference
-  "Link a Terra Data Repo snapshot with id SNAPSHOT-ID to a fully-qualified
-  Terra WORKSPACE as NAME (with the snapshot name as its base if unspecified),
-  optionally described by DESCRIPTION."
+  "Link SNAPSHOT-ID to WORKSPACE as NAME with DESCRIPTION.
+  If NAME unspecified, generate a unique reference name from the snapshot name."
   ([workspace snapshot-id name description]
    (-> (workspace-api-url workspace "snapshots")
        (http/post {:headers      (auth/get-auth-header)

--- a/api/src/wfl/service/rawls.clj
+++ b/api/src/wfl/service/rawls.clj
@@ -36,13 +36,13 @@
   ([workspace snapshot-id name]
    (create-snapshot-reference workspace snapshot-id name "")))
 
-(defn get-snapshot
-  "Return the snapshot in fully-qualified Terra WORKSPACE with REFERENCE-ID."
+(defn get-snapshot-reference
+  "Return the snapshot reference in fully-qualified Terra WORKSPACE with REFERENCE-ID."
   [workspace reference-id]
   (get-workspace-json workspace "snapshots" reference-id))
 
-(defn delete-snapshot
-  "Delete the snapshot in fully-qualified Terra WORKSPACE with REFERENCE-ID."
+(defn delete-snapshot-reference
+  "Delete the snapshot reference in fully-qualified Terra WORKSPACE with REFERENCE-ID."
   [workspace reference-id]
   (-> (workspace-api-url workspace "snapshots" reference-id)
       (http/delete {:headers (auth/get-auth-header)})

--- a/api/test/wfl/integration/modules/covid_test.clj
+++ b/api/test/wfl/integration/modules/covid_test.clj
@@ -1,0 +1,67 @@
+(ns wfl.integration.modules.covid-test
+  (:require [clojure.test :refer :all]
+            [clojure.test :as clj-test]
+            [wfl.tools.fixtures :as fixtures]
+            [wfl.jdbc :as jdbc]
+            [wfl.module.covid :as covid]
+            [wfl.service.rawls :as rawls])
+  (:import [clojure.lang ExceptionInfo]))
+
+(clj-test/use-fixtures :once fixtures/temporary-postgresql-database)
+
+(def workload {:id 1})
+
+(def workspace "general-dev-billing-account/test-snapshots")
+(def executor {:workspace workspace})
+
+(def snapshot-id "7cb392d8-949b-419d-b40b-d039617d2fc7")
+(def reference-id "2d15f9bd-ecb9-46b3-bb6c-f22e20235232")
+
+;; Source and source details
+(def source {:details (format "%s_%09d" "TerraDataRepoSourceDetails" 1)})
+(def sd-base {:id 1})
+(def sd-snapshot (assoc sd-base :snapshot_id snapshot-id))
+(def sd-reference (assoc sd-snapshot :snapshot_reference_id reference-id))
+
+(defn ^:private mock-rawls-snapshot-reference [& _]
+  {:cloningInstructions "COPY_NOTHING",
+   :description "test importing a snapshot into a workspace",
+   :name "snapshot",
+   :reference {:instanceName "terra", :snapshot snapshot-id},
+   :referenceId reference-id,
+   :referenceType "DATA_REPO_SNAPSHOT",
+   :workspaceId "e9d053b9-d79f-40b7-b701-904bf542ec2d"})
+
+(defn ^:private mock-throw [& _] (throw (ex-info "mocked throw" {})))
+
+(deftest test-snapshot-imported
+  (let [snapshot-imported? #'covid/snapshot-imported?]
+    (testing "Missing snapshot, missing reference, or failed fetch returns false"
+      (with-redefs-fn
+        {#'rawls/get-snapshot-reference mock-throw}
+        #(letfn [(go [sd] (is (false? (snapshot-imported? sd executor))))]
+           (let [source-details [sd-base sd-snapshot sd-reference]]
+             (run! go source-details)))))
+    (testing "Snapshot, reference, and successful fetch returns true"
+      (with-redefs-fn
+        {#'rawls/get-snapshot-reference mock-rawls-snapshot-reference}
+        #(is (true? (snapshot-imported? sd-reference executor)))))))
+
+(deftest test-import-snapshot
+  (let [import-snapshot! #'covid/import-snapshot!]
+    #_(testing "Successful create writes to db"
+        (jdbc/with-db-transaction [tx (fixtures/testing-db-config)]
+          (with-redefs-fn
+            {#'rawls/create-snapshot-reference mock-rawls-snapshot-reference}
+            #(import-snapshot! tx workload source sd-snapshot executor))))
+    (testing "Failed create throws"
+      (jdbc/with-db-transaction [tx (fixtures/testing-db-config)]
+        (with-redefs-fn
+          {#'rawls/create-snapshot-reference mock-throw}
+          #(is (thrown-with-msg?
+                ExceptionInfo #"Rawls unable to create snapshot reference"
+                (import-snapshot! tx
+                                  workload
+                                  source
+                                  sd-snapshot
+                                  executor))))))))

--- a/api/test/wfl/integration/rawls_test.clj
+++ b/api/test/wfl/integration/rawls_test.clj
@@ -27,10 +27,11 @@
                 (is (= snapshot-name (:name snapshot)))
                 (:referenceId snapshot)))]
         (testing "Get"
-          (let [snapshot (rawls/get-snapshot workspace reference-id)]
+          (let [snapshot (rawls/get-snapshot-reference workspace reference-id)]
             (is (= "DATA_REPO_SNAPSHOT" (:referenceType snapshot)))
             (is (= snapshot-id (get-in snapshot [:reference :snapshot])))
             (is (= snapshot-name (:name snapshot)))))
         (testing "Create already exists"
           (is (thrown-with-msg? ExceptionInfo #"clj-http: status 409"
                                 (make-reference))))))))
+

--- a/api/test/wfl/integration/rawls_test.clj
+++ b/api/test/wfl/integration/rawls_test.clj
@@ -34,4 +34,3 @@
         (testing "Create already exists"
           (is (thrown-with-msg? ExceptionInfo #"clj-http: status 409"
                                 (make-reference))))))))
-

--- a/database/changesets/20210422_TerraDataRepoSourceDetailsTable.xml
+++ b/database/changesets/20210422_TerraDataRepoSourceDetailsTable.xml
@@ -20,7 +20,6 @@
                 id                          bigint,      -- unique to this table
                 snapshot_creation_job_id    text,        -- id of the TDR snapshot creation job
                 snapshot_id                 text,        -- id of the snapshot lives in TDR
-                snapshot_reference_id       text,        -- id of the snapshot reference lives in the workspace
                 datarepo_row_id             text         -- id of the TDR data row
             )
         </sql>

--- a/database/changesets/20210422_TerraExecutorDetailsTable.xml
+++ b/database/changesets/20210422_TerraExecutorDetailsTable.xml
@@ -18,6 +18,7 @@
         <sql>
             CREATE TYPE TerraExecutorDetails AS (
                 id                     bigint,      -- unique to this table
+                snapshot_reference_id  text,        -- id of the snapshot reference lives in the workspace
                 rawls_submission_id    text,        -- id of the Rawls submission
                 workflow_id            text,        -- id of the Terra workflow
                 workflow_status        text         -- status of the Terra workflow


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1215

My component of the COVID update loop: importing TDR snapshots to the workspace.  I consider it safe to merge, but is subject to change if/when the data model evolves further and we connect the pieces of the update loop.

Directly upstream from me:
- [Workflow creation](https://broadinstitute.atlassian.net/browse/GH-1213)
- [Polling for TDR snapshots](https://broadinstitute.atlassian.net/browse/GH-1222)

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Data model change: a `snapshot_reference_id` is linked to a workspace and should be associated with the executor, not the source (TDR in our use case).
- `covid/get-imported-snapshot-reference` -  nil or snapshot reference from Rawls for `snapshot_reference_id` in executor details instance (to be created from `TerraExecutorDetails`).
- `covid/import-snapshot!` - import snapshot to workspace, writing to DB if successful
- added integration tests (incomplete coverage)

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- Robust testing would be easiest with workflow creation fleshed out.  I cannot presently run `covid/import-snapshot!` and write to the database for this reason (more info in my inline comment on `covid_test.clj`).  Is waiting for this functionality the right move?  If not, would appreciate mobbing / pairing to build out a lightweight integration test set-up.
- I pass around objects that I expect will be DB records and destructure them.  We may elect to pass the needed parameters directly.  For now, I err towards overcommunication.