### PR TITLE
[GH-1336] Fix continual snapshot creation

### DIFF
--- a/api/src/wfl/module/covid.clj
+++ b/api/src/wfl/module/covid.clj
@@ -14,6 +14,7 @@
             [wfl.util :as util :refer [do-or-nil]]
             [wfl.wfl :as wfl])
   (:import [clojure.lang ExceptionInfo]
+           [java.sql Timestamp]
            [java.time OffsetDateTime ZoneId]
            [java.time.format DateTimeFormatter]
            [java.util UUID]
@@ -323,15 +324,10 @@
       (assoc source :dataset dataset))))
 
 (defn ^:private find-new-rows
-  "Find new rows in TDR by querying between `last_checked` and the
-   frozen `now`."
-  [{:keys [dataset table column last_checked] :as _source} now]
-  (-> (datarepo/query-table-between
-       dataset
-       table
-       column
-       [last_checked now]
-       [:datarepo_row_id])
+  "Find new rows in TDR by querying the dataset between the `interval`."
+  [{:keys [dataset table column] :as _source} interval]
+  (-> dataset
+      (datarepo/query-table-between table column interval [:datarepo_row_id])
       :rows
       flatten))
 
@@ -419,15 +415,22 @@
    (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
      (update-last-checked tx source now))))
 
+(defn ^:private timestamp-to-offsetdatetime [^Timestamp t]
+  "Parse the Timestamp `t` into an `OffsetDateTime`."
+  (OffsetDateTime/ofInstant (.toInstant t) (ZoneId/of "UTC")))
+
+(def ^:private bigquery-datetime-format
+  (DateTimeFormatter/ofPattern "yyyy-MM-dd'T'HH:mm:ss"))
+
 (defn ^:private find-and-snapshot-new-rows
   "Create and enqueue snapshots from new rows in the `source` dataset."
-  [source utc-now]
-  (let [date-format (DateTimeFormatter/ofPattern "yyyy-MM-dd'T'HH:mm:ss")]
-    (->> (.format utc-now date-format)
-         (find-new-rows source)
-         (create-snapshots source utc-now)
-         (write-snapshots-creation-jobs source utc-now))
-    (update-last-checked source utc-now)))
+  [{:keys [last_checked] :as source} utc-now]
+  (->> [(timestamp-to-offsetdatetime last_checked) utc-now]
+       (mapv #(.format % bigquery-datetime-format))
+       (find-new-rows source)
+       (create-snapshots source utc-now)
+       (write-snapshots-creation-jobs source utc-now))
+  (update-last-checked source utc-now))
 
 (defn ^:private update-pending-snapshot-jobs
   "Update the status of TDR snapshot jobs that are still 'running'."

--- a/api/test/wfl/integration/modules/covid_test.clj
+++ b/api/test/wfl/integration/modules/covid_test.clj
@@ -16,11 +16,14 @@
             [wfl.util                       :as util])
   (:import [java.util ArrayDeque UUID]
            [java.lang Math]
-           [wfl.util UserException]))
+           [wfl.util UserException]
+           (java.time LocalDateTime)))
 
 ;; Snapshot creation mock
 (def ^:private mock-new-rows-size 2021)
-(defn ^:private mock-find-new-rows [_ _] (take mock-new-rows-size (range)))
+(defn ^:private mock-find-new-rows [_ interval]
+  (is (every? #(LocalDateTime/parse % @#'covid/bigquery-datetime-format) interval))
+  (take mock-new-rows-size (range)))
 (defn ^:private mock-create-snapshots [_ _ row-ids]
   (letfn [(f [idx shard] [(vec shard) (format "mock_job_id_%s" idx)])]
     (->> (partition-all 500 row-ids)


### PR DESCRIPTION
RR: https://broadinstitute.atlassian.net/browse/GH-1336

Our BigQuery query was wrong as we were simply calling `toString` on a java.sql.Timestamp. This lead to queries like

```sql
SELECT (datarepo_row_id)
FROM `tdr-prod-workflow-launcher-dev.datarepo_ehigham_covid_bashing.flowcells`
WHERE last_modified_date BETWEEN '2021-05-26 15:31:18.287641' AND '2021-05-26T20:00:13'
```

The space in the interval was causing the problem and BigQuery interpreted that as a date. The fix is to ensure the lower and upper bound of our query-between interval is of the same type by coercing java.sql.Timestamp `last_checked` into a java.time.OffsetDateTime.

