### PR TITLE
GH-1342: Let test-covid-workload run in parallel and fix its method configuration namespace.

### DIFF
--- a/api/test/wfl/system/v1_endpoint_test.clj
+++ b/api/test/wfl/system/v1_endpoint_test.clj
@@ -219,22 +219,24 @@
 
 (defn ^:private covid-workload-request []
   "Build a covid workload request."
-  (let [source   {:name    "Terra DataRepo"
-                  :dataset "79fc88f5-dcf4-48b0-8c01-615dfbc1c63a"
-                  :table   "flowcells"
-                  :column  "last_modified_date"}
-        executor {:name                       "Terra"
-                  :workspace                  "wfl-dev/CDC_Viral_Sequencing"
-                  :methodConfiguration        "cdc-covid-surveillance/sarscov2_illumina_full"
-                  :methodConfigurationVersion 1
-                  :fromSource                 "importSnapshot"}
-        sink     {:name           "Terra Workspace"
-                  :workspace      "wfl-dev/CDC_Viral_Sequencing"
-                  :entityType     "assemblies"
-                  :identifier     "flowcell_id"
-                  :fromOutputs    (resources/read-resource
-                                   "sarscov2_illumina_full/entity-from-outputs.edn")
-                  :skipValidation true}]
+  (let [terra-ns  (comp (partial str/join "/") (partial vector "wfl-dev"))
+        workspace (terra-ns "CDC_Viral_Sequencing")
+        source    {:name    "Terra DataRepo"
+                   :dataset "79fc88f5-dcf4-48b0-8c01-615dfbc1c63a"
+                   :table   "flowcells"
+                   :column  "last_modified_date"}
+        executor  {:name                       "Terra"
+                   :workspace                  workspace
+                   :methodConfiguration        (terra-ns "sarscov2_illumina_full")
+                   :methodConfigurationVersion 1
+                   :fromSource                 "importSnapshot"}
+        sink      {:name           "Terra Workspace"
+                   :workspace      workspace
+                   :entityType     "assemblies"
+                   :identifier     "flowcell_id"
+                   :fromOutputs    (resources/read-resource
+                                    "sarscov2_illumina_full/entity-from-outputs.edn")
+                   :skipValidation true}]
     (workloads/covid-workload-request source executor sink)))
 
 (defn instantify-timestamps
@@ -242,7 +244,7 @@
   [m & ks]
   (reduce (fn [m k] (update m k instant/read-instant-timestamp)) m ks))
 
-(deftest ^:private test-covid-workload
+(deftest ^:parallel test-covid-workload
   (testing "/create covid workload"
     (let [workload-request (covid-workload-request)
           {:keys [creator started uuid] :as workload}


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

Fix these.

- https://broadinstitute.atlassian.net/browse/GH-1342
- https://broadinstitute.atlassian.net/browse/GH-1343

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Fix ^:private typo on test-covid-workload system test.
- Use consistent namespaces for workspace and method configuration.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- Run `clojure -M:test --focus wfl.system.v1-endpoint-test/test-covid-workload` against a local server.
- (-Ensure I didn't check in debugging code?-)