### PR TITLE
[GH-1293] fix test-create-submissions-for-entity-set

### DIFF
--- a/api/test/wfl/integration/firecloud_test.clj
+++ b/api/test/wfl/integration/firecloud_test.clj
@@ -31,15 +31,14 @@
   (util/bracket
    #(firecloud/create-submission workspace method-configuration entity)
    #(firecloud/abort-submission workspace %)
-   #(let [workflow (-> (firecloud/get-submission workspace %) :workflows first)]
+   #(let [get-workflows (fn [] (:workflows (firecloud/get-submission workspace %)))
+          workflow      (first (get-workflows))]
       (is (= (second entity) (get-in workflow [:workflowEntity :entityName])))
       (is (#{"Queued" "Submitted"}
            ;; GH-1212: `get-submission` can return the workflow before it has
            ;; been queued. In such cases :status is nil so try again
-           (or (:status workflow) (-> (firecloud/get-submission workspace %)
-                                      :workflows
-                                      first
-                                      :status)))))))
+           (or (:status workflow)
+               (util/poll (comp :status first get-workflows))))))))
 
 (deftest test-create-submissions-for-entity-set
   (testing "Empty entity list throws AssertionError"
@@ -55,16 +54,15 @@
            workspace method-configuration (repeat entity-count entity) entity-set-name)
          #((firecloud/abort-submission workspace %)
            (firecloud/delete-entities workspace [[entity-set-type entity-set-name]]))
-         #(let [[workflow & rest] (-> (firecloud/get-submission workspace %) :workflows)]
+         #(let [get-workflows     (fn [] (:workflows (firecloud/get-submission workspace %)))
+                [workflow & rest] (get-workflows)]
             (is (empty? rest))
             (is (= (second entity) (get-in workflow [:workflowEntity :entityName])))
             (is (#{"Queued" "Submitted"}
                 ;; GH-1212: `get-submission` can return the workflow before it has
                 ;; been queued. In such cases :status is nil so try again
-                 (or (:status workflow) (-> (firecloud/get-submission workspace %)
-                                            :workflows
-                                            first
-                                            :status))))))))))
+                 (or (:status workflow)
+                     (util/poll (comp :status first get-workflows)))))))))))
 
 (defn ^:private with-entity?
   "Check if entity name is found in HTTP response."


### PR DESCRIPTION
RR: https://broadinstitute.atlassian.net/browse/GH-1293

Simply getting the submission again is not sufficient to guarantee that
the workflow has been queued for execution. Poll instead.
This is the same issue as https://broadinstitute.atlassian.net/browse/GH-1212