### PR TITLE
[GH-1318] Stop Workload Source

### DIFF
--- a/api/src/wfl/module/covid.clj
+++ b/api/src/wfl/module/covid.clj
@@ -461,6 +461,14 @@
            (jdbc/query tx)
            first))))
 
+(defn ^:private tdr-snapshot-list-queue-length [{:keys [items] :as _source}]
+  (let [query "SELECT COUNT (*) FROM %s WHERE consumed IS NULL"]
+    (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+      (->> (format query items)
+           (jdbc/query tx)
+           first
+           :count))))
+
 (defn ^:private pop-tdr-snapshot-list [{:keys [items] :as source}]
   (if-let [{:keys [id]} (peek-tdr-snapshot-list source)]
     (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
@@ -473,6 +481,7 @@
 (defoverload load-source!   tdr-snapshot-list-type load-tdr-snapshot-list)
 (defoverload peek-queue!    tdr-snapshot-list-type
   (comp edn/read-string :item peek-tdr-snapshot-list))
+(defoverload queue-length!  tdr-snapshot-list-type tdr-snapshot-list-queue-length)
 (defoverload pop-queue!     tdr-snapshot-list-type pop-tdr-snapshot-list)
 
 ;; Terra Executor

--- a/api/src/wfl/module/covid.clj
+++ b/api/src/wfl/module/covid.clj
@@ -124,8 +124,8 @@
                          :id)]
     (-> [(format set-details continuous-workload-table-name)]
         (concat (map first src-exc-snk) [items])
-        (->> (jdbc/execute! tx))
-        first)))
+        (->> (jdbc/execute! tx)))
+    items))
 
 (defn ^:private patch-workload [tx {:keys [id]} colls]
   (jdbc/update! tx :workload colls ["id = ?" id]))

--- a/api/test/wfl/tools/workloads.clj
+++ b/api/test/wfl/tools/workloads.clj
@@ -127,31 +127,33 @@
 
 (defn covid-workload-request
   "Make a COVID Sarscov2IlluminaFull workload creation request."
-  [source executor sink]
-  {:source   (merge
-              {:name    "Terra DataRepo",
-               :dataset ""
-               :table   ""
-               :column  ""}
-              source)
-   :executor (merge
-              {:name                       "Terra"
-               :workspace                  "namespace/name"
-               :methodConfiguration        ""
-               :methodConfigurationVersion 0
-               :fromSource                 ""}
-              executor)
-   :sink     (merge
-              {:name        "Terra Workspace"
-               :workspace   "namespace/name"
-               :entity      ""
-               :fromOutputs {}
-               :identifier  ""}
-              sink)
-   :pipeline covid/pipeline
-   :project  @project
-   :creator  @email
-   :labels   ["hornet:test"]})
+  ([source executor sink]
+   {:source   (merge
+               {:name    "Terra DataRepo",
+                :dataset ""
+                :table   ""
+                :column  ""}
+               source)
+    :executor (merge
+               {:name                       "Terra"
+                :workspace                  "namespace/name"
+                :methodConfiguration        ""
+                :methodConfigurationVersion 0
+                :fromSource                 ""}
+               executor)
+    :sink     (merge
+               {:name        "Terra Workspace"
+                :workspace   "namespace/name"
+                :entity      ""
+                :fromOutputs {}
+                :identifier  ""}
+               sink)
+    :pipeline covid/pipeline
+    :project  @project
+    :creator  @email
+    :labels   ["hornet:test"]})
+  ([]
+   (covid-workload-request {} {} {})))
 
 (defn xx-workload-request
   [identifier]

--- a/database/changesets/20210422_TerraDataRepoSourceTable.xml
+++ b/database/changesets/20210422_TerraDataRepoSourceTable.xml
@@ -22,7 +22,8 @@
                 dataset_table       TEXT NOT NULL,                                     -- the name of the dataset table
                 table_column_name   TEXT NOT NULL,                                     -- name of a column in table containing orderable and strictly increasing data
                 details             TEXT NOT NULL,                                     -- the identifier of the source details table
-                last_checked        TIMESTAMPTZ,                                       -- a timestamp used for WFL to monitor new data on a rolling basis
+                last_checked        TIMESTAMPTZ,                                       -- when WFL last checked TDR for new data
+                stopped             TIMESTAMPTZ,                                       -- when WFL stopped checking for new data
                 CONSTRAINT TERRADATAREPOSOURCE_PKEY PRIMARY KEY (id)
             )
         </sql>


### PR DESCRIPTION
RR: https://broadinstitute.atlassian.net/browse/GH-1318
Add `stop-source` multimethod and implement for the TerraDataRepoSource.
When stopped, the source will stop looking for new rows to snaphot in
the TDR.

Also added logic for when the workload is finished. In this case, once
started the workload is finished when it has been stopped and both
source and executor queues are empty. To do this, I added another
multimethod to return the length of the queues.

For the executor, the length of the queue is the number of workflows
that have not been consumed or aborted.

For the source, the length of the queue is the number of unconsumed
records whose snapshot job is not 'failed'.

Note that this is slightly at odds with peek, where peek is meant to
return objects that are ready to be consumed.

