### PR TITLE
[GH-1350] fix Terra Workspace sink validation

### DIFF
--- a/api/src/wfl/module/covid.clj
+++ b/api/src/wfl/module/covid.clj
@@ -984,13 +984,12 @@
                                (util/make-map entityType fromOutputs))))
       (let [attributes    (->> (get-in entity-types [entity-type :attributeNames])
                                (cons (str entityType "_id"))
-                               sort
                                (mapv keyword))
             [missing _ _] (data/diff (set (keys fromOutputs)) (set attributes))]
         (when (seq missing)
           (throw (UserException. unknown-attributes-error-message
                                  {:entityType  entityType
-                                  :attributes  attributes
+                                  :attributes  (sort attributes)
                                   :missing     (sort missing)
                                   :fromOutputs fromOutputs}))))))
   sink)

--- a/api/src/wfl/module/covid.clj
+++ b/api/src/wfl/module/covid.clj
@@ -991,7 +991,7 @@
           (throw (UserException. unknown-attributes-error-message
                                  {:entityType  entityType
                                   :attributes  attributes
-                                  :missing     (vec (sort missing))
+                                  :missing     (sort missing)
                                   :fromOutputs fromOutputs}))))))
   sink)
 


### PR DESCRIPTION
RR: https://broadinstitute.atlassian.net/browse/GH-1350
The "Terra Workspace" sink validation did not validate that the
attributes listed in `fromOutputs` exist in the specified entity
type in the workspace. This PR fixes this.