### PR TITLE
Update documentation and infrastructure for release candidates

### DIFF
--- a/api/build/build.clj
+++ b/api/build/build.clj
@@ -104,7 +104,11 @@
   (let [derived        (str/join "/" [".." "derived" "api"])
         resources      (io/file derived "resources")
         test-resources (io/file derived "test" "resources")]
-    (pprint the-version)
-    (write-the-version-file resources the-version)
-    (run! #(write-workflow-description test-resources %) (find-wdls))
-    (System/exit 0)))
+    (try
+      (pprint the-version)
+      (write-the-version-file resources the-version)
+      (run! #(write-workflow-description test-resources %) (find-wdls))
+      (System/exit 0)
+      (catch Throwable t
+        (pprint t)
+        (System/exit 1)))))

--- a/api/module.mk
+++ b/api/module.mk
@@ -79,10 +79,10 @@ $(SYSTEM): $(TEST_SCM_SRC)
 DOCKER_IMAGE_NAME := broadinstitute/workflow-launcher-$(MODULE)
 $(IMAGES): $(MODULE_DIR)/Dockerfile $(MODULE_DIR)/.dockerignore
 	$(DOCKER) build \
-        --file $< \
- 		--tag $(DOCKER_IMAGE_NAME):latest \
-        --tag $(DOCKER_IMAGE_NAME):$(WFL_VERSION) \
-        $(PROJECT_DIR)
+		--file $< \
+		--tag $(DOCKER_IMAGE_NAME):latest \
+		--tag $(DOCKER_IMAGE_NAME):$(WFL_VERSION) \
+		$(PROJECT_DIR)
 	@$(TOUCH) $@
 
 $(CLEAN):

--- a/api/module.mk
+++ b/api/module.mk
@@ -76,10 +76,17 @@ $(SYSTEM): $(TEST_SCM_SRC)
 	$(TEE) $(DERIVED_MODULE_DIR)/system.log
 	@$(TOUCH) $@
 
-DOCKER_API_IMAGE := broadinstitute/workflow-launcher-$(MODULE):$(WFL_VERSION)
+DOCKER_IMAGE_NAME := broadinstitute/workflow-launcher-$(MODULE)
 $(IMAGES): $(MODULE_DIR)/Dockerfile $(MODULE_DIR)/.dockerignore
-	$(DOCKER) build --file $< --tag $(DOCKER_API_IMAGE) $(PROJECT_DIR)
+	$(DOCKER) build \
+        --file $< \
+ 		--tag $(DOCKER_IMAGE_NAME):latest \
+        --tag $(DOCKER_IMAGE_NAME):$(WFL_VERSION) \
+        $(PROJECT_DIR)
 	@$(TOUCH) $@
 
 $(CLEAN):
-	-$(DOCKER) image rm -f $(DOCKER_API_IMAGE)
+	-$(DOCKER) image rm -f $(DOCKER_IMAGE_NAME):$(WFL_VERSION)
+
+$(DISTCLEAN):
+	-$(DOCKER) image rm -f $(DOCKER_IMAGE_NAME):latest

--- a/docs/md/dev-release.md
+++ b/docs/md/dev-release.md
@@ -8,10 +8,14 @@ in order to release a new version of WFL:
    - the version string should match that specified in `version`
 2. Identify and cherry-pick additional commits from `develop` that you want
    to release (e.g. late features and bug fixes).
-3. Create a pull request into `main`. You will need to run
+3. Create a release candidate and deploy to a testing environment. See
+   instructions bellow.
+4. [Bash](https://broadinstitute.atlassian.net/wiki/spaces/GHConfluence/pages/1731658083/Feature+Bashes)
+   the release candidate. Add/cherry-pick any bug fixes that result. 
+5. Create a pull request into `main`. You will need to run
    `./ops/cli.py release` to generate the changelog for this release (the `-d`
    flag can be used to do a dry run without writing to the `CHANGELOG.md`file).
-5. When the PR is approved, merge it into `main`. The release action will run
+6. When the PR is approved, merge it into `main`. The release action will run
    automatically to build, test and build and push the tagged docker images of
    WFL to [DockerHub](https://hub.docker.com/repository/docker/broadinstitute/workflow-launcher-api).
    Please merge PRs that have passed all automated tests only.
@@ -22,4 +26,37 @@ in order to release a new version of WFL:
 
 !!! tip
     Remember to create a PR to bump the version string in `version` in
-    `develop` for the next release.
+    `develop` for the next release, including changes to `CHANGELOG.md`
+    from the release.
+
+## Creating a Release Candidate
+
+In this example, we will create a release candidate for vX.Y.Z. We will assume
+the existence of a release branch `release/X.Y.Z-rc`. From `wfl`'s root
+directory:
+
+1. Ensure your local repository clone is clean
+    ```
+    $ make distclean
+    ```
+
+2. Prepare sources
+    ```bash
+    $ git checkout release/X.Y.Z-rc
+    $ git pull origin release/X.Y.Z-rc --ff
+    ```
+
+4. Build the docker images locally
+    ```bash
+    $ make TARGET=images
+    ```
+
+5. Tag the commit and release the images to dockerhub with the release
+   candidate tag. Let us assume that this is the Mth release candidate.
+    ```bash
+    $ ./ops/cli.py tag-and-push-images --version=X.Y.Z-rcN
+    ```
+
+!!! tip
+    You can run `make` in parallel by adding `-jN` to the end of your `make`
+    command, where `N` is the number of concurrent jobs to run.

--- a/ops/cli.py
+++ b/ops/cli.py
@@ -39,10 +39,13 @@ def exit_if_dry_run(config: WflInstanceConfig) -> None:
 
 
 def publish_docker_images(config: WflInstanceConfig) -> None:
-    """Publish existing docker images for the stored version."""
+    """Publish latest docker images for the stored version."""
     info(f"=>  Publishing Docker images for version {config.version}")
     for module in ["api", "ui"]:
-        shell(f"docker push broadinstitute/workflow-launcher-{module}:{config.version}")
+        image = f"broadinstitute/workflow-launcher-{module}"
+        # re-tag the image in case the version is being overwritten.
+        shell(f"docker tag {image}:latest {image}:{config.version}")
+        shell(f"docker push {image}:{config.version}")
     success("Published Docker images")
 
 
@@ -119,6 +122,8 @@ def cli() -> WflInstanceConfig:
 
     parser.add_argument("-d", "--dry-run", action="store_true",
                         help="exit before COMMAND makes any remote changes")
+    parser.add_argument("-v", "--version",
+                        help="specify the version to use instead of the 'version' file")
 
     return WflInstanceConfig(**vars(parser.parse_args()))
 

--- a/ui/module.mk
+++ b/ui/module.mk
@@ -27,14 +27,21 @@ $(BUILD): $(DERIVED_SRC)
 	$(NPM) run build --prefix $(DERIVED_MODULE_DIR)
 	@$(TOUCH) $@
 
-DOCKER_UI_IMAGE := broadinstitute/workflow-launcher-$(MODULE):$(WFL_VERSION)
+DOCKER_IMAGE_NAME := broadinstitute/workflow-launcher-$(MODULE)
 $(IMAGES): $(MODULE_DIR)/Dockerfile $(MODULE_DIR)/.dockerignore
 	$(CP) $(MODULE_DIR)/.dockerignore $(DERIVED_MODULE_DIR)
-	$(DOCKER) build --file $< --tag $(DOCKER_UI_IMAGE) $(DERIVED_MODULE_DIR)
+	$(DOCKER) build \
+		--file $< \
+		--tag $(DOCKER_IMAGE_NAME):latest \
+		--tag $(DOCKER_IMAGE_NAME):$(WFL_VERSION) \
+		$(DERIVED_MODULE_DIR)
 	@$(TOUCH) $@
 
 $(CLEAN):
-	-$(DOCKER) image rm -f $(DOCKER_UI_IMAGE)
+	-$(DOCKER) image rm -f $(DOCKER_IMAGE_NAME):$(WFL_VERSION)
+
+$(DISTCLEAN):
+	-$(DOCKER) image rm -f $(DOCKER_IMAGE_NAME):latest
 
 $(DERIVED_NPM_CONFIG): $(DERIVED_MODULE_DIR)/%.json : $(MODULE_DIR)/%.json
 	$(JQ) '.version="$(WFL_VERSION)"' $< > $@


### PR DESCRIPTION
Update documentation and infrastructure for release candidates
- creating release candiates
- bashing release candidates

Restore version override in cli.py.
Re-tag latest docker images in cli.py so that version can be overwritten.

Update IMAGES target in Makefile to add the :latest tag. This is the image that will be tagged when we run cli.py tag-and-push-images.
Clean up :latest images on distclean target.