### PR TITLE
TerraExecutor/update-executor should update active, failed workflow statuses

### DIFF
--- a/api/test/wfl/integration/modules/covid_test.clj
+++ b/api/test/wfl/integration/modules/covid_test.clj
@@ -4,6 +4,7 @@
             [clojure.string        :as str]
             [wfl.jdbc              :as jdbc]
             [wfl.module.covid      :as covid]
+            [wfl.service.firecloud :as firecloud]
             [wfl.service.postgres  :as postgres]
             [wfl.service.rawls     :as rawls]
             [wfl.tools.fixtures    :as fixtures]
@@ -54,6 +55,16 @@
 (defn ^:private mock-create-submission [& _]
   {:submissionId submission-id
    :workflows [running-workflow succeeded-workflow]})
+
+;; Workflow fetch mocks within update-workflow-statuses!
+(defn ^:private mock-workflow-update-status [_ _ workflow-id]
+  (is (not (= (:workflowId succeeded-workflow) workflow-id))
+      "Successful workflow records should be filtered out before firecloud fetch")
+  {:status "Succeeded" :workflowId workflow-id})
+(defn ^:private mock-workflow-keep-status [_ _ workflow-id]
+  (is (not (= (:workflowId succeeded-workflow) workflow-id))
+      "Successful workflow records should be filtered out before firecloud fetch")
+  running-workflow)
 
 (let [new-env {"WFL_FIRECLOUD_URL"
                "https://firecloud-orchestration.dsde-dev.broadinstitute.org"}]
@@ -132,22 +143,29 @@
         source   (make-queue-from-list [snapshot])
         executor (create-terra-executor (rand-int 1000000))]
     (letfn [(verify-record-against-workflow [record workflow idx]
-              (is (= idx (:id record)))
-              (is (= (:status workflow) (:workflow_status record)))
-              (is (= (:workflowId workflow) (:workflow_id record))))]
+              (is (= idx (:id record))
+                  "The record ID was incorrect given the workflow order in mocked submission")
+              (is (= (:workflowId workflow) (:workflow_id record))
+                  "The workflow ID was incorrect and should match corresponding record"))]
       (with-redefs-fn
-        {#'rawls/create-snapshot-reference   mock-rawls-create-snapshot-reference
-         #'covid/create-submission!          mock-create-submission}
+        {#'rawls/create-snapshot-reference mock-rawls-create-snapshot-reference
+         #'covid/create-submission!        mock-create-submission
+         #'firecloud/get-workflow          mock-workflow-update-status}
         #(covid/update-executor! source executor))
       (is (-> source :queue empty?) "The snapshot was not consumed.")
       (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
         (let [[running-record succeeded-record & _ :as records]
-              (->> executor :details (postgres/get-table tx))]
+              (->> executor :details (postgres/get-table tx) (sort-by :id))]
           (is (== 2 (count records))
-              "The workflows were not written to the database")
-          (is (every? #(= snapshot-reference-id (:snapshot_reference_id %)) records))
-          (is (every? #(= submission-id (:rawls_submission_id %)) records))
-          (is (every? #(nil? (:consumed %)) records))
+              "Exactly 2 workflows should have been written to the database")
+          (is (every? #(= snapshot-reference-id (:snapshot_reference_id %)) records)
+              "The snapshot reference ID was incorrect and should match all records")
+          (is (every? #(= submission-id (:rawls_submission_id %)) records)
+              "The submission ID was incorrect and should match all records")
+          (is (every? #(= "Succeeded" (:workflow_status %)) records)
+              "Status update mock should have marked running workflow as succeeded")
+          (is (every? #(nil? (:consumed %)) records)
+              "All records should be unconsumed")
           (verify-record-against-workflow running-record running-workflow 1)
           (verify-record-against-workflow succeeded-record succeeded-workflow 2))))))
 
@@ -158,7 +176,8 @@
         executor   (create-terra-executor (rand-int 1000000))]
     (with-redefs-fn
       {#'rawls/create-snapshot-reference   mock-rawls-create-snapshot-reference
-       #'covid/create-submission!          mock-create-submission}
+       #'covid/create-submission!          mock-create-submission
+       #'firecloud/get-workflow            mock-workflow-keep-status}
       #(covid/update-executor! source executor))
     (with-redefs-fn
       {#'covid/peek-terra-executor-queue #'covid/peek-terra-executor-details}


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1315

Overview of new method `update-terra-workflow-statuses!`, called at the end of `update-terra-executor`:
1. Fetch executor details workflow records with active or failed status.
2. For each record, use Firecloud to fetch an up-to-date workflow.
3. Update the record's status using the workflow object.

Initially I thought I'd use @ehigham 's new code added in [this PR](https://github.com/broadinstitute/wfl/pull/396), but ended up going another way.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- See above.
- Supplemented existing integration tests.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- Run affected integration tests.
- I will add comments inline to flag possibly-debatable choices.