### PR TITLE
Adding flags for skipping validation of source, executor and sink in requests

### DIFF
--- a/api/src/wfl/module/covid.clj
+++ b/api/src/wfl/module/covid.clj
@@ -279,11 +279,12 @@
 
 (defn verify-data-repo-source!
   "Verify that the `dataset` exists and that the WFL has the necessary permissions to read it"
-  [{:keys [name dataset table column] :as source}]
-  (when-not (some? dataset)
-    (throw (ex-info "Dataset is Nil" {:source source})))
-  (-> (datarepo/dataset (:dataset source))
-      (throw-unless-table-exists table column)))
+  [{:keys [name dataset table column skipValidation] :as source}]
+  (when-not skipValidation
+    (when-not (some? dataset)
+      (throw (ex-info "Dataset is Nil" {:source source})))
+    (-> (datarepo/dataset (:dataset source))
+        (throw-unless-table-exists table column))))
 
 (defn ^:private find-new-rows
   "Find new rows in TDR by querying between `last_checked` and the
@@ -488,9 +489,10 @@
 
 (defn verify-terra-executor!
   "Verify the method-configuration exists."
-  [{:keys [name methodConfiguration] :as executor}]
-  (when-not (:methodConfiguration executor)
-    (throw (ex-info "Unknown Method Configuration" {:executor executor}))))
+  [{:keys [name methodConfiguration skipValidation] :as executor}]
+  (when-not skipValidation
+    (when-not (:methodConfiguration executor)
+      (throw (ex-info "Unknown Method Configuration" {:executor executor})))))
 
 (defn ^:private import-snapshot!
   "Return snapshot reference for ID imported to WORKSPACE as NAME."
@@ -652,12 +654,13 @@
 
 (defn verify-terra-sink!
   "Verify that the WFL has access to both firecloud and the `workspace`."
-  [{:keys [name workspace] :as sink}]
-  (try
-    (firecloud/get-workspace workspace)
-    (catch Throwable t
-      (throw (ex-info "Cannot access the workspace" {:workspace workspace
-                                                     :cause     (.getMessage t)})))))
+  [{:keys [name workspace skipValidation] :as sink}]
+  (when-not skipValidation
+    (try
+      (firecloud/get-workspace workspace)
+      (catch Throwable t
+        (throw (ex-info "Cannot access the workspace" {:workspace workspace
+                                                       :cause     (.getMessage t)}))))))
 
 ;; visible for testing
 (defn rename-gather

--- a/api/test/wfl/integration/modules/covid_test.clj
+++ b/api/test/wfl/integration/modules/covid_test.clj
@@ -12,7 +12,7 @@
             [wfl.tools.resources   :as resources])
   (:import [java.util ArrayDeque UUID]
            [java.lang Math]
-           (org.postgresql.util PSQLException)))
+           [org.postgresql.util PSQLException]))
 
 ;; Snapshot creation mock
 (def ^:private mock-new-rows-size 2021)
@@ -152,14 +152,14 @@
                                                                workloads/create-workload!))))
 
 (deftest test-create-covid-workload-without-dataset-and-skipping-validation
-  (workloads/create-workload!
-   (workloads/covid-workload-request {:dataset nil
-                                      :table   testing-table-name
-                                      :column  testing-column-name
-                                      :skipValidation true}
-                                     {:workspace            testing-workspace
-                                      :methodConfiguration testing-method-configuration}
-                                     {:workspace testing-workspace})))
+  (is (workloads/create-workload!
+       (workloads/covid-workload-request {:dataset nil
+                                          :table   testing-table-name
+                                          :column  testing-column-name
+                                          :skipValidation true}
+                                         {:workspace            testing-workspace
+                                          :methodConfiguration testing-method-configuration}
+                                         {:workspace testing-workspace}))))
 
 (deftest test-create-covid-workload-with-misnamed-executor
   (is (thrown-with-msg? RuntimeException #"Failed to create workload - unknown executor" (-> (make-covid-workload-request)

--- a/api/test/wfl/tools/workloads.clj
+++ b/api/test/wfl/tools/workloads.clj
@@ -132,21 +132,24 @@
               {:name    "Terra DataRepo",
                :dataset ""
                :table   ""
-               :column  ""}
+               :column  ""
+               :skipValidation false}
               source)
    :executor (merge
               {:name                       "Terra"
                :workspace                  "namespace/name"
                :methodConfiguration        ""
                :methodConfigurationVersion 0
-               :fromSource                 ""}
+               :fromSource                 ""
+               :skipValidation false}
               executor)
    :sink     (merge
               {:name        "Terra Workspace"
                :workspace   "namespace/name"
                :entity      ""
                :fromOutputs {}
-               :identifier  ""}
+               :identifier  ""
+               :skipValidation false}
               sink)
    :pipeline covid/pipeline
    :project  @project

--- a/api/test/wfl/tools/workloads.clj
+++ b/api/test/wfl/tools/workloads.clj
@@ -127,34 +127,34 @@
 
 (defn covid-workload-request
   "Make a COVID Sarscov2IlluminaFull workload creation request."
-  [source executor sink]
-  {:source   (merge
-              {:name    "Terra DataRepo",
-               :dataset ""
-               :table   ""
-               :column  ""
-               :skipValidation false}
-              source)
-   :executor (merge
-              {:name                       "Terra"
-               :workspace                  "namespace/name"
-               :methodConfiguration        ""
-               :methodConfigurationVersion 0
-               :fromSource                 ""
-               :skipValidation false}
-              executor)
-   :sink     (merge
-              {:name        "Terra Workspace"
-               :workspace   "namespace/name"
-               :entity      ""
-               :fromOutputs {}
-               :identifier  ""
-               :skipValidation false}
-              sink)
-   :pipeline covid/pipeline
-   :project  @project
-   :creator  @email
-   :labels   ["hornet:test"]})
+  ([source executor sink]
+   {:source   (merge
+                {:name    "Terra DataRepo",
+                 :dataset ""
+                 :table   ""
+                 :column  ""
+                 :skipValidation false}
+                source)
+    :executor (merge
+                {:name                       "Terra"
+                 :workspace                  "namespace/name"
+                 :methodConfiguration        ""
+                 :methodConfigurationVersion 0
+                 :fromSource                 ""
+                 :skipValidation false}
+                executor)
+    :sink     (merge
+                {:name        "Terra Workspace"
+                 :workspace   "namespace/name"
+                 :entity      ""
+                 :fromOutputs {}
+                 :identifier  ""
+                 :skipValidation false}
+                sink)
+    :pipeline covid/pipeline
+    :project  @project
+    :creator  @email
+    :labels   ["hornet:test"]})
   ([]
    (covid-workload-request {} {} {})))
 


### PR DESCRIPTION
### Purpose
The purpose of this PR is to add flags for skipping validation to source, executor and sink requests.

This is for ticket GH-1299

### Changes
I improved several of the tests for validation and also added flags and tests for skipping validation

### Review Instructions
Please review this ticket for functionality - does it cover all of the things that it should? Also, for code improvements - is there a better way of writing what I did and if so, what is it?
