### PR TITLE
[GH-1314] expose workflows via `GET /api/v1/workload/{uuid}/workflows`

### DIFF
--- a/api/src/wfl/api/handlers.clj
+++ b/api/src/wfl/api/handlers.clj
@@ -80,12 +80,12 @@
   "Return the workflows managed by the workload."
   [request]
   (let [uuid (get-in request [:path-params :uuid])]
-    (log/infof "GET /api/v1/workflows with uuid: %s" uuid)
-    (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
-      (->> (workloads/load-workload-for-uuid tx uuid)
-           workloads/workflows
-           (mapv strip-workflow-internals)
-           succeed))))
+    (log/infof "GET /api/v1/workload/%s/workflows" uuid)
+    (->> (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+           (workloads/load-workload-for-uuid tx uuid))
+         workloads/workflows
+         (mapv strip-workflow-internals)
+         succeed)))
 
 (defn post-start
   "Start the workload with UUID in REQUEST."

--- a/api/src/wfl/api/handlers.clj
+++ b/api/src/wfl/api/handlers.clj
@@ -1,19 +1,19 @@
 (ns wfl.api.handlers
   "Define handlers for API endpoints. Note that pipeline modules MUST be required here."
-  (:require [clojure.set :refer [rename-keys]]
+  (:require [clojure.set                    :refer [rename-keys]]
             [clojure.tools.logging.readable :as logr]
-            [ring.util.http-response :as response]
-            [wfl.api.workloads :as workloads]
-            [wfl.module.aou :as aou]
+            [ring.util.http-response        :as response]
+            [wfl.api.workloads              :as workloads]
+            [wfl.module.aou                 :as aou]
             [wfl.module.arrays]
             [wfl.module.copyfile]
             [wfl.module.wgs]
             [wfl.module.xx]
             [wfl.module.sg]
-            [wfl.jdbc :as jdbc]
-            [wfl.service.google.storage :as gcs]
-            [wfl.service.postgres :as postgres]
-            [clojure.tools.logging :as log]))
+            [wfl.jdbc                       :as jdbc]
+            [wfl.service.google.storage     :as gcs]
+            [wfl.service.postgres           :as postgres]
+            [clojure.tools.logging          :as log]))
 
 (defn succeed
   "A successful response with BODY."

--- a/api/src/wfl/api/handlers.clj
+++ b/api/src/wfl/api/handlers.clj
@@ -83,7 +83,6 @@
     (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
       (->> (workloads/load-workload-for-uuid tx uuid)
            (workloads/workflows tx)
-           workloads/workflows
            (mapv strip-workflow-internals)
            succeed))))
 

--- a/api/src/wfl/api/handlers.clj
+++ b/api/src/wfl/api/handlers.clj
@@ -1,6 +1,7 @@
 (ns wfl.api.handlers
   "Define handlers for API endpoints. Note that pipeline modules MUST be required here."
   (:require [clojure.set                    :refer [rename-keys]]
+            [clojure.tools.logging          :as log]
             [clojure.tools.logging.readable :as logr]
             [ring.util.http-response        :as response]
             [wfl.api.workloads              :as workloads]
@@ -12,8 +13,7 @@
             [wfl.module.sg]
             [wfl.jdbc                       :as jdbc]
             [wfl.service.google.storage     :as gcs]
-            [wfl.service.postgres           :as postgres]
-            [clojure.tools.logging          :as log]))
+            [wfl.service.postgres           :as postgres]))
 
 (defn succeed
   "A successful response with BODY."

--- a/api/src/wfl/api/handlers.clj
+++ b/api/src/wfl/api/handlers.clj
@@ -80,11 +80,12 @@
   [request]
   (let [uuid (get-in request [:path-params :uuid])]
     (log/infof "GET /api/v1/workload/%s/workflows" uuid)
-    (->> (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
-           (workloads/load-workload-for-uuid tx uuid))
-         workloads/workflows
-         (mapv strip-workflow-internals)
-         succeed)))
+    (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+      (->> (workloads/load-workload-for-uuid tx uuid)
+           (workloads/workflows tx)
+           workloads/workflows
+           (mapv strip-workflow-internals)
+           succeed))))
 
 (defn post-start
   "Start the workload with UUID in REQUEST."

--- a/api/src/wfl/api/handlers.clj
+++ b/api/src/wfl/api/handlers.clj
@@ -27,7 +27,9 @@
 
 (defn ^:private prune
   [coll]
-  (apply dissoc coll [:id :items]))
+  (->> (apply dissoc coll [:id :items])
+       (filter second)
+       (into {})))
 
 (defn strip-workflow-internals
   [workflow]
@@ -36,10 +38,7 @@
 (defn strip-internals
   "Strip internal properties from the `workload` and its `workflows`."
   [workload]
-  (->> (workloads/workflows workload)
-       (mapv strip-workflow-internals)
-       (assoc workload :workflows)
-       prune))
+  (prune workload))
 
 (defn append-to-aou-workload
   "Append new workflows to an existing started AoU workload describe in BODY of REQUEST."

--- a/api/src/wfl/api/routes.clj
+++ b/api/src/wfl/api/routes.clj
@@ -55,6 +55,11 @@
            :parameters {:query ::spec/workload-query}
            :responses  {200 {:body ::spec/workload-responses}}
            :handler    handlers/get-workload}}]
+   ["/api/v1/workload/:uuid/workflows"
+    {:get {:summary    "Get workflows managed by the workload."
+           :parameters {:path-params ::spec/uuid}
+           :responses  {200 {:body ::spec/workflows}}
+           :handler    handlers/get-workflows}}]
    ["/api/v1/create"
     {:post {:summary    "Create a new workload."
             :parameters {:body ::spec/workload-request}

--- a/api/src/wfl/api/routes.clj
+++ b/api/src/wfl/api/routes.clj
@@ -57,7 +57,7 @@
            :handler    handlers/get-workload}}]
    ["/api/v1/workload/:uuid/workflows"
     {:get {:summary    "Get workflows managed by the workload."
-           :parameters {:path-params ::spec/uuid}
+           :parameters {:path {:uuid ::spec/uuid}}
            :responses  {200 {:body ::spec/workflows}}
            :handler    handlers/get-workflows}}]
    ["/api/v1/create"

--- a/api/src/wfl/api/workloads.clj
+++ b/api/src/wfl/api/workloads.clj
@@ -30,8 +30,8 @@
   (fn [_ body] (:pipeline body)))
 
 (defmulti workflows
-  "Return the workflows managed by the `workload`."
-  (fn [workload] (:pipeline workload)))
+  "Use `tx` to return the workflows managed by the `workload`."
+  (fn [tx workload] (:pipeline workload)))
 
 ;; loading utilities
 (defmulti load-workload-impl

--- a/api/src/wfl/module/aou.clj
+++ b/api/src/wfl/module/aou.clj
@@ -286,4 +286,4 @@
     (if (and started (not finished)) (update! workload) workload)))
 
 (defoverload workloads/workflows          pipeline batch/workflows)
-(defoverload workloads/load-workload-impl pipeline batch/pre-v0.4.0-load-workload-impl)
+(defoverload workloads/load-workload-impl pipeline batch/load-batch-workload-impl)

--- a/api/src/wfl/module/aou.clj
+++ b/api/src/wfl/module/aou.clj
@@ -285,5 +285,5 @@
             (workloads/load-workload-for-id tx id))]
     (if (and started (not finished)) (update! workload) workload)))
 
-(defoverload workloads/workflows          pipeline batch/workflows)
+(defoverload workloads/workflows          pipeline batch/pre-v0_4_0-load-workflows)
 (defoverload workloads/load-workload-impl pipeline batch/load-batch-workload-impl)

--- a/api/src/wfl/module/arrays.clj
+++ b/api/src/wfl/module/arrays.clj
@@ -160,14 +160,6 @@
             (workloads/load-workload-for-id tx id))]
     (if (and started (not finished)) (update! workload) workload)))
 
-(defmethod workloads/load-workload-impl
-  pipeline
-  [tx {:keys [items] :as workload}]
-  (letfn [(unnilify [m] (into {} (filter second m)))]
-    (->> (postgres/get-table tx items)
-         (mapv (comp #(update % :inputs util/parse-json) unnilify))
-         (assoc workload :workflows)
-         unnilify)))
-
+(defoverload workloads/load-workload-impl pipeline batch/load-batch-workload-impl)
 (defoverload workloads/stop-workload! pipeline batch/stop-workload!)
 (defoverload workloads/workflows      pipeline batch/workflows)

--- a/api/src/wfl/module/arrays.clj
+++ b/api/src/wfl/module/arrays.clj
@@ -129,7 +129,7 @@
               (jdbc/update! tx items
                             {:updated now :uuid submissionId :status "Submitted"}
                             ["id = ?" id]))]
-      (let [ids-uuids (map submit! (workloads/workflows workload))]
+      (let [ids-uuids (map submit! (workloads/workflows tx workload))]
         (run! (partial update! tx) ids-uuids)
         (jdbc/update! tx :workload {:started now} ["uuid = ?" uuid])))))
 

--- a/api/src/wfl/module/batch.clj
+++ b/api/src/wfl/module/batch.clj
@@ -161,8 +161,7 @@
 
 (defn workflows
   "Return the workflows managed by the `workload`."
-  [workload]
-  (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
-    (if (workloads/saved-before? "0.4.0" workload)
-      (pre-v0.4.0-load-workflows tx workload)
-      (load-batch-workflows tx workload))))
+  [tx workload]
+  (if (workloads/saved-before? "0.4.0" workload)
+    (pre-v0.4.0-load-workflows tx workload)
+    (load-batch-workflows tx workload)))

--- a/api/src/wfl/module/batch.clj
+++ b/api/src/wfl/module/batch.clj
@@ -99,7 +99,7 @@
   [_ workload]
   (into {} (filter second workload)))
 
-(defn ^:private pre-v0_4_0-load-workflows
+(defn pre-v0_4_0-load-workflows
   [tx workload]
   (letfn [(unnilify [m] (into {} (filter second m)))
           (split-inputs [m]
@@ -107,8 +107,7 @@
               (assoc (select-keys m keep) :inputs (apply dissoc m keep))))
           (load-options [m] (update m :options (fnil util/parse-json "null")))]
     (->> (postgres/get-table tx (:items workload))
-         (mapv (comp unnilify split-inputs load-options))
-         (assoc workload :workflows))))
+         (mapv (comp unnilify split-inputs load-options)))))
 
 (defn ^:private load-batch-workflows
   "Use transaction `tx` to load the workflows in the `_workload` stored in a

--- a/api/src/wfl/module/copyfile.clj
+++ b/api/src/wfl/module/copyfile.clj
@@ -118,7 +118,7 @@
 (defn start-copyfile-workload!
   "Use transaction TX to start _WORKLOAD."
   [tx {:keys [items uuid executor] :as workload}]
-  (let [executor (is-known-cromwell-url? executor)
+  (let [executor        (is-known-cromwell-url? executor)
         default-options (make-workflow-options executor)]
     (letfn [(submit! [{:keys [id inputs options]}]
               [id (submit-workflow executor inputs
@@ -128,7 +128,7 @@
               (jdbc/update! tx items
                             {:updated (OffsetDateTime/now) :uuid uuid :status "Submitted"}
                             ["id = ?" id]))]
-      (run! (comp (partial update! tx) submit!) (workloads/workflows workload))
+      (run! (comp (partial update! tx) submit!) (workloads/workflows tx workload))
       (jdbc/update! tx :workload
                     {:started (OffsetDateTime/now)} ["uuid = ?" uuid]))))
 

--- a/api/src/wfl/module/copyfile.clj
+++ b/api/src/wfl/module/copyfile.clj
@@ -141,14 +141,7 @@
     (start-copyfile-workload! tx workload)
     (workloads/load-workload-for-id tx id)))
 
-(defoverload workloads/update-workload! pipeline batch/update-workload!)
-(defoverload workloads/stop-workload!   pipeline batch/stop-workload!)
-
-(defmethod workloads/load-workload-impl
-  pipeline
-  [tx workload]
-  (if (workloads/saved-before? "0.4.0" workload)
-    (batch/pre-v0.4.0-load-workload-impl tx workload)
-    (batch/load-batch-workload-impl tx workload)))
-
-(defoverload workloads/workflows pipeline batch/workflows)
+(defoverload workloads/update-workload!   pipeline batch/update-workload!)
+(defoverload workloads/stop-workload!     pipeline batch/stop-workload!)
+(defoverload workloads/load-workload-impl pipeline batch/load-batch-workload-impl)
+(defoverload workloads/workflows          pipeline batch/workflows)

--- a/api/src/wfl/module/sg.clj
+++ b/api/src/wfl/module/sg.clj
@@ -11,7 +11,6 @@
             [wfl.service.clio               :as clio]
             [wfl.service.cromwell           :as cromwell]
             [wfl.service.google.storage     :as gcs]
-            [wfl.service.postgres           :as postgres]
             [wfl.util                       :as util]
             [wfl.wfl                        :as wfl])
   (:import [java.time OffsetDateTime]))
@@ -86,6 +85,7 @@
     (let [now (OffsetDateTime/now)]
       (run! update-record!
             (batch/submit-workload! workload
+                                    (workloads/workflows tx workload)
                                     executor
                                     workflow-wdl
                                     cromwellify-workflow-inputs
@@ -191,9 +191,8 @@
 ;; visible for testing
 (defn register-workload-in-clio
   "Register `workload` outputs with Clio."
-  [{:keys [executor output] :as workload}]
-  (run! (partial register-workflow-in-clio executor output)
-        (workloads/workflows workload)))
+  [{:keys [executor output] :as _workload} workflows]
+  (run! (partial register-workflow-in-clio executor output) workflows))
 
 (defn update-sg-workload!
   "Use transaction `tx` to batch-update `workload` statuses."
@@ -204,7 +203,9 @@
             (workloads/load-workload-for-id tx id))]
     (if (and started (not finished))
       (let [workload' (update! workload)]
-        (when (:finished workload') (register-workload-in-clio workload'))
+        (when (:finished workload')
+          (->> (workloads/workflows tx workload')
+               (register-workload-in-clio workload')))
         workload')
       workload)))
 

--- a/api/src/wfl/module/sg.clj
+++ b/api/src/wfl/module/sg.clj
@@ -212,6 +212,5 @@
 (defoverload workloads/start-workload!    pipeline start-sg-workload!)
 (defoverload workloads/update-workload!   pipeline update-sg-workload!)
 (defoverload workloads/stop-workload!     pipeline batch/stop-workload!)
-(defoverload workloads/load-workload-impl pipeline
-  batch/load-batch-workload-impl)
+(defoverload workloads/load-workload-impl pipeline batch/load-batch-workload-impl)
 (defoverload workloads/workflows          pipeline batch/workflows)

--- a/api/src/wfl/module/wgs.clj
+++ b/api/src/wfl/module/wgs.clj
@@ -185,9 +185,16 @@
   (letfn [(update-record! [{:keys [id] :as workflow}]
             (let [values (select-keys workflow [:uuid :status :updated])]
               (jdbc/update! tx items values ["id = ?" id])))]
-    (let [now (OffsetDateTime/now)
+    (let [now      (OffsetDateTime/now)
           executor (is-known-cromwell-url? executor)]
-      (run! update-record! (batch/submit-workload! workload executor workflow-wdl make-workflow-inputs cromwell-label (make-workflow-options executor)))
+      (run! update-record!
+            (batch/submit-workload! workload
+                                    (workloads/workflows tx workload)
+                                    executor
+                                    workflow-wdl
+                                    make-workflow-inputs
+                                    cromwell-label
+                                    (make-workflow-options executor)))
       (jdbc/update! tx :workload {:started now} ["id = ?" id]))
     (workloads/load-workload-for-id tx id)))
 

--- a/api/src/wfl/module/wgs.clj
+++ b/api/src/wfl/module/wgs.clj
@@ -191,14 +191,7 @@
       (jdbc/update! tx :workload {:started now} ["id = ?" id]))
     (workloads/load-workload-for-id tx id)))
 
-(defoverload workloads/update-workload! pipeline batch/update-workload!)
-(defoverload workloads/stop-workload!   pipeline batch/stop-workload!)
-
-(defmethod workloads/load-workload-impl
-  pipeline
-  [tx workload]
-  (if (workloads/saved-before? "0.4.0" workload)
-    (batch/pre-v0.4.0-load-workload-impl tx workload)
-    (batch/load-batch-workload-impl tx workload)))
-
-(defoverload workloads/workflows pipeline batch/workflows)
+(defoverload workloads/update-workload!   pipeline batch/update-workload!)
+(defoverload workloads/stop-workload!     pipeline batch/stop-workload!)
+(defoverload workloads/load-workload-impl pipeline batch/load-batch-workload-impl)
+(defoverload workloads/workflows          pipeline batch/workflows)

--- a/api/src/wfl/module/xx.clj
+++ b/api/src/wfl/module/xx.clj
@@ -163,7 +163,14 @@
               (jdbc/update! tx items values ["id = ?" id])))]
     (let [now (OffsetDateTime/now)
           executor (is-known-cromwell-url? executor)]
-      (run! update-record! (batch/submit-workload! workload executor workflow-wdl cromwellify-workflow-inputs cromwell-label (make-workflow-options executor)))
+      (run! update-record!
+            (batch/submit-workload! workload
+                                    (workloads/workflows tx workload)
+                                    executor
+                                    workflow-wdl
+                                    cromwellify-workflow-inputs
+                                    cromwell-label
+                                    (make-workflow-options executor)))
       (jdbc/update! tx :workload {:started now} ["id = ?" id]))
     (workloads/load-workload-for-id tx id)))
 

--- a/api/test/wfl/integration/modules/sg_test.clj
+++ b/api/test/wfl/integration/modules/sg_test.clj
@@ -45,13 +45,13 @@
    :creator @workloads/email})
 
 (defn mock-submit-workload
-  [workload _ _ _ _ _]
+  [_ workflows _ _ _ _ _]
   (let [now (OffsetDateTime/now)]
     (letfn [(submit [workflow uuid] (assoc workflow
                                            :status "Submitted"
                                            :updated now
                                            :uuid    uuid))]
-      (map submit (workloads/workflows workload) the-uuids))))
+      (map submit workflows the-uuids))))
 
 (deftest test-create-workload!
   (letfn [(verify-workflow [workflow]
@@ -375,11 +375,11 @@
             (jdbc/update! tx items
                           {:status "Succeeded" :updated (OffsetDateTime/now)}
                           ["id = ?" id]))]
-    (run! update! (workloads/workflows workload))))
+    (run! update! (wfl.api.workloads/workflows tx workload))))
 
 (deftest test-workload-state-transition
   (let [count           (atom 0)
-        increment-count (fn [_] (swap! count inc))]
+        increment-count (fn [& _] (swap! count inc))]
     (with-redefs-fn
       {#'cromwell/submit-workflows             mock-cromwell-submit-workflows
        #'batch/batch-update-workflow-statuses! mock-batch-update-workflow-statuses!

--- a/api/test/wfl/integration/modules/wgs_test.clj
+++ b/api/test/wfl/integration/modules/wgs_test.clj
@@ -200,16 +200,16 @@
                   workloads/workflows))))
 
 (defn mock-batch-update-workflow-statuses!
-  [tx {:keys [workflows items] :as _workload}]
+  [tx {:keys [items] :as workload}]
   (letfn [(update! [{:keys [id]}]
             (jdbc/update! tx items
                           {:status "Succeeded" :updated (OffsetDateTime/now)}
                           ["id = ?" id]))]
-    (run! update! workflows)))
+    (run! update! (wfl.api.workloads/workflows tx workload))))
 
 (deftest test-workload-state-transition
   (with-redefs-fn
-    {#'cromwell/submit-workflows                mock-submit-workflows
+    {#'cromwell/submit-workflows             mock-submit-workflows
      #'batch/batch-update-workflow-statuses! mock-batch-update-workflow-statuses!}
     #(shared/run-workload-state-transition-test! (make-wgs-workload-request))))
 

--- a/api/test/wfl/tools/workloads.clj
+++ b/api/test/wfl/tools/workloads.clj
@@ -287,7 +287,8 @@
     (wfl.api.workloads/update-workload! tx workload)))
 
 (defn workflows [workload]
-  (wfl.api.workloads/workflows workload))
+  (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+    (wfl.api.workloads/workflows tx workload)))
 
 (defn load-workload-for-uuid [uuid]
   (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]

--- a/api/test/wfl/tools/workloads.clj
+++ b/api/test/wfl/tools/workloads.clj
@@ -258,7 +258,7 @@
         (when (> elapsed timeout)
           (throw (TimeoutException.
                   (format "Timed out waiting for workload %s" uuid))))
-        (if (or (:finished workload) (every? finished? (:workflows wl)))
+        (if (or (:finished workload) (every? finished? (endpoints/get-workflows wl)))
           (done! wl)
           (do
             (log/infof "Waiting for workload %s to complete" uuid)

--- a/api/test/wfl/unit/api_handlers_test.clj
+++ b/api/test/wfl/unit/api_handlers_test.clj
@@ -1,18 +1,12 @@
 (ns wfl.unit.api-handlers-test
   (:require [clojure.test       :refer [deftest is use-fixtures]]
-            [wfl.api.handlers   :as handlers]
-            [wfl.api.workloads  :as workloads]
-            [wfl.tools.fixtures :as fixtures]))
-
-(use-fixtures :once
-  (fixtures/method-overload-fixture workloads/workflows "Test" :workflows))
+            [wfl.api.handlers   :as handlers]))
 
 (deftest test-strip-internals
   (let [workload  (handlers/strip-internals
                    {:id 0
                     :pipeline "Test"
-                    :items "ExampleTable_0000001"
-                    :workflows [{:id 0} {:id 1}]})]
+                    :items "ExampleTable_0000001"})]
     (is (wfl.util/absent? workload :id))
     (is (wfl.util/absent? workload :items))
-    (is (every? #(wfl.util/absent? % :id) (:workflows workload)))))
+    (is (wfl.util/absent? workload :workflows))))


### PR DESCRIPTION
RR: https://broadinstitute.atlassian.net/browse/GH-1314
Adding a separate `workflows` selector will allow us to decouple the workload representation from serialisation artefacts that aren’t useful for a user.

In this PR, I'm changing
```
GET /api/v1/workloads
```
to only return workload metadata (everything but the workflows) and adding
```
GET /api/v1/workloads/{uuid}/workflows
```
to fetch the workflows in the workload.
Below is the swagger UI with the new endpoint.

![Screenshot from 2021-05-17 15-52-24](https://user-images.githubusercontent.com/8223952/118548104-d2b14900-b751-11eb-95ea-e17767bf85fc.png)

