### PR TITLE
GH-1307 GH-1312 Update method configuration using snapshot reference

### DIFF
--- a/api/src/wfl/module/covid.clj
+++ b/api/src/wfl/module/covid.clj
@@ -422,6 +422,39 @@
   (cond (= "importSnapshot" fromSource) (import-snapshot! executor source-item)
         :else (throw (ex-info "Unknown fromSource" {:executor executor}))))
 
+(defn ^:private update-method-configuration
+  "Update METHODCONFIGURATION in WORKSPACE with snapshot reference NAME
+  as :dataReferenceName via Firecloud.
+  Update executor table record ID with incremented METHODCONFIGURATIONVERSION.
+  Return EXECUTOR with incremented METHODCONFIGURATIONVERSION."
+  [{:keys [id
+           workspace
+           methodConfiguration
+           methodConfigurationVersion] :as executor}
+   {:keys [name]                       :as _reference}]
+  (let [{:keys [methodConfigVersion] :as firecloud-mc}
+        (try
+          (firecloud/get-method-configuration workspace methodConfiguration)
+          (catch Throwable t
+            (throw (ex-info "Method configuration does not exist in workspace"
+                            {:executor executor
+                             :cause    (.getMessage t)}))))
+        inc-version (inc methodConfigurationVersion)]
+    (when-not (== methodConfigurationVersion methodConfigVersion)
+      (throw (ex-info (str "Firecloud method configuration version != expected: "
+                           "possible concurrent modification")
+                      {:executor            executor
+                       :methodConfiguration firecloud-mc})))
+    (-> firecloud-mc
+        (assoc :dataReferenceName name)
+        (->> (firecloud/update-method-configuration workspace
+                                                    methodConfiguration)))
+    (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+      (jdbc/update! tx terra-executor-table
+                    {:method_configuration_version inc-version}
+                    ["id = ?" id]))
+    (assoc executor :methodConfigurationVersion inc-version)))
+
 (defn ^:private create-submission!
   "TO IMPLEMENT:
   Create submission from REFERENCE."
@@ -443,8 +476,9 @@
       (jdbc/insert-multi! tx details (map to-rows workflows)))))
 
 (defn ^:private update-terra-workflow-statuses!
-  "Update statuses in DETAILS table for active or failed WORKSPACE workflows."
-  [{:keys [workspace details] :as _executor}]
+  "Update statuses in DETAILS table for active or failed WORKSPACE workflows.
+  Return EXECUTOR."
+  [{:keys [workspace details] :as executor}]
   (letfn [(read-active-or-failed-workflows
             []
             (let [query "SELECT *
@@ -472,7 +506,8 @@
                   (run! records))))]
     (->> (read-active-or-failed-workflows)
          (map update-workflow-status)
-         (write-workflow-statuses (OffsetDateTime/now)))))
+         (write-workflow-statuses (OffsetDateTime/now)))
+    executor))
 
 (defn ^:private update-terra-executor
   "Create new submission from new SOURCE snapshot if available,
@@ -481,12 +516,13 @@
   Return EXECUTOR."
   [source executor]
   (if-let [snapshot (peek-queue! source)]
-    (let [reference  (from-source executor snapshot)
-          submission (create-submission! executor reference)]
-      (write-workflows! executor reference submission)
-      (pop-queue! source)))
-  (update-terra-workflow-statuses! executor)
-  executor)
+    (let [reference        (from-source executor snapshot)
+          updated-executor (update-method-configuration executor reference)
+          submission       (create-submission! updated-executor reference)]
+      (write-workflows! updated-executor reference submission)
+      (pop-queue! source)
+      (update-terra-workflow-statuses! updated-executor))
+    (update-terra-workflow-statuses! executor)))
 
 (defn ^:private peek-terra-executor-details
   "Get first unconsumed successful workflow record from DETAILS table."

--- a/api/test/wfl/integration/modules/covid_test.clj
+++ b/api/test/wfl/integration/modules/covid_test.clj
@@ -55,9 +55,11 @@
 (defn ^:private mock-firecloud-get-method-configuration [& _]
   {:methodConfigVersion methodConfigVersion})
 (defn ^:private mock-firecloud-update-method-configuration
-  [_ _ {:keys [dataReferenceName]}]
+  [_ _ {:keys [dataReferenceName] :as mc}]
   (is (= dataReferenceName snapshot-reference-name)
       "Snapshot reference name should be passed to method config update")
+  (is (= (:methodConfigVersion mc) (inc methodConfigVersion))
+      "Incremented version should be passed to method config update")
   nil)
 
 ;; Submission mock

--- a/api/test/wfl/integration/modules/covid_test.clj
+++ b/api/test/wfl/integration/modules/covid_test.clj
@@ -217,7 +217,8 @@
     (with-redefs-fn
       {#'rawls/create-snapshot-reference       mock-rawls-create-snapshot-reference
        #'firecloud/get-method-configuration    mock-firecloud-get-method-configuration
-       #'firecloud/update-method-configuration mock-firecloud-update-method-configuration       #'covid/create-submission!          mock-create-submission
+       #'firecloud/update-method-configuration mock-firecloud-update-method-configuration
+       #'covid/create-submission!              mock-create-submission
        #'firecloud/get-workflow                mock-workflow-keep-status}
       #(covid/update-executor! source executor))
     (with-redefs-fn


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

https://broadinstitute.atlassian.net/browse/GH-1307
https://broadinstitute.atlassian.net/browse/GH-1312

When creating submissions from snapshots, we have to modify the method configuration to specify the snapshot reference's name. Because Terra is an interactive tool, that same method config can be modified by a user at the same time.

I used the COVID demo script's method configuration updating as a starting point, to which I added additional checks for method configuration existence and version matching, as well as DB updating.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

In new method `update-method-configuration`:
1. GET the method configuration from Firecloud (presently includes verification that the method configuration exists, but should be moved to `verify-terra-executor!` when available).
2. Throw if the Firecloud-derived method configuration version doesn't match our DB record.
3. Update the method configuration with the snapshot reference name and POST to Firecloud.
4. Increment our DB record's method configuration version.

Supplemented integration tests to check that the snapshot reference name is POSTed to Firecloud as expected and that the executor object's version is incremented.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- I'm not convinced that someone unfamiliar with my new method would know what's going on, so fresh eyes to the space are especially welcome, as are suggestions to make it clearer.
