### PR TITLE
[GH-1215] COVID `update-terra-executor` progress

### DIFF
--- a/api/src/wfl/module/covid.clj
+++ b/api/src/wfl/module/covid.clj
@@ -48,10 +48,10 @@
   [{:keys [details] :as queue}]
   (if-let [{:keys [id] :as _item} (peek-queue! queue)]
     (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
-        (let [now (OffsetDateTime/now)]
-          (jdbc/update! tx details {:consumed now
-                                    :updated  now}
-                        ["id = ?" id])))
+      (let [now (OffsetDateTime/now)]
+        (jdbc/update! tx details {:consumed now
+                                  :updated  now}
+                      ["id = ?" id])))
     (throw (ex-info "No items in queue" {:queue queue}))))
 
 ;; interfaces

--- a/api/src/wfl/module/covid.clj
+++ b/api/src/wfl/module/covid.clj
@@ -275,8 +275,7 @@
 (defn ^:private create-submission!
   "TO IMPLEMENT:
   Create submission from REFERENCE."
-  [executor reference]
-)
+  [executor reference])
 
 (defn ^:private write-workflows!
   "Write WORKFLOWS to DETAILS table."

--- a/api/src/wfl/module/covid.clj
+++ b/api/src/wfl/module/covid.clj
@@ -308,7 +308,7 @@
             )]
     (let [now      (OffsetDateTime/now) ; Use to update... something?
           snapshots (find-new-snapshots source)]
-      (when (seq? snapshots)
+      (when (seq snapshots)
         (create-submissions executor (import-snapshots! executor snapshots))))))
 
 (defn ^:private peek-terra-executor-queue [{:keys [queue] :as _executor}]

--- a/api/src/wfl/module/covid.clj
+++ b/api/src/wfl/module/covid.clj
@@ -77,7 +77,7 @@
 
 (defmulti from-source!
   "Return `source-item` coerced to form understood by `executor`."
-  (fn [executor source-item] (:from_source executor)))
+  (fn [executor source-item] (:fromSource executor)))
 
 (defmulti update-executor!
   "Update the executor with the `source`"

--- a/api/src/wfl/module/covid.clj
+++ b/api/src/wfl/module/covid.clj
@@ -39,9 +39,7 @@
   [{:keys [details] :as _queue}]
   (let [query "SELECT * FROM %s WHERE NOT consumed ORDER BY id ASC LIMIT 1"]
     (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
-      (->> (format query details)
-           (jdbc/query tx)
-           (first)))))
+      (first (jdbc/query tx (format query details))))))
 
 (defn pop-queue!
   "Consume first unconsumed item in DETAILS table, or throw if empty."

--- a/api/src/wfl/module/covid.clj
+++ b/api/src/wfl/module/covid.clj
@@ -181,7 +181,7 @@
                     (set/rename-keys tdr-source-serialized-fields)
                     (assoc :details details)
                     (->> (jdbc/insert! tx tdr-source-table)))]
-    [tdr-source-type (-> items first :id)]))
+    [tdr-source-type (-> items first :id str)]))
 
 ;; Create and add new snapshots to the snapshot queue
 (defn ^:private update-tdr-source [source]
@@ -201,16 +201,6 @@
         (assoc :type tdr-source-type)
         (set/rename-keys (set/map-invert tdr-source-serialized-fields)))
     (throw (ex-info "source_items is not an integer" details))))
-
-(defn ^:private create-tdr-source [tx id request]
-  (let [create  "CREATE TABLE %s OF TerraDataRepoSourceDetails (PRIMARY KEY (id))"
-        details (format "TerraDataRepoSourceDetails_%09d" id)
-        _       (jdbc/execute! tx [(format create details)])
-        items   (-> (select-keys request (keys tdr-source-serialized-fields))
-                    (set/rename-keys tdr-source-serialized-fields)
-                    (assoc :details details)
-                    (->> (jdbc/insert! tx tdr-source-table)))]
-    [tdr-source-type (-> items first :id str)]))
 
 (defn ^:private peek-tdr-source-details
   "Get first unconsumed snapshot record from DETAILS table."

--- a/api/src/wfl/module/covid.clj
+++ b/api/src/wfl/module/covid.clj
@@ -279,9 +279,9 @@
 (defn ^:private import-snapshot-v2!
   "Import snapshot with SNAPSHOT_ID to WORKSPACE.
   Update EXECUTOR with resulting reference id."
-  [{:keys [workspace :as executor]}
+  [{:keys [workspace] :as executor}
    ;; snapshot_id is a property of source details, this destructuring may change.
-   {:keys [snapshot_id :as _source]}]
+   {:keys [snapshot_id] :as _source}]
   (let [reference (rawls/create-snapshot-reference workspace snapshot_id)]
     (assoc executor :snapshot_reference_id (:referenceId reference))
     reference))

--- a/api/src/wfl/service/rawls.clj
+++ b/api/src/wfl/service/rawls.clj
@@ -23,8 +23,7 @@
       util/response-body-json))
 
 (defn create-snapshot-reference
-  "Link SNAPSHOT-ID to WORKSPACE as NAME with DESCRIPTION.
-  If NAME unspecified, use the snapshot name."
+  "Link SNAPSHOT-ID to WORKSPACE as NAME with DESCRIPTION."
   ([workspace snapshot-id name description]
    (-> (workspace-api-url workspace "snapshots")
        (http/post {:headers      (auth/get-auth-header)
@@ -35,10 +34,7 @@
                                                  :escape-slash false)})
        util/response-body-json))
   ([workspace snapshot-id name]
-   (create-snapshot-reference workspace snapshot-id name ""))
-  ([workspace snapshot-id]
-   (let [name (:name (datarepo/snapshot snapshot-id))]
-     (create-snapshot-reference workspace snapshot-id name))))
+   (create-snapshot-reference workspace snapshot-id name "")))
 
 (defn get-snapshot-reference
   "Return the snapshot reference in fully-qualified Terra WORKSPACE with REFERENCE-ID."

--- a/api/src/wfl/service/rawls.clj
+++ b/api/src/wfl/service/rawls.clj
@@ -24,7 +24,7 @@
 
 (defn create-snapshot-reference
   "Link SNAPSHOT-ID to WORKSPACE as NAME with DESCRIPTION.
-  If NAME unspecified, generate a unique reference name from the snapshot name."
+  If NAME unspecified, use the snapshot name."
   ([workspace snapshot-id name description]
    (-> (workspace-api-url workspace "snapshots")
        (http/post {:headers      (auth/get-auth-header)
@@ -37,7 +37,7 @@
   ([workspace snapshot-id name]
    (create-snapshot-reference workspace snapshot-id name ""))
   ([workspace snapshot-id]
-   (let [name (util/randomize (:name (datarepo/snapshot snapshot-id)))]
+   (let [name (:name (datarepo/snapshot snapshot-id))]
      (create-snapshot-reference workspace snapshot-id name))))
 
 (defn get-snapshot-reference

--- a/api/test/wfl/integration/modules/covid_test.clj
+++ b/api/test/wfl/integration/modules/covid_test.clj
@@ -33,60 +33,9 @@
     (fixtures/method-overload-fixture
      covid/pop-queue! test-queue-type test-queue-pop)))
 
-(def workload {:id 1})
-
 ;; For temporary workspace creation
 (def workspace-prefix "general-dev-billing-account/test-workspace")
 (def group "hornet-eng")
-
-(def snapshot-id "7cb392d8-949b-419d-b40b-d039617d2fc7")
-(def reference-id "2d15f9bd-ecb9-46b3-bb6c-f22e20235232")
-
-;; Source details
-(def source-details {:id 1 :snapshot_id snapshot-id})
-
-;; Executor and its details
-(def executor-base {:details (format "%s_%09d" "TerraExecutorDetails" 1)})
-(def ed-base {:id 1})
-(def ed-reference (assoc ed-base :snapshot_reference_id reference-id))
-
-(defn ^:private mock-rawls-snapshot-reference [& _]
-  {:cloningInstructions "COPY_NOTHING",
-   :description "test importing a snapshot into a workspace",
-   :name "snapshot",
-   :reference {:instanceName "terra", :snapshot snapshot-id},
-   :referenceId reference-id,
-   :referenceType "DATA_REPO_SNAPSHOT",
-   :workspaceId "e9d053b9-d79f-40b7-b701-904bf542ec2d"})
-
-(defn ^:private mock-throw [& _] (throw (ex-info "mocked throw" {})))
-
-#_(deftest test-get-imported-snapshot-reference
-    (fixtures/with-temporary-workspace workspace-prefix group
-      (fn [workspace]
-        (let [executor (assoc executor-base :workspace workspace)
-              fetch (fn [ed] (#'covid/get-imported-snapshot-reference executor ed))]
-          (with-redefs-fn {#'rawls/get-snapshot-reference mock-throw}
-            #(let [go (fn [ed] (is (not (fetch ed))))
-                   executor-details [ed-base ed-reference]]
-               (run! go executor-details)))
-          (with-redefs-fn {#'rawls/get-snapshot-reference mock-rawls-snapshot-reference}
-            #(is (fetch ed-reference)))))))
-
-#_(deftest test-import-snapshot
-    (fixtures/with-temporary-workspace workspace-prefix group
-      (fn [workspace]
-        (let [executor (assoc executor-base :workspace workspace)]
-          #_(testing "Successful create writes to db"
-              (jdbc/with-db-transaction [tx (fixtures/testing-db-config)]
-                (with-redefs-fn {#'rawls/create-snapshot-reference mock-rawls-snapshot-reference}
-                  #(#'covid/import-snapshot! tx workload source-details executor ed-base))))
-          (testing "Failed create throws"
-            (jdbc/with-db-transaction [tx (fixtures/testing-db-config)]
-              (with-redefs-fn {#'rawls/create-snapshot-reference mock-throw}
-                #(is (thrown-with-msg?
-                      ExceptionInfo #"mocked throw"
-                      (#'covid/import-snapshot! tx workload source-details executor ed-base))))))))))
 
 (deftest test-create-workload
   (letfn [(verify-source [{:keys [type last_checked details]}]

--- a/api/test/wfl/integration/modules/covid_test.clj
+++ b/api/test/wfl/integration/modules/covid_test.clj
@@ -6,13 +6,14 @@
             [wfl.module.covid      :as covid]
             [wfl.service.firecloud :as firecloud]
             [wfl.service.postgres  :as postgres]
+            [wfl.service.rawls     :as rawls]
             [wfl.tools.fixtures    :as fixtures]
             [wfl.tools.workloads   :as workloads]
             [wfl.tools.resources   :as resources]
             [wfl.util              :as util])
-  (:import [java.util ArrayDeque]))
+  (:import [java.util ArrayDeque UUID]))
 
-;; queue mocks
+;; Queue mocks
 (def ^:private test-queue-type "TestQueue")
 (defn ^:private make-queue-from-list [items]
   {:type test-queue-type :queue (ArrayDeque. items)})
@@ -21,7 +22,24 @@
   (-> this :queue .getFirst))
 
 (defn ^:private test-queue-pop [this]
-  (-> this :queue .removeLast))
+  (-> this :queue .removeFirst))
+
+;; Snapshot reference mock
+(def ^:private snapshot-reference-id
+  (str (UUID/randomUUID)))
+(defn ^:private mock-rawls-create-snapshot-reference [& _]
+  {:referenceId snapshot-reference-id})
+
+;; Submission mock
+(def ^:private submission-id
+  (str (UUID/randomUUID)))
+(def ^:private running-workflow
+  {:status "Running" :workflowId (str (UUID/randomUUID))})
+(def ^:private succeeded-workflow
+  {:status "Succeeded" :workflowId (str (UUID/randomUUID))})
+(defn ^:private mock-create-submission [& _]
+  {:submissionId submission-id
+   :workflows [running-workflow succeeded-workflow]})
 
 (let [new-env {"WFL_FIRECLOUD_URL"
                "https://firecloud-orchestration.dsde-dev.broadinstitute.org"}]
@@ -66,6 +84,45 @@
     (is (not (:started workload)))
     (is (:started (workloads/start-workload! workload)))))
 
+(deftest test-update-terra-executor
+  (fixtures/with-temporary-workspace
+    workspace-prefix group
+    (fn [workspace]
+      (let [snapshot {:name "test-snapshot-name"
+                      :id   (str (UUID/randomUUID))}
+            source (make-queue-from-list [snapshot])
+            executor (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+                       (->> {:name                       "Terra"
+                             :workspace                  workspace
+                             :methodConfiguration        "mc-namespace/mc-name"
+                             :methodConfigurationVersion 1
+                             :entity                     "snapshot"
+                             :fromSource                 "importSnapshot"
+                             :skipValidation             true}
+                            (covid/create-executor! tx 0)
+                            (zipmap [:executor_type :executor_items])
+                            (covid/load-executor! tx)))
+            verify-record-against-workflow
+            (fn [record workflow idx]
+              (is (= idx (:id record)))
+              (is (= (:status workflow) (:workflow_status record)))
+              (is (= (:workflowId workflow) (:workflow_id record))))]
+        (with-redefs-fn
+          {#'rawls/create-snapshot-reference   mock-rawls-create-snapshot-reference
+           #'covid/create-submission!          mock-create-submission}
+          #(covid/update-executor! source executor))
+        (is (-> source :queue empty?) "The snapshot was not consumed.")
+        (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+          (let [[running-record succeeded-record & _ :as records]
+                (->> executor :details (postgres/get-table tx))]
+            (is (== 2 (count records))
+                "The workflows were not written to the database")
+            (is (every? #(= snapshot-reference-id (:snapshot_reference_id %)) records))
+            (is (every? #(= submission-id (:rawls_submission_id %)) records))
+            (is (every? #(nil? (:consumed %)) records))
+            (verify-record-against-workflow running-record running-workflow 1)
+            (verify-record-against-workflow succeeded-record succeeded-workflow 2)))))))
+
 (deftest test-update-terra-workspace-sink
   (fixtures/with-temporary-workspace
     workspace-prefix group
@@ -105,4 +162,5 @@
                (fn [] (seq (firecloud/list-entities workspace "flowcell"))))]
           (is (= name flowcell-id) "The test entity was not created"))))))
 
-(test-vars [#'test-update-terra-workspace-sink])
+(test-vars [#'test-update-terra-executor
+            #'test-update-terra-workspace-sink])

--- a/api/test/wfl/integration/modules/covid_test.clj
+++ b/api/test/wfl/integration/modules/covid_test.clj
@@ -6,13 +6,11 @@
             [wfl.module.covid      :as covid]
             [wfl.service.firecloud :as firecloud]
             [wfl.service.postgres  :as postgres]
-            [wfl.service.rawls     :as rawls]
             [wfl.tools.fixtures    :as fixtures]
             [wfl.tools.workloads   :as workloads]
             [wfl.tools.resources   :as resources]
             [wfl.util              :as util])
-  (:import [clojure.lang ExceptionInfo]
-           [java.util ArrayDeque]))
+  (:import [java.util ArrayDeque]))
 
 ;; queue mocks
 (def ^:private test-queue-type "TestQueue")

--- a/api/test/wfl/integration/modules/covid_test.clj
+++ b/api/test/wfl/integration/modules/covid_test.clj
@@ -63,32 +63,32 @@
 
 (defn ^:private mock-throw [& _] (throw (ex-info "mocked throw" {})))
 
-(deftest test-get-imported-snapshot-reference
-  (fixtures/with-temporary-workspace workspace-prefix group
-    (fn [workspace]
-      (let [executor (assoc executor-base :workspace workspace)
-            fetch (fn [ed] (#'covid/get-imported-snapshot-reference executor ed))]
-        (with-redefs-fn {#'rawls/get-snapshot-reference mock-throw}
-          #(let [go (fn [ed] (is (not (fetch ed))))
-                 executor-details [ed-base ed-reference]]
-             (run! go executor-details)))
-        (with-redefs-fn {#'rawls/get-snapshot-reference mock-rawls-snapshot-reference}
-          #(is (fetch ed-reference)))))))
+#_(deftest test-get-imported-snapshot-reference
+    (fixtures/with-temporary-workspace workspace-prefix group
+      (fn [workspace]
+        (let [executor (assoc executor-base :workspace workspace)
+              fetch (fn [ed] (#'covid/get-imported-snapshot-reference executor ed))]
+          (with-redefs-fn {#'rawls/get-snapshot-reference mock-throw}
+            #(let [go (fn [ed] (is (not (fetch ed))))
+                   executor-details [ed-base ed-reference]]
+               (run! go executor-details)))
+          (with-redefs-fn {#'rawls/get-snapshot-reference mock-rawls-snapshot-reference}
+            #(is (fetch ed-reference)))))))
 
-(deftest test-import-snapshot
-  (fixtures/with-temporary-workspace workspace-prefix group
-    (fn [workspace]
-      (let [executor (assoc executor-base :workspace workspace)]
-        #_(testing "Successful create writes to db"
-            (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
-              (with-redefs-fn {#'rawls/create-snapshot-reference mock-rawls-snapshot-reference}
-                #(#'covid/import-snapshot! tx workload source-details executor ed-base))))
-        (testing "Failed create throws"
-          (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
-            (with-redefs-fn {#'rawls/create-snapshot-reference mock-throw}
-              #(is (thrown-with-msg?
-                    ExceptionInfo #"mocked throw"
-                    (#'covid/import-snapshot! tx workload source-details executor ed-base))))))))))
+#_(deftest test-import-snapshot
+    (fixtures/with-temporary-workspace workspace-prefix group
+      (fn [workspace]
+        (let [executor (assoc executor-base :workspace workspace)]
+          #_(testing "Successful create writes to db"
+              (jdbc/with-db-transaction [tx (fixtures/testing-db-config)]
+                (with-redefs-fn {#'rawls/create-snapshot-reference mock-rawls-snapshot-reference}
+                  #(#'covid/import-snapshot! tx workload source-details executor ed-base))))
+          (testing "Failed create throws"
+            (jdbc/with-db-transaction [tx (fixtures/testing-db-config)]
+              (with-redefs-fn {#'rawls/create-snapshot-reference mock-throw}
+                #(is (thrown-with-msg?
+                      ExceptionInfo #"mocked throw"
+                      (#'covid/import-snapshot! tx workload source-details executor ed-base))))))))))
 
 (deftest test-create-workload
   (letfn [(verify-source [{:keys [type last_checked details]}]

--- a/api/test/wfl/integration/modules/covid_test.clj
+++ b/api/test/wfl/integration/modules/covid_test.clj
@@ -96,7 +96,6 @@
                              :workspace                  workspace
                              :methodConfiguration        "mc-namespace/mc-name"
                              :methodConfigurationVersion 1
-                             :entity                     "snapshot"
                              :fromSource                 "importSnapshot"
                              :skipValidation             true}
                             (covid/create-executor! tx 0)
@@ -161,6 +160,3 @@
               (util/poll
                (fn [] (seq (firecloud/list-entities workspace "flowcell"))))]
           (is (= name flowcell-id) "The test entity was not created"))))))
-
-(test-vars [#'test-update-terra-executor
-            #'test-update-terra-workspace-sink])


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1215

Main focus was fleshing out `update-terra-executor` to include snapshot import and sketch the update pattern.  As part of this work I got a better understanding of how we intend to use queues to pass items from source to executor and executor to sink.

Full functionality depends on [Rex's PR](https://github.com/broadinstitute/wfl/pull/371) for:
- New snapshot naming convention
- Reintroduction of `snapshot_id` to source details table

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Added `update-terra-executor` and required helpers: coerce an available snapshot from `source` queue to a snapshot reference, add entry point for submission creation (@tbl3rd) and write new workflows to executor details instance.
- Refined queue peek and pop for source and executor based on @ehigham 's clarification and mobbing discussion with @rexwangcc .  Notably, queue peeks return a meaningful object (snapshot for source, workflow for executor) rather than a database record.
- Removed now-deprecated code from earlier update loop design.
- Added integration test.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- Would appreciate a double-check on how I've generated new record ids when writing to an executor details instance. 
- @tbl3rd - would like to hear your thoughts on `update-terra-executor` submission creation.

### In the future
- Expand `update-terra-executor` to check and update status of active workflows.
- Add unit tests for new helper methods as desired.
