### PR TITLE
[GH-1306] Add `workflows` multimethod for workloads

### DIFF
--- a/api/src/wfl/api/handlers.clj
+++ b/api/src/wfl/api/handlers.clj
@@ -1,19 +1,18 @@
 (ns wfl.api.handlers
   "Define handlers for API endpoints. Note that pipeline modules MUST be required here."
-  (:require [clojure.set :refer [rename-keys]]
+  (:require [clojure.set                    :refer [rename-keys]]
             [clojure.tools.logging.readable :as logr]
-            [ring.util.http-response :as response]
-            [wfl.api.workloads :as workloads]
-            [wfl.module.aou :as aou]
+            [ring.util.http-response        :as response]
+            [wfl.api.workloads              :as workloads]
+            [wfl.module.aou                 :as aou]
             [wfl.module.arrays]
             [wfl.module.copyfile]
             [wfl.module.wgs]
             [wfl.module.xx]
             [wfl.module.sg]
-            [wfl.jdbc :as jdbc]
-            [wfl.service.google.storage :as gcs]
-            [wfl.service.postgres :as postgres]
-            [wfl.util :as util]))
+            [wfl.jdbc                       :as jdbc]
+            [wfl.service.google.storage     :as gcs]
+            [wfl.service.postgres           :as postgres]))
 
 (defn succeed
   "A successful response with BODY."
@@ -29,7 +28,10 @@
   "Strip internal properties from the `workload` and its `workflows`."
   [workload]
   (let [prune #(apply dissoc % [:id :items])]
-    (prune (update workload :workflows (partial mapv prune)))))
+    (->> (workloads/workflows workload)
+         (mapv prune)
+         (assoc workload :workflows)
+         prune)))
 
 (defn append-to-aou-workload
   "Append new workflows to an existing started AoU workload describe in BODY of REQUEST."

--- a/api/src/wfl/api/workloads.clj
+++ b/api/src/wfl/api/workloads.clj
@@ -1,9 +1,8 @@
 (ns wfl.api.workloads
-  (:require [clojure.string :as str]
-            [wfl.jdbc :as jdbc]
-            [wfl.service.postgres :as postgres]
-            [wfl.util :as util]
-            [clojure.tools.logging :as log]))
+  (:require [clojure.string        :as str]
+            [clojure.tools.logging :as log]
+            [wfl.jdbc              :as jdbc]
+            [wfl.util              :as util]))
 
 ;; always derive from base :wfl/exception
 (derive ::invalid-pipeline :wfl/exception)
@@ -29,6 +28,10 @@
 (defmulti update-workload!
   "(transaction workload) -> workload"
   (fn [_ body] (:pipeline body)))
+
+(defmulti workflows
+  "Return the workflows managed by the `workload`."
+  (fn [workload] (:pipeline workload)))
 
 ;; loading utilities
 (defmulti load-workload-impl
@@ -126,19 +129,13 @@
             {:cause body
              :type  ::invalid-pipeline})))
 
-(defn default-load-workload-impl
-  [tx workload]
-  (letfn [(unnilify [m] (into {} (filter second m)))
-          (split-inputs [m]
-            (let [keep [:id :finished :status :updated :uuid :options]]
-              (assoc (select-keys m keep) :inputs (apply dissoc m keep))))
-          (load-options [m] (update m :options (fnil util/parse-json "null")))]
-    (->> (postgres/get-table tx (:items workload))
-         (mapv (comp unnilify split-inputs load-options))
-         (assoc workload :workflows)
-         unnilify)))
-
-(defoverload load-workload-impl :default default-load-workload-impl)
+(defmethod load-workload-impl
+  :default
+  [_ body]
+  (throw
+   (ex-info "Failed to load workload - no such pipeline"
+            {:cause body
+             :type  ::invalid-pipeline})))
 
 ;; Common workload operations
 (defn saved-before?

--- a/api/src/wfl/module/aou.clj
+++ b/api/src/wfl/module/aou.clj
@@ -1,16 +1,15 @@
 (ns wfl.module.aou
   "Process Arrays for the All Of Us project."
-  (:require [clojure.string :as str]
-            [clojure.tools.logging :as log]
-            [wfl.api.workloads :as workloads :refer [defoverload]]
-            [wfl.jdbc :as jdbc]
-            [wfl.module.batch :as batch]
-            [wfl.references :as references]
-            [wfl.service.cromwell :as cromwell]
+  (:require [clojure.string             :as str]
+            [clojure.tools.logging      :as log]
+            [wfl.api.workloads          :as workloads :refer [defoverload]]
+            [wfl.jdbc                   :as jdbc]
+            [wfl.module.batch           :as batch]
+            [wfl.references             :as references]
+            [wfl.service.cromwell       :as cromwell]
             [wfl.service.google.storage :as gcs]
-            [wfl.service.postgres :as postgres]
-            [wfl.util :as util]
-            [wfl.wfl :as wfl])
+            [wfl.util                   :as util]
+            [wfl.wfl                    :as wfl])
   (:import [java.sql Timestamp]
            [java.time OffsetDateTime]
            [java.util UUID]))
@@ -280,8 +279,10 @@
   pipeline
   [tx {:keys [started finished] :as workload}]
   (letfn [(update! [{:keys [id] :as workload}]
-            (postgres/update-workflow-statuses! tx workload)
+            (batch/update-workflow-statuses! tx workload)
             (when (:stopped workload)
-              (postgres/update-workload-status! tx workload))
+              (batch/update-workload-status! tx workload))
             (workloads/load-workload-for-id tx id))]
     (if (and started (not finished)) (update! workload) workload)))
+
+(defoverload workloads/workflows pipeline batch/workflows)

--- a/api/src/wfl/module/aou.clj
+++ b/api/src/wfl/module/aou.clj
@@ -285,4 +285,5 @@
             (workloads/load-workload-for-id tx id))]
     (if (and started (not finished)) (update! workload) workload)))
 
-(defoverload workloads/workflows pipeline batch/workflows)
+(defoverload workloads/workflows          pipeline batch/workflows)
+(defoverload workloads/load-workload-impl pipeline batch/pre-v0.4.0-load-workload-impl)

--- a/api/src/wfl/module/batch.clj
+++ b/api/src/wfl/module/batch.clj
@@ -1,13 +1,77 @@
 (ns wfl.module.batch
   "Some utilities shared between batch workloads in cromwell."
-  (:require [wfl.api.workloads :as workloads]
-            [wfl.jdbc :as jdbc]
+  (:require [clj-http.client      :as http]
+            [clojure.string       :as str]
+            [wfl.api.workloads    :as workloads]
+            [wfl.auth             :as auth]
+            [wfl.jdbc             :as jdbc]
             [wfl.service.cromwell :as cromwell]
             [wfl.service.postgres :as postgres]
-            [wfl.util :as util]
-            [wfl.wfl :as wfl])
+            [wfl.util             :as util]
+            [wfl.wfl              :as wfl])
   (:import [java.time OffsetDateTime]
            [java.util UUID]))
+
+(defn ^:private cromwell-status
+  "`status` of the workflow with `uuid` in `cromwell`."
+  [cromwell uuid]
+  (-> (str/join "/" [cromwell "api" "workflows" "v1" uuid "status"])
+      (http/get {:headers (auth/get-auth-header)})
+      :body
+      util/parse-json
+      :status))
+
+(def ^:private finished?
+  "Test if a workflow `:status` is in a terminal state."
+  (set (conj cromwell/final-statuses "skipped")))
+
+(defn make-update-workflows [get-status!]
+  (fn [tx {:keys [items] :as workload}]
+    (letfn [(update! [{:keys [id uuid]} status]
+              (jdbc/update! tx items
+                            {:status status
+                             :updated (OffsetDateTime/now)
+                             :uuid uuid}
+                            ["id = ?" id]))]
+      (->> (workloads/workflows workload)
+           (remove (comp nil? :uuid))
+           (remove (comp finished? :status))
+           (run! #(update! % (get-status! workload %)))))))
+
+(def update-workflow-statuses!
+  "Use `tx` to update `status` of Cromwell `workflows` in a `workload`."
+  (letfn [(get-cromwell-status [{:keys [executor]} {:keys [uuid]}]
+            (if (util/uuid-nil? uuid)
+              "skipped"
+              (cromwell-status executor uuid)))]
+    (make-update-workflows get-cromwell-status)))
+
+(defn batch-update-workflow-statuses!
+  "Use `tx` to update the `status` of the workflows in `_workload`."
+  [tx {:keys [executor uuid items] :as _workoad}]
+  (let [uuid->status (->> {:label (str "workload:" uuid) :includeSubworkflows "false"}
+                          (cromwell/query executor)
+                          (map (juxt :id :status)))]
+    (letfn [(update! [[uuid status]]
+              (jdbc/update! tx items
+                            {:status status :updated (OffsetDateTime/now)}
+                            ["uuid = ?" uuid]))]
+      (run! update! uuid->status))))
+
+(defn active-workflows
+  "Use `tx` to query all the workflows in `_workload` whose :status is not in
+  `finished?`"
+  [tx {:keys [items] :as _workload}]
+  (let [query "SELECT id FROM %s WHERE status IS NULL OR status NOT IN %s"]
+    (->> (util/to-quoted-comma-separated-list finished?)
+         (format query items)
+         (jdbc/query tx))))
+
+(defn update-workload-status!
+  "Use `tx` to mark `workload` finished when all `workflows` are finished."
+  [tx {:keys [id] :as workload}]
+  (when (empty? (active-workflows tx workload))
+    (jdbc/update! tx :workload {:finished (OffsetDateTime/now)} ["id = ?" id])))
 
 (defn add-workload-table!
   "Use transaction `tx` to add a `CromwellWorkflow` table
@@ -29,6 +93,18 @@
     (jdbc/db-do-commands tx [(format create table)])
     (jdbc/update!        tx :workload {:items table} ["id = ?" id])
     [id table]))
+
+(defn pre-v0.4.0-load-workload-impl
+  [tx workload]
+  (letfn [(unnilify [m] (into {} (filter second m)))
+          (split-inputs [m]
+            (let [keep [:id :finished :status :updated :uuid :options]]
+              (assoc (select-keys m keep) :inputs (apply dissoc m keep))))
+          (load-options [m] (update m :options (fnil util/parse-json "null")))]
+    (->> (postgres/get-table tx (:items workload))
+         (mapv (comp unnilify split-inputs load-options))
+         (assoc workload :workflows)
+         unnilify)))
 
 (defn load-batch-workload-impl
   "Use transaction `tx` to load and associate the workflows in the `workload`
@@ -65,8 +141,8 @@
   "Use transaction TX to batch-update WORKLOAD statuses."
   [tx {:keys [started finished] :as workload}]
   (letfn [(update! [{:keys [id] :as workload}]
-            (postgres/batch-update-workflow-statuses! tx workload)
-            (postgres/update-workload-status! tx workload)
+            (batch-update-workflow-statuses! tx workload)
+            (update-workload-status! tx workload)
             (workloads/load-workload-for-id tx id))]
     (if (and started (not finished)) (update! workload) workload)))
 
@@ -80,3 +156,8 @@
               (when-not (:started workload) (patch! {:finished now}))
               (workloads/load-workload-for-id tx id)))]
     (if-not (or stopped finished) (stop! workload) workload)))
+
+(defn workflows
+  "Return the workflows managed by the `workload`."
+  [workload]
+  (:workflows workload))

--- a/api/src/wfl/module/copyfile.clj
+++ b/api/src/wfl/module/copyfile.clj
@@ -1,12 +1,12 @@
 (ns wfl.module.copyfile
   "A dummy module for smoke testing wfl/cromwell auth."
-  (:require [clojure.data.json :as json]
-            [clojure.string :as str]
-            [wfl.api.workloads :as workloads :refer [defoverload]]
-            [wfl.jdbc :as jdbc]
-            [wfl.module.batch :as batch]
+  (:require [clojure.data.json    :as json]
+            [clojure.string       :as str]
+            [wfl.api.workloads    :as workloads :refer [defoverload]]
+            [wfl.jdbc             :as jdbc]
+            [wfl.module.batch     :as batch]
             [wfl.service.cromwell :as cromwell]
-            [wfl.util :as util])
+            [wfl.util             :as util])
   (:import [java.time OffsetDateTime]))
 
 (def pipeline "copyfile")
@@ -128,7 +128,7 @@
               (jdbc/update! tx items
                             {:updated (OffsetDateTime/now) :uuid uuid :status "Submitted"}
                             ["id = ?" id]))]
-      (run! (comp (partial update! tx) submit!) (:workflows workload))
+      (run! (comp (partial update! tx) submit!) (workloads/workflows workload))
       (jdbc/update! tx :workload
                     {:started (OffsetDateTime/now)} ["uuid = ?" uuid]))))
 
@@ -148,5 +148,7 @@
   pipeline
   [tx workload]
   (if (workloads/saved-before? "0.4.0" workload)
-    (workloads/default-load-workload-impl tx workload)
+    (batch/pre-v0.4.0-load-workload-impl tx workload)
     (batch/load-batch-workload-impl tx workload)))
+
+(defoverload workloads/workflows pipeline batch/workflows)

--- a/api/src/wfl/module/covid.clj
+++ b/api/src/wfl/module/covid.clj
@@ -169,11 +169,6 @@
                     {:id       items
                      :workload workload}))))
 
-(defn ^:private workflows
-  "Return all the workflows managed by the `_workload`."
-  [{:keys [executor] :as _workload}]
-  (executor-workflows executor))
-
 ;; Terra Data Repository Source
 (def ^:private tdr-source-name  "Terra DataRepo")
 (def ^:private tdr-source-type  "TerraDataRepoSource")
@@ -453,4 +448,4 @@
 (defoverload workloads/update-workload!   pipeline update-covid-workload)
 (defoverload workloads/stop-workload!     pipeline batch/stop-workload!)
 (defoverload workloads/load-workload-impl pipeline load-covid-workload-impl)
-(defoverload workloads/workflows          pipeline workflows)
+(defoverload workloads/workflows          pipeline (comp executor-workflows :executor))

--- a/api/src/wfl/module/covid.clj
+++ b/api/src/wfl/module/covid.clj
@@ -362,8 +362,8 @@
          (when-not (postgres/table-exists? tx details)
            (throw (ex-info "Missing executor details table" {:table details})))
          (->> (format "SELECT DISTINCT rawls_submission_id FROM %s" details)
-           (jdbc/query tx)))
-    (mapcat (comp :workflows #(firecloud/get-submission workspace %)))))
+              (jdbc/query tx)))
+       (mapcat (comp :workflows #(firecloud/get-submission workspace %)))))
 
 (defoverload create-executor! terra-executor-name create-terra-executor)
 (defoverload update-executor! terra-executor-type update-terra-executor)

--- a/api/src/wfl/module/covid.clj
+++ b/api/src/wfl/module/covid.clj
@@ -373,8 +373,9 @@
 (defoverload load-sink!   terra-workspace-sink-type load-terra-workspace-sink)
 (defoverload update-sink! terra-workspace-sink-type update-terra-workspace-sink)
 
-(defoverload workloads/create-workload! pipeline create-covid-workload)
-(defoverload workloads/start-workload! pipeline start-covid-workload)
-(defoverload workloads/update-workload! pipeline update-covid-workload)
-(defoverload workloads/stop-workload! pipeline batch/stop-workload!)
+(defoverload workloads/create-workload!   pipeline create-covid-workload)
+(defoverload workloads/start-workload!    pipeline start-covid-workload)
+(defoverload workloads/update-workload!   pipeline update-covid-workload)
+(defoverload workloads/stop-workload!     pipeline batch/stop-workload!)
 (defoverload workloads/load-workload-impl pipeline load-covid-workload-impl)
+(defoverload workloads/workflows          pipeline workflows)

--- a/api/src/wfl/module/covid.clj
+++ b/api/src/wfl/module/covid.clj
@@ -290,8 +290,8 @@
          (when-not (postgres/table-exists? tx details)
            (throw (ex-info "Missing executor details table" {:table details})))
          (->> (format "SELECT DISTINCT rawls_submission_id FROM %s" details)
-              (jdbc/query tx))
-         (mapcat (comp :workflows #(firecloud/get-submission workspace %))))))
+              (jdbc/query tx)))
+       (mapcat (comp :workflows #(firecloud/get-submission workspace %)))))
 
 (defoverload create-executor!   terra-executor-name create-terra-executor)
 (defoverload load-executor!     terra-executor-type load-terra-executor)

--- a/api/src/wfl/module/wgs.clj
+++ b/api/src/wfl/module/wgs.clj
@@ -1,15 +1,14 @@
 (ns wfl.module.wgs
   "Reprocess (External) Whole Genomes."
-  (:require [clojure.data.json :as json]
-            [clojure.string :as str]
-            [wfl.api.workloads :as workloads :refer [defoverload]]
-            [wfl.jdbc :as jdbc]
-            [wfl.module.all :as all]
-            [wfl.references :as references]
+  (:require [clojure.data.json          :as json]
+            [clojure.string             :as str]
+            [wfl.api.workloads          :as workloads :refer [defoverload]]
+            [wfl.jdbc                   :as jdbc]
+            [wfl.module.batch           :as batch]
+            [wfl.references             :as references]
             [wfl.service.google.storage :as gcs]
-            [wfl.util :as util]
-            [wfl.wfl :as wfl]
-            [wfl.module.batch :as batch])
+            [wfl.util                   :as util]
+            [wfl.wfl                    :as wfl])
   (:import [java.time OffsetDateTime]))
 
 (def pipeline "ExternalWholeGenomeReprocessing")
@@ -199,5 +198,7 @@
   pipeline
   [tx workload]
   (if (workloads/saved-before? "0.4.0" workload)
-    (workloads/default-load-workload-impl tx workload)
+    (batch/pre-v0.4.0-load-workload-impl tx workload)
     (batch/load-batch-workload-impl tx workload)))
+
+(defoverload workloads/workflows pipeline batch/workflows)

--- a/api/src/wfl/module/xx.clj
+++ b/api/src/wfl/module/xx.clj
@@ -1,16 +1,15 @@
 (ns wfl.module.xx
   "Reprocess External Exomes, whatever they are."
-  (:require [clojure.data.json :as json]
-            [clojure.string :as str]
-            [wfl.api.workloads :refer [defoverload]]
-            [wfl.api.workloads :as workloads]
-            [wfl.jdbc :as jdbc]
-            [wfl.module.all :as all]
-            [wfl.module.batch :as batch]
-            [wfl.references :as references]
+  (:require [clojure.data.json          :as json]
+            [clojure.string             :as str]
+            [wfl.api.workloads          :refer [defoverload]]
+            [wfl.api.workloads          :as workloads]
+            [wfl.jdbc                   :as jdbc]
+            [wfl.module.batch           :as batch]
+            [wfl.references             :as references]
             [wfl.service.google.storage :as gcs]
-            [wfl.util :as util]
-            [wfl.wfl :as wfl])
+            [wfl.util                   :as util]
+            [wfl.wfl                    :as wfl])
   (:import [java.time OffsetDateTime]))
 
 (def pipeline "ExternalExomeReprocessing")
@@ -168,8 +167,9 @@
       (jdbc/update! tx :workload {:started now} ["id = ?" id]))
     (workloads/load-workload-for-id tx id)))
 
-(defoverload workloads/create-workload! pipeline create-xx-workload!)
-(defoverload workloads/start-workload! pipeline start-xx-workload!)
-(defoverload workloads/update-workload! pipeline batch/update-workload!)
-(defoverload workloads/stop-workload! pipeline batch/stop-workload!)
+(defoverload workloads/create-workload!   pipeline create-xx-workload!)
+(defoverload workloads/start-workload!    pipeline start-xx-workload!)
+(defoverload workloads/update-workload!   pipeline batch/update-workload!)
+(defoverload workloads/stop-workload!     pipeline batch/stop-workload!)
 (defoverload workloads/load-workload-impl pipeline batch/load-batch-workload-impl)
+(defoverload workloads/workflows          pipeline batch/workflows)

--- a/api/src/wfl/service/rawls.clj
+++ b/api/src/wfl/service/rawls.clj
@@ -23,8 +23,7 @@
       util/response-body-json))
 
 (defn create-snapshot-reference
-  "Link SNAPSHOT-ID to WORKSPACE as NAME with DESCRIPTION.
-  If NAME unspecified, generate a unique reference name from the snapshot name."
+  "Link SNAPSHOT-ID to WORKSPACE as NAME with DESCRIPTION."
   ([workspace snapshot-id name description]
    (-> (workspace-api-url workspace "snapshots")
        (http/post {:headers      (auth/get-auth-header)
@@ -35,10 +34,7 @@
                                                  :escape-slash false)})
        util/response-body-json))
   ([workspace snapshot-id name]
-   (create-snapshot-reference workspace snapshot-id name ""))
-  ([workspace snapshot-id]
-   (let [name (util/randomize (:name (datarepo/snapshot snapshot-id)))]
-     (create-snapshot-reference workspace snapshot-id name))))
+   (create-snapshot-reference workspace snapshot-id name "")))
 
 (defn get-snapshot-reference
   "Return the snapshot reference in fully-qualified Terra WORKSPACE with REFERENCE-ID."

--- a/api/test/wfl/integration/modules/arrays_test.clj
+++ b/api/test/wfl/integration/modules/arrays_test.clj
@@ -4,7 +4,7 @@
             [wfl.service.firecloud :as terra]
             [wfl.tools.fixtures :as fixtures]
             [wfl.tools.workloads :as workloads])
-  (:import (java.util UUID)))
+  (:import [java.util UUID]))
 
 (use-fixtures
   :once
@@ -39,7 +39,7 @@
 (deftest test-create-arrays-workload!
   (let [workload (-> (make-arrays-workload-request)
                      workloads/create-workload!)]
-    (run! check-inputs (:workflows workload))))
+    (run! check-inputs (workloads/workflows workload))))
 
 (deftest test-workload-state-transition
   (with-redefs-fn
@@ -58,16 +58,18 @@
                         workloads/create-workload!
                         workloads/start-workload!)]
        (is (:started workload))
-       (run! check-inputs (:workflows workload))
-       (run! check-workflow (:workflows workload)))))
+       (let [workflows (workloads/workflows workload)]
+         (run! check-inputs workflows)
+         (run! check-workflow (workflows))))))
 
 (deftest test-exec-arrays-workload!
   (with-redefs-fn {#'terra/create-submission mock-terra-create-submission}
     #(let [workload (-> (make-arrays-workload-request)
                         workloads/execute-workload!)]
        (is (:started workload))
-       (run! check-inputs (:workflows workload))
-       (run! check-workflow (:workflows workload)))))
+       (let [workflows (workloads/workflows workload)]
+         (run! check-inputs workflows)
+         (run! check-workflow (workflows))))))
 
 (deftest test-update-arrays-workload!
   (letfn [(check-status [status workflow]
@@ -75,7 +77,7 @@
     (with-redefs-fn {#'terra/get-workflow-status-by-entity mock-get-workflow-status-by-entity}
       #(let [workload (-> (make-arrays-workload-request)
                           workloads/execute-workload!)]
-         (run! (partial check-status "Submitted") (:workflows workload))
+         (run! (partial check-status "Submitted") (workloads/workflows workload))
          (let [updated-workload (workloads/update-workload! workload)]
-           (run! (partial check-status "Succeeded") (:workflows updated-workload))
+           (run! (partial check-status "Succeeded") (workloads/workflows updated-workload))
            (is (:finished updated-workload)))))))

--- a/api/test/wfl/integration/modules/arrays_test.clj
+++ b/api/test/wfl/integration/modules/arrays_test.clj
@@ -60,7 +60,7 @@
        (is (:started workload))
        (let [workflows (workloads/workflows workload)]
          (run! check-inputs workflows)
-         (run! check-workflow (workflows))))))
+         (run! check-workflow workflows)))))
 
 (deftest test-exec-arrays-workload!
   (with-redefs-fn {#'terra/create-submission mock-terra-create-submission}
@@ -69,7 +69,7 @@
        (is (:started workload))
        (let [workflows (workloads/workflows workload)]
          (run! check-inputs workflows)
-         (run! check-workflow (workflows))))))
+         (run! check-workflow workflows)))))
 
 (deftest test-update-arrays-workload!
   (letfn [(check-status [status workflow]

--- a/api/test/wfl/integration/modules/copyfile_test.clj
+++ b/api/test/wfl/integration/modules/copyfile_test.clj
@@ -4,14 +4,15 @@
             [wfl.integration.modules.shared :as shared]
             [wfl.jdbc                       :as jdbc]
             [wfl.module.all                 :as all]
+            [wfl.module.batch               :as batch]
             [wfl.module.copyfile            :as copyfile]
             [wfl.service.cromwell           :as cromwell]
             [wfl.service.postgres           :as postgres]
             [wfl.tools.fixtures             :as fixtures]
             [wfl.tools.workloads            :as workloads]
             [wfl.util                       :as util])
-  (:import (java.util UUID)
-           (java.time OffsetDateTime)))
+  (:import [java.util UUID]
+           [java.time OffsetDateTime]))
 
 (use-fixtures :once fixtures/temporary-postgresql-database)
 
@@ -55,7 +56,7 @@
                  (partial map
                           #(assoc % :options {:supports_options true :overwritten true})))
          workloads/execute-workload!
-         :workflows
+         workloads/workflows
          (->> (map (comp verify-workflow-options :options))))))))
 
 (deftest test-submitted-workflow-inputs
@@ -89,20 +90,20 @@
                   (assoc-in [:common :options] {})
                   (update :items (partial map #(assoc % :options {})))
                   workloads/create-workload!
-                  :workflows))))
+                  workloads/workflows))))
 
 (defn mock-batch-update-workflow-statuses!
-  [tx {:keys [workflows items] :as _workload}]
+  [tx {:keys [items] :as workload}]
   (letfn [(update! [{:keys [id]}]
             (jdbc/update! tx items
                           {:status "Succeeded" :updated (OffsetDateTime/now)}
                           ["id = ?" id]))]
-    (run! update! workflows)))
+    (run! update! (workloads/workflows workload))))
 
 (deftest test-workload-state-transition
   (with-redefs-fn
     {#'cromwell/submit-workflow                 (fn [& _] (UUID/randomUUID))
-     #'postgres/batch-update-workflow-statuses! mock-batch-update-workflow-statuses!}
+     #'batch/batch-update-workflow-statuses! mock-batch-update-workflow-statuses!}
     #(shared/run-workload-state-transition-test!
       (make-copyfile-workload-request "gs://b/in" "gs://b/out"))))
 

--- a/api/test/wfl/integration/modules/covid_test.clj
+++ b/api/test/wfl/integration/modules/covid_test.clj
@@ -157,5 +157,3 @@
               (util/poll
                (fn [] (seq (firecloud/list-entities workspace "flowcell"))))]
           (is (= name flowcell-id) "The test entity was not created"))))))
-
-(test-vars [#'test-update-terra-workspace-sink])

--- a/api/test/wfl/integration/modules/covid_test.clj
+++ b/api/test/wfl/integration/modules/covid_test.clj
@@ -51,10 +51,6 @@
     (fixtures/method-overload-fixture
      covid/pop-queue! test-queue-type test-queue-pop)))
 
-;; For temporary workspace creation
-(def workspace-prefix "general-dev-billing-account/test-workspace")
-(def group "hornet-eng")
-
 (deftest test-create-workload
   (letfn [(verify-source [{:keys [type last_checked details]}]
             (is (= type "TerraDataRepoSource"))
@@ -85,81 +81,100 @@
     (is (:started (workloads/start-workload! workload)))))
 
 (deftest test-update-terra-executor
-  (fixtures/with-temporary-workspace
-    workspace-prefix group
-    (fn [workspace]
-      (let [snapshot {:name "test-snapshot-name"
-                      :id   (str (UUID/randomUUID))}
-            source (make-queue-from-list [snapshot])
-            executor (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
-                       (->> {:name                       "Terra"
-                             :workspace                  workspace
-                             :methodConfiguration        "mc-namespace/mc-name"
-                             :methodConfigurationVersion 1
-                             :fromSource                 "importSnapshot"
-                             :skipValidation             true}
-                            (covid/create-executor! tx 0)
-                            (zipmap [:executor_type :executor_items])
-                            (covid/load-executor! tx)))
-            verify-record-against-workflow
-            (fn [record workflow idx]
+  (let [snapshot {:name "test-snapshot-name"
+                  :id   (str (UUID/randomUUID))}
+        source   (make-queue-from-list [snapshot])
+        executor (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+                   (->> {:name                       "Terra"
+                         :workspace                  "workspace-ns/workspace-name"
+                         :methodConfiguration        "mc-namespace/mc-name"
+                         :methodConfigurationVersion 1
+                         :fromSource                 "importSnapshot"
+                         :skipValidation             true}
+                        (covid/create-executor! tx (rand-int 1000000))
+                        (zipmap [:executor_type :executor_items])
+                        (covid/load-executor! tx)))]
+    (letfn [(verify-record-against-workflow [record workflow idx]
               (is (= idx (:id record)))
               (is (= (:status workflow) (:workflow_status record)))
               (is (= (:workflowId workflow) (:workflow_id record))))]
-        (with-redefs-fn
-          {#'rawls/create-snapshot-reference   mock-rawls-create-snapshot-reference
-           #'covid/create-submission!          mock-create-submission}
-          #(covid/update-executor! source executor))
-        (is (-> source :queue empty?) "The snapshot was not consumed.")
-        (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
-          (let [[running-record succeeded-record & _ :as records]
-                (->> executor :details (postgres/get-table tx))]
-            (is (== 2 (count records))
-                "The workflows were not written to the database")
-            (is (every? #(= snapshot-reference-id (:snapshot_reference_id %)) records))
-            (is (every? #(= submission-id (:rawls_submission_id %)) records))
-            (is (every? #(nil? (:consumed %)) records))
-            (verify-record-against-workflow running-record running-workflow 1)
-            (verify-record-against-workflow succeeded-record succeeded-workflow 2)))))))
+      (with-redefs-fn
+        {#'rawls/create-snapshot-reference   mock-rawls-create-snapshot-reference
+         #'covid/create-submission!          mock-create-submission}
+        #(covid/update-executor! source executor))
+      (is (-> source :queue empty?) "The snapshot was not consumed.")
+      (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+        (let [[running-record succeeded-record & _ :as records]
+              (->> executor :details (postgres/get-table tx))]
+          (is (== 2 (count records))
+              "The workflows were not written to the database")
+          (is (every? #(= snapshot-reference-id (:snapshot_reference_id %)) records))
+          (is (every? #(= submission-id (:rawls_submission_id %)) records))
+          (is (every? #(nil? (:consumed %)) records))
+          (verify-record-against-workflow running-record running-workflow 1)
+          (verify-record-against-workflow succeeded-record succeeded-workflow 2))))))
+
+(deftest test-peek-terra-executor-queue
+  (let [succeeded? #{"Succeeded"}
+        source     (make-queue-from-list [{:name "test-snapshot-name"
+                                           :id   (str (UUID/randomUUID))}])
+        executor   (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+                     (->> {:name                       "Terra"
+                           :workspace                  "workspace-ns/workspace-name"
+                           :methodConfiguration        "mc-namespace/mc-name"
+                           :methodConfigurationVersion 1
+                           :fromSource                 "importSnapshot"
+                           :skipValidation             true}
+                          (covid/create-executor! tx (rand-int 1000000))
+                          (zipmap [:executor_type :executor_items])
+                          (covid/load-executor! tx)))]
+    (with-redefs-fn
+      {#'rawls/create-snapshot-reference   mock-rawls-create-snapshot-reference
+       #'covid/create-submission!          mock-create-submission}
+      #(covid/update-executor! source executor))
+    (with-redefs-fn
+      {#'covid/peek-terra-executor-queue #'covid/peek-terra-executor-details}
+      #(do (is (succeeded? (-> executor covid/peek-queue! :workflow_status)))
+           (covid/pop-queue! executor)
+           (is (nil? (covid/peek-queue! executor)))))))
 
 (deftest test-update-terra-workspace-sink
-  (fixtures/with-temporary-workspace
-    workspace-prefix group
-    (fn [workspace]
-      (let [flowcell-id
-            "test"
-            workflow
-            {:uuid    "2768b29e-c808-4bd6-a46b-6c94fd2a67aa"
-             :status  "Succeeded"
-             :outputs (-> "sarscov2_illumina_full/outputs.edn"
-                          resources/read-resource
-                          (assoc :flowcell_id flowcell-id))}
-            executor
-            (make-queue-from-list [workflow])
-            sink
-            (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
-              (->> {:name           "Terra Workspace"
-                    :workspace      workspace
-                    :entity         "flowcell"
-                    :fromOutputs    (resources/read-resource
-                                     "sarscov2_illumina_full/entity-from-outputs.edn")
-                    :identifier     "flowcell_id"
-                    :skipValidation true}
-                   (covid/create-sink! tx 0)
-                   (zipmap [:sink_type :sink_items])
-                   (covid/load-sink! tx)))]
-        (covid/update-sink! executor sink)
-        (is (-> executor :queue empty?) "The workflow was not consumed")
-        (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
-          (let [records (->> sink :details (postgres/get-table tx))]
-            (is (== 1 (count records))
-                "The record was not written to the database")
-            (is (= (:uuid workflow) (-> records first :workflow))
-                "The workflow UUID was not written")))
-        (let [[{:keys [name]} & _]
-              (util/poll
-               (fn [] (seq (firecloud/list-entities workspace "flowcell"))))]
-          (is (= name flowcell-id) "The test entity was not created"))))))
+  (let [flowcell-id "test"
+        entity-type "flowcell"
+        workflow    {:uuid    "2768b29e-c808-4bd6-a46b-6c94fd2a67aa"
+                     :status  "Succeeded"
+                     :outputs (-> "sarscov2_illumina_full/outputs.edn"
+                                  resources/read-resource
+                                  (assoc :flowcell_id flowcell-id))}
+        executor    (make-queue-from-list [workflow])
+        sink        (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+                      (->> {:name           "Terra Workspace"
+                            :workspace      "workspace-ns/workspace-name"
+                            :entity         entity-type
+                            :fromOutputs    (resources/read-resource
+                                             "sarscov2_illumina_full/entity-from-outputs.edn")
+                            :identifier     "flowcell_id"
+                            :skipValidation true}
+                           (covid/create-sink! tx (rand-int 1000000))
+                           (zipmap [:sink_type :sink_items])
+                           (covid/load-sink! tx)))]
+    (letfn [(verify-upsert-request [workspace [[name type _]]]
+              (is (= "workspace-ns/workspace-name" workspace))
+              (is (= name flowcell-id))
+              (is (= type entity-type)))]
+      (with-redefs-fn
+        {#'rawls/batch-upsert verify-upsert-request}
+        #(covid/update-sink! executor sink))
+      (is (-> executor :queue empty?) "The workflow was not consumed")
+      (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+        (let [[record & rest] (->> sink :details (postgres/get-table tx))]
+          (is record
+              "The record was not written to the database")
+          (is (empty? rest) "More than one record was written")
+          (is (= (:uuid workflow) (:workflow record))
+              "The workflow UUID was not written")
+          (is (= flowcell-id (:entity_name record))
+              "The entity name was not correct"))))))
 
 (deftest test-get-workflows-empty
   (let [workload (workloads/create-workload!

--- a/api/test/wfl/integration/modules/covid_test.clj
+++ b/api/test/wfl/integration/modules/covid_test.clj
@@ -23,7 +23,7 @@
   (-> this :queue .getFirst))
 
 (defn ^:private test-queue-pop [this]
-  (-> this :queue .removeLast))
+  (-> this :queue .removeFirst))
 
 (let [new-env {"WFL_FIRECLOUD_URL"
                "https://firecloud-orchestration.dsde-dev.broadinstitute.org"}]
@@ -157,3 +157,8 @@
               (util/poll
                (fn [] (seq (firecloud/list-entities workspace "flowcell"))))]
           (is (= name flowcell-id) "The test entity was not created"))))))
+
+(deftest test-get-workflows-empty
+  (let [workload (workloads/create-workload!
+                  (workloads/covid-workload-request {} {} {}))]
+    (is (empty? (workloads/workflows workload)))))

--- a/api/test/wfl/integration/modules/covid_test.clj
+++ b/api/test/wfl/integration/modules/covid_test.clj
@@ -11,10 +11,9 @@
             [wfl.tools.workloads   :as workloads]
             [wfl.tools.resources   :as resources]
             [wfl.util              :as util])
-  (:import [clojure.lang ExceptionInfo]
-           [java.util ArrayDeque]))
+  (:import [java.util ArrayDeque UUID]))
 
-;; queue mocks
+;; Queue mocks
 (def ^:private test-queue-type "TestQueue")
 (defn ^:private make-queue-from-list [items]
   {:type test-queue-type :queue (ArrayDeque. items)})
@@ -24,6 +23,23 @@
 
 (defn ^:private test-queue-pop [this]
   (-> this :queue .removeFirst))
+
+;; Snapshot reference mock
+(def ^:private snapshot-reference-id
+  (str (UUID/randomUUID)))
+(defn ^:private mock-rawls-create-snapshot-reference [& _]
+  {:referenceId snapshot-reference-id})
+
+;; Submission mock
+(def ^:private submission-id
+  (str (UUID/randomUUID)))
+(def ^:private running-workflow
+  {:status "Running" :workflowId (str (UUID/randomUUID))})
+(def ^:private succeeded-workflow
+  {:status "Succeeded" :workflowId (str (UUID/randomUUID))})
+(defn ^:private mock-create-submission [& _]
+  {:submissionId submission-id
+   :workflows [running-workflow succeeded-workflow]})
 
 (let [new-env {"WFL_FIRECLOUD_URL"
                "https://firecloud-orchestration.dsde-dev.broadinstitute.org"}]
@@ -35,60 +51,9 @@
     (fixtures/method-overload-fixture
      covid/pop-queue! test-queue-type test-queue-pop)))
 
-(def workload {:id 1})
-
 ;; For temporary workspace creation
 (def workspace-prefix "general-dev-billing-account/test-workspace")
 (def group "hornet-eng")
-
-(def snapshot-id "7cb392d8-949b-419d-b40b-d039617d2fc7")
-(def reference-id "2d15f9bd-ecb9-46b3-bb6c-f22e20235232")
-
-;; Source details
-(def source-details {:id 1 :snapshot_id snapshot-id})
-
-;; Executor and its details
-(def executor-base {:details (format "%s_%09d" "TerraExecutorDetails" 1)})
-(def ed-base {:id 1})
-(def ed-reference (assoc ed-base :snapshot_reference_id reference-id))
-
-(defn ^:private mock-rawls-snapshot-reference [& _]
-  {:cloningInstructions "COPY_NOTHING",
-   :description "test importing a snapshot into a workspace",
-   :name "snapshot",
-   :reference {:instanceName "terra", :snapshot snapshot-id},
-   :referenceId reference-id,
-   :referenceType "DATA_REPO_SNAPSHOT",
-   :workspaceId "e9d053b9-d79f-40b7-b701-904bf542ec2d"})
-
-(defn ^:private mock-throw [& _] (throw (ex-info "mocked throw" {})))
-
-(deftest test-get-imported-snapshot-reference
-  (fixtures/with-temporary-workspace workspace-prefix group
-    (fn [workspace]
-      (let [executor (assoc executor-base :workspace workspace)
-            fetch (fn [ed] (#'covid/get-imported-snapshot-reference executor ed))]
-        (with-redefs-fn {#'rawls/get-snapshot-reference mock-throw}
-          #(let [go (fn [ed] (is (not (fetch ed))))
-                 executor-details [ed-base ed-reference]]
-             (run! go executor-details)))
-        (with-redefs-fn {#'rawls/get-snapshot-reference mock-rawls-snapshot-reference}
-          #(is (fetch ed-reference)))))))
-
-(deftest test-import-snapshot
-  (fixtures/with-temporary-workspace workspace-prefix group
-    (fn [workspace]
-      (let [executor (assoc executor-base :workspace workspace)]
-        #_(testing "Successful create writes to db"
-            (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
-              (with-redefs-fn {#'rawls/create-snapshot-reference mock-rawls-snapshot-reference}
-                #(#'covid/import-snapshot! tx workload source-details executor ed-base))))
-        (testing "Failed create throws"
-          (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
-            (with-redefs-fn {#'rawls/create-snapshot-reference mock-throw}
-              #(is (thrown-with-msg?
-                    ExceptionInfo #"mocked throw"
-                    (#'covid/import-snapshot! tx workload source-details executor ed-base))))))))))
 
 (deftest test-create-workload
   (letfn [(verify-source [{:keys [type last_checked details]}]
@@ -118,6 +83,44 @@
                   (workloads/covid-workload-request {} {} {}))]
     (is (not (:started workload)))
     (is (:started (workloads/start-workload! workload)))))
+
+(deftest test-update-terra-executor
+  (fixtures/with-temporary-workspace
+    workspace-prefix group
+    (fn [workspace]
+      (let [snapshot {:name "test-snapshot-name"
+                      :id   (str (UUID/randomUUID))}
+            source (make-queue-from-list [snapshot])
+            executor (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+                       (->> {:name                       "Terra"
+                             :workspace                  workspace
+                             :methodConfiguration        "mc-namespace/mc-name"
+                             :methodConfigurationVersion 1
+                             :fromSource                 "importSnapshot"
+                             :skipValidation             true}
+                            (covid/create-executor! tx 0)
+                            (zipmap [:executor_type :executor_items])
+                            (covid/load-executor! tx)))
+            verify-record-against-workflow
+            (fn [record workflow idx]
+              (is (= idx (:id record)))
+              (is (= (:status workflow) (:workflow_status record)))
+              (is (= (:workflowId workflow) (:workflow_id record))))]
+        (with-redefs-fn
+          {#'rawls/create-snapshot-reference   mock-rawls-create-snapshot-reference
+           #'covid/create-submission!          mock-create-submission}
+          #(covid/update-executor! source executor))
+        (is (-> source :queue empty?) "The snapshot was not consumed.")
+        (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+          (let [[running-record succeeded-record & _ :as records]
+                (->> executor :details (postgres/get-table tx))]
+            (is (== 2 (count records))
+                "The workflows were not written to the database")
+            (is (every? #(= snapshot-reference-id (:snapshot_reference_id %)) records))
+            (is (every? #(= submission-id (:rawls_submission_id %)) records))
+            (is (every? #(nil? (:consumed %)) records))
+            (verify-record-against-workflow running-record running-workflow 1)
+            (verify-record-against-workflow succeeded-record succeeded-workflow 2)))))))
 
 (deftest test-update-terra-workspace-sink
   (fixtures/with-temporary-workspace

--- a/api/test/wfl/integration/modules/covid_test.clj
+++ b/api/test/wfl/integration/modules/covid_test.clj
@@ -4,13 +4,11 @@
             [clojure.string        :as str]
             [wfl.jdbc              :as jdbc]
             [wfl.module.covid      :as covid]
-            [wfl.service.firecloud :as firecloud]
             [wfl.service.postgres  :as postgres]
             [wfl.service.rawls     :as rawls]
             [wfl.tools.fixtures    :as fixtures]
             [wfl.tools.workloads   :as workloads]
-            [wfl.tools.resources   :as resources]
-            [wfl.util              :as util])
+            [wfl.tools.resources   :as resources])
   (:import [java.util ArrayDeque UUID]))
 
 ;; Queue mocks

--- a/api/test/wfl/integration/modules/sg_test.clj
+++ b/api/test/wfl/integration/modules/sg_test.clj
@@ -1,19 +1,18 @@
 (ns wfl.integration.modules.sg-test
-  (:require [clojure.string :as str]
-            [clojure.test :refer [deftest is testing use-fixtures]]
+  (:require [clojure.string                 :as str]
+            [clojure.test                   :refer [deftest is testing use-fixtures]]
             [wfl.integration.modules.shared :as shared]
-            [wfl.module.batch :as batch]
-            [wfl.module.sg :as sg]
-            [wfl.service.clio :as clio]
-            [wfl.service.cromwell :as cromwell]
-            [wfl.service.google.storage :as gcs]
-            [wfl.tools.fixtures :as fixtures]
-            [wfl.tools.workloads :as workloads]
-            [wfl.util :as util :refer [absent?]]
-            [wfl.service.postgres :as postgres]
-            [wfl.jdbc :as jdbc])
-  (:import (java.time OffsetDateTime)
-           (java.util UUID)))
+            [wfl.jdbc                       :as jdbc]
+            [wfl.module.batch               :as batch]
+            [wfl.module.sg                  :as sg]
+            [wfl.service.clio               :as clio]
+            [wfl.service.cromwell           :as cromwell]
+            [wfl.service.google.storage     :as gcs]
+            [wfl.tools.fixtures             :as fixtures]
+            [wfl.tools.workloads            :as workloads]
+            [wfl.util                       :as util :refer [absent?]])
+  (:import [java.time OffsetDateTime]
+           [java.util UUID]))
 
 (use-fixtures :once fixtures/temporary-postgresql-database)
 
@@ -46,13 +45,13 @@
    :creator @workloads/email})
 
 (defn mock-submit-workload
-  [{:keys [workflows]} _ _ _ _ _]
+  [workload _ _ _ _ _]
   (let [now (OffsetDateTime/now)]
     (letfn [(submit [workflow uuid] (assoc workflow
                                            :status "Submitted"
                                            :updated now
                                            :uuid    uuid))]
-      (map submit workflows the-uuids))))
+      (map submit (workloads/workflows workload) the-uuids))))
 
 (deftest test-create-workload!
   (letfn [(verify-workflow [workflow]
@@ -64,7 +63,7 @@
               (is (:created workload))
               (is (absent? workload :started))
               (is (absent? workload :finished))
-              (run! verify-workflow (:workflows workload))))]
+              (run! verify-workflow (workloads/workflows workload))))]
     (testing "single-sample workload-request"
       (go! (the-sg-workload-request)))))
 
@@ -75,7 +74,8 @@
               (is (= expected (select-keys inputs (keys expected)))))]
       (run! ok (-> (the-sg-workload-request)
                    (assoc-in [:common :inputs] expected)
-                   workloads/create-workload! :workflows
+                   workloads/create-workload!
+                   workloads/workflows
                    (->> (map :inputs)))))))
 
 (deftest test-start-workload!
@@ -89,7 +89,7 @@
            workloads/start-workload!
            (as-> workload
                  (is (:started workload))
-             (run! go! (:workflows workload)))))))
+             (run! go! (workloads/workflows workload)))))))
 
 (deftest test-hidden-inputs
   (testing "google_account_vault_path and vault_token_path are not in inputs"
@@ -98,7 +98,7 @@
               (is (absent? inputs :google_account_vault_path)))]
       (->> (the-sg-workload-request)
            workloads/create-workload!
-           :workflows
+           workloads/workflows
            (run! (comp go! :inputs))))))
 
 (deftest test-submitted-workflow-inputs
@@ -142,7 +142,8 @@
              (assoc-in [:common :options] {:overwritten             false
                                            :supports_common_options true})
              (update :items (partial map overmap))
-             workloads/execute-workload! :workflows
+             workloads/execute-workload!
+             workloads/workflows
              (->> (map (comp verify-workflow-options :options))))))))
 
 (deftest test-empty-workflow-options
@@ -151,7 +152,8 @@
     (run! go! (-> (the-sg-workload-request)
                   (assoc-in [:common :options] {})
                   (update :items (partial map empty-options))
-                  workloads/create-workload! :workflows))))
+                  workloads/create-workload!
+                  workloads/workflows))))
 
 (defn ^:private mock-clio-add-bam-found
   "Fail because a `_clio` BAM record already exists for `_md`"
@@ -316,10 +318,10 @@
         workloads/execute-workload!
         workloads/update-workload!
         (as-> workload
-              (let [{:keys [finished pipeline workflows]} workload]
+              (let [{:keys [finished pipeline]} workload]
                 (is finished)
                 (is (= sg/pipeline pipeline))
-                (is (= (count items) (count workflows))))))))
+                (is (= (count items) (-> workload workloads/workflows count))))))))
 
 (deftest test-clio-updates-bam-found
   (testing "Clio not updated if outputs already known."
@@ -365,24 +367,24 @@
     (is (seq (clio/query-bam @workloads/clio-url {:bam_path bam_path})))))
 
 (defmethod workloads/postcheck sg/pipeline postcheck-sg-workload
-  [{:keys [output workflows] :as _workload}]
-  (run! (partial workflow-postcheck output) workflows))
+  [{:keys [output] :as workload}]
+  (run! (partial workflow-postcheck output) (workloads/workflows workload)))
 
 (defn ^:private mock-batch-update-workflow-statuses!
-  [tx {:keys [workflows items] :as _workload}]
+  [tx {:keys [items] :as workload}]
   (letfn [(update! [{:keys [id]}]
             (jdbc/update! tx items
                           {:status "Succeeded" :updated (OffsetDateTime/now)}
                           ["id = ?" id]))]
-    (run! update! workflows)))
+    (run! update! (workloads/workflows workload))))
 
 (deftest test-workload-state-transition
   (let [count           (atom 0)
         increment-count (fn [_] (swap! count inc))]
     (with-redefs-fn
-      {#'cromwell/submit-workflows                mock-cromwell-submit-workflows
-       #'postgres/batch-update-workflow-statuses! mock-batch-update-workflow-statuses!
-       #'sg/register-workload-in-clio             increment-count}
+      {#'cromwell/submit-workflows             mock-cromwell-submit-workflows
+       #'batch/batch-update-workflow-statuses! mock-batch-update-workflow-statuses!
+       #'sg/register-workload-in-clio          increment-count}
       #(shared/run-workload-state-transition-test! (the-sg-workload-request)))
     (is (== 1 @count) "Clio was updated more than once")))
 

--- a/api/test/wfl/integration/modules/sg_test.clj
+++ b/api/test/wfl/integration/modules/sg_test.clj
@@ -84,12 +84,11 @@
             (is (:status workflow))
             (is (:updated workflow)))]
     (with-redefs-fn {#'batch/submit-workload! mock-submit-workload}
-      #(-> (the-sg-workload-request)
-           workloads/create-workload!
-           workloads/start-workload!
-           (as-> workload
-                 (is (:started workload))
-             (run! go! (workloads/workflows workload)))))))
+      #(let [workload (-> (the-sg-workload-request)
+                          workloads/create-workload!
+                          workloads/start-workload!)]
+         (is (:started workload))
+         (run! go! (workloads/workflows workload))))))
 
 (deftest test-hidden-inputs
   (testing "google_account_vault_path and vault_token_path are not in inputs"

--- a/api/test/wfl/integration/modules/wgs_test.clj
+++ b/api/test/wfl/integration/modules/wgs_test.clj
@@ -112,12 +112,12 @@
              inputs))]
     (with-redefs-fn
       {#'cromwell/submit-workflows verify-inputs}
-      #(-> (make-wgs-workload-request)
-           (update :items use-input_bam)
-           (workloads/execute-workload!)
-           (as-> workload
-                 (is (:started workload))
-             (run! go! (workloads/workflows workload)))))))
+      #(let [workload (-> (make-wgs-workload-request)
+                          (update :items use-input_bam)
+                          workloads/execute-workload!)]
+
+         (is (:started workload))
+         (run! go! (workloads/workflows workload))))))
 
 (deftest test-submitted-workflow-inputs
   (letfn [(prefixed? [prefix key] (str/starts-with? (str key) (str prefix)))

--- a/api/test/wfl/integration/modules/wgs_test.clj
+++ b/api/test/wfl/integration/modules/wgs_test.clj
@@ -1,19 +1,20 @@
 (ns wfl.integration.modules.wgs-test
-  (:require [clojure.set :refer [rename-keys]]
+  (:require [clojure.set  :refer [rename-keys]]
             [clojure.test :refer [deftest testing is] :as clj-test]
+            [clojure.string                 :as str]
             [wfl.integration.modules.shared :as shared]
-            [wfl.service.cromwell :as cromwell]
-            [wfl.tools.fixtures :as fixtures]
-            [wfl.tools.workloads :as workloads]
-            [wfl.module.wgs :as wgs]
-            [wfl.jdbc :as jdbc]
-            [wfl.module.all :as all]
-            [wfl.util :as util]
-            [wfl.references :as references]
-            [clojure.string :as str]
-            [wfl.service.postgres :as postgres])
-  (:import (java.util UUID)
-           (java.time OffsetDateTime)))
+            [wfl.jdbc                       :as jdbc]
+            [wfl.module.all                 :as all]
+            [wfl.module.batch               :as batch]
+            [wfl.module.wgs                 :as wgs]
+            [wfl.references                 :as references]
+            [wfl.service.cromwell           :as cromwell]
+            [wfl.service.postgres           :as postgres]
+            [wfl.tools.fixtures             :as fixtures]
+            [wfl.tools.workloads            :as workloads]
+            [wfl.util                       :as util])
+  (:import [java.util UUID]
+           [java.time OffsetDateTime]))
 
 (clj-test/use-fixtures :once fixtures/temporary-postgresql-database)
 
@@ -41,7 +42,7 @@
             (-> (make-wgs-workload-request)
                 (assoc-in [:common :inputs] {:reference_fasta_prefix prefix})
                 workloads/create-workload!
-                :workflows)))))
+                workloads/workflows)))))
 
 (deftest test-create-with-reference-fasta-prefix-override
   (let [prefix "gs://fake-input-bucket/ref-fasta"]
@@ -57,7 +58,7 @@
                 (assoc-in [:common :inputs] {:reference_fasta_prefix "gs://ignore/this/ref-fasta"})
                 (update :items (partial map #(update % :inputs (fn [xs] (assoc xs :reference_fasta_prefix prefix)))))
                 workloads/create-workload!
-                :workflows)))))
+                workloads/workflows)))))
 
 (deftest test-start-wgs-workload!
   (with-redefs-fn {#'cromwell/submit-workflows mock-submit-workflows}
@@ -69,7 +70,7 @@
                  (is
                   (not-any? (partial contains? workflow) (keys workloads/wgs-inputs))
                   "Inputs are not at the top-level"))]
-         (run! check-nesting (:workflows workload))))))
+         (run! check-nesting (workloads/workflows workload))))))
 
 (defn ^:private old-create-wgs-workload! []
   (let [request (make-wgs-workload-request)]
@@ -116,7 +117,7 @@
            (workloads/execute-workload!)
            (as-> workload
                  (is (:started workload))
-             (run! go! (:workflows workload)))))))
+             (run! go! (workloads/workflows workload)))))))
 
 (deftest test-submitted-workflow-inputs
   (letfn [(prefixed? [prefix key] (str/starts-with? (str key) (str prefix)))
@@ -187,7 +188,7 @@
                  (partial map
                           #(assoc % :options {:supports_options true :overwritten true})))
          workloads/execute-workload!
-         :workflows
+         workloads/workflows
          (->> (map (comp verify-workflow-options :options))))))))
 
 (deftest test-empty-workflow-options
@@ -196,7 +197,7 @@
                   (assoc-in [:common :options] {})
                   (update :items (partial map #(assoc % :options {})))
                   workloads/create-workload!
-                  :workflows))))
+                  workloads/workflows))))
 
 (defn mock-batch-update-workflow-statuses!
   [tx {:keys [workflows items] :as _workload}]
@@ -209,7 +210,7 @@
 (deftest test-workload-state-transition
   (with-redefs-fn
     {#'cromwell/submit-workflows                mock-submit-workflows
-     #'postgres/batch-update-workflow-statuses! mock-batch-update-workflow-statuses!}
+     #'batch/batch-update-workflow-statuses! mock-batch-update-workflow-statuses!}
     #(shared/run-workload-state-transition-test! (make-wgs-workload-request))))
 
 (deftest test-stop-workload-state-transition

--- a/api/test/wfl/integration/modules/xx_test.clj
+++ b/api/test/wfl/integration/modules/xx_test.clj
@@ -54,12 +54,11 @@
             (is (:status workflow))
             (is (:updated workflow)))]
     (with-redefs-fn {#'cromwell/submit-workflows mock-submit-workflows}
-      #(-> (make-xx-workload-request)
-           workloads/create-workload!
-           workloads/start-workload!
-           (as-> workload
-                 (is (:started workload))
-             (run! go! (workloads/workflows workload)))))))
+      #(let [workload (-> (make-xx-workload-request)
+                          workloads/create-workload!
+                          workloads/start-workload!)]
+         (is (:started workload))
+         (run! go! (workloads/workflows workload))))))
 
 (deftest test-hidden-inputs
   (testing "google_account_vault_path and vault_token_path are not in inputs"

--- a/api/test/wfl/tools/workloads.clj
+++ b/api/test/wfl/tools/workloads.clj
@@ -286,6 +286,9 @@
   (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
     (wfl.api.workloads/update-workload! tx workload)))
 
+(defn workflows [workload]
+  (wfl.api.workloads/workflows workload))
+
 (defn load-workload-for-uuid [uuid]
   (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
     (wfl.api.workloads/load-workload-for-uuid tx uuid)))

--- a/api/test/wfl/unit/api_handlers_test.clj
+++ b/api/test/wfl/unit/api_handlers_test.clj
@@ -1,10 +1,16 @@
 (ns wfl.unit.api-handlers-test
-  (:require [clojure.test :refer [deftest is]]
-            [wfl.api.handlers :as handlers]))
+  (:require [clojure.test       :refer [deftest is use-fixtures]]
+            [wfl.api.handlers   :as handlers]
+            [wfl.api.workloads  :as workloads]
+            [wfl.tools.fixtures :as fixtures]))
+
+(use-fixtures :once
+  (fixtures/method-overload-fixture workloads/workflows "Test" :workflows))
 
 (deftest test-strip-internals
   (let [workload  (handlers/strip-internals
                    {:id 0
+                    :pipeline "Test"
                     :items "ExampleTable_0000001"
                     :workflows [{:id 0} {:id 1}]})]
     (is (wfl.util/absent? workload :id))


### PR DESCRIPTION
RR: https://broadinstitute.atlassian.net/browse/GH-1306
Add workflows multimethod
Change all locations where workflows are accessed via the `:workflows` keyword to use this function.
Implement `workflows` for COVID
- I've added a simple test to make sure the SQL is correct
- Awaiting executor implementation to test with more than 0 workflows.