### PR TITLE
[GH-1341] Fix accepting malformed labels in workload request

### DIFF
--- a/api/src/wfl/api/spec.clj
+++ b/api/src/wfl/api/spec.clj
@@ -106,7 +106,7 @@
 (s/def ::identifier string?)
 (s/def ::fromOutputs map?)
 (s/def ::fromSource string?)
-(s/def ::labels (s/* string?))
+(s/def ::labels (s/* util/label?))
 (s/def ::name string?)
 (s/def ::methodConfiguration (s/and string? util/terra-namespaced-name?))
 (s/def ::methodConfigurationVersion integer?)
@@ -143,7 +143,9 @@
 (s/def ::batch-workload-request (s/keys :opt-un [::common
                                                  ::input
                                                  ::items
-                                                 ::output]
+                                                 ::labels
+                                                 ::output
+                                                 ::watchers]
                                         :req-un [(or ::cromwell ::executor)
                                                  ::pipeline
                                                  ::project]))
@@ -167,26 +169,25 @@
 
 (s/def ::covid-workload-request (s/keys :req-un [::executor
                                                  ::pipeline
+                                                 ::project
                                                  ::sink
                                                  ::source]
                                         :opt-un [::labels
-                                                 ::project
                                                  ::watchers]))
 
 (s/def ::covid-workload-response (s/keys :req-un [::created
                                                   ::creator
                                                   ::executor
                                                   ::labels
-                                                  ::pipeline
                                                   ::sink
                                                   ::source
                                                   ::uuid
                                                   ::version
                                                   ::watchers]
                                          :opt-un [::finished
-                                                  ::release
                                                   ::started
-                                                  ::stopped]))
+                                                  ::stopped
+                                                  ::updated]))
 
 (s/def ::workload-request (s/or :batch ::batch-workload-request
                                 :covid ::covid-workload-request))

--- a/api/src/wfl/module/covid.clj
+++ b/api/src/wfl/module/covid.clj
@@ -130,7 +130,6 @@
    :executor
    :finished
    :labels
-   :pipeline
    :sink
    :source
    :started
@@ -193,7 +192,7 @@
       (select-keys $ workload-metadata-keys)
       (merge $ src-exc-sink)
       (filter second $)
-      (into {:type :workload :id id} $))))
+      (into {:type :workload :id id :pipeline pipeline} $))))
 
 (defn ^:private start-covid-workload
   "Start creating and managing workflows from the source."
@@ -234,6 +233,7 @@
 (defn ^:private workload-to-edn [workload]
   (-> workload
       (util/select-non-nil-keys workload-metadata-keys)
+      (dissoc :pipeline)
       (update :source   util/to-edn)
       (update :executor util/to-edn)
       (update :sink     util/to-edn)))

--- a/api/src/wfl/util.clj
+++ b/api/src/wfl/util.clj
@@ -559,3 +559,21 @@
   "Map SYMBOLS as keywords to their values in the environment."
   [& symbols]
   (zipmap (map keyword symbols) symbols))
+
+(let [alphanumunderdash? (into (set "-_") alphanumeric?)]
+  (defn ^:private label-name?
+    "True if `_s` starts with a letter followed by any number of letters, numbers
+     underscores or dashes."
+    [[first & rest :as _s]]
+    (and (letter? first) (every? alphanumunderdash? rest))))
+
+(defn ^:private label-value?
+  "True if `s` is not a blank string."
+  [^String s]
+  (not (str/blank? s)))
+
+(defn label?
+  "True if `s` is a string of the form \"name:value\"."
+  [s]
+  (let [[name value & rest] (str/split s #":" 3)]
+    (and (label-name? name) (label-value? value) (nil? rest))))

--- a/api/test/wfl/unit/spec_test.clj
+++ b/api/test/wfl/unit/spec_test.clj
@@ -28,3 +28,19 @@
         (let [uuid-request {:uuid uuid}
               proj-request {:project project}]
           (run! valid? [uuid-request proj-request]))))))
+
+(deftest test-labels-spec
+  (let [valid?   s/valid?
+        invalid? (comp not s/valid?)] ;; i die
+    (doseq [[test? label]
+            [[valid?   "test:label"]
+             [valid?   "te_-st:l ab31 "]
+             [valid?   "test:00000000-0000-0000-0000-000000000000"]
+             [invalid? ":"]
+             [invalid? "::"]
+             [invalid? "test:"]
+             [invalid? "test :"]
+             [invalid? ":label"]
+             [invalid? "label"]
+             [invalid? "test:label:bad"]]]
+      (is (test? ::spec/labels [label]) (format "failed: %s" label)))))


### PR DESCRIPTION
RR: https://broadinstitute.atlassian.net/browse/GH-1341
Enforce labels are of the form "name:value" where
- name starts with a letter followed by any combination of letters,
  numbers, underscores and dashes
- value is any non-blank string not containing `:`

I had to include labels in the batch workload request as the coercion
layer got confused when you gave it bad labels.

