### PR TITLE
[GH-1357] Fix failure to sink workflow outputs

### DIFF
--- a/api/src/wfl/api/spec.clj
+++ b/api/src/wfl/api/spec.clj
@@ -60,11 +60,12 @@
                       :copyfile ::copyfile-workflow-inputs
                       :wgs      ::wgs-workflow-inputs
                       :xx       ::xx-workflow-inputs
-                      :sg       ::sg-workflow-inputs))
+                      :sg       ::sg-workflow-inputs
+                      :other    map?))
 
-(s/def ::workflows (s/* ::workflow))
 (s/def ::workflow  (s/keys :req-un [::inputs]
                            :opt-un [::status ::updated ::uuid ::options]))
+(s/def ::workflows (s/* ::workflow))
 
 ;; aou
 (s/def ::analysis_version_number integer?)
@@ -170,8 +171,7 @@
                                                   ::input
                                                   ::started
                                                   ::stopped
-                                                  ::wdl
-                                                  ::workflows]
+                                                  ::wdl]
                                          :req-un [::commit
                                                   ::created
                                                   ::creator

--- a/api/test/wfl/integration/modules/covid_test.clj
+++ b/api/test/wfl/integration/modules/covid_test.clj
@@ -1,28 +1,28 @@
 (ns wfl.integration.modules.covid-test
   "Test the Sarscov2IlluminaFull COVID pipeline."
-  (:require [clojure.test :refer :all]
-            [clojure.spec.alpha :as s]
-            [clojure.string :as str]
+  (:require [clojure.test                   :refer :all]
+            [clojure.set                    :as set]
+            [clojure.spec.alpha             :as s]
+            [clojure.string                 :as str]
             [reitit.coercion.spec]
-            [reitit.ring :as ring]
-            [reitit.ring.coercion :as coercion]
-            [wfl.api.spec :as spec]
-            [wfl.api.spec :as spec]
+            [reitit.ring                    :as ring]
+            [reitit.ring.coercion           :as coercion]
+            [wfl.api.spec                   :as spec]
+            [wfl.api.spec                   :as spec]
             [wfl.integration.modules.shared :as shared]
-            [wfl.jdbc :as jdbc]
-            [wfl.module.covid :as covid]
-            [wfl.service.firecloud :as firecloud]
-            [wfl.service.postgres :as postgres]
-            [wfl.service.rawls :as rawls]
-            [wfl.tools.fixtures :as fixtures]
-            [wfl.tools.workloads :as workloads]
-            [wfl.tools.resources :as resources]
-            [wfl.util :as util]
-            [clojure.set :as set])
-  (:import [java.util ArrayDeque UUID]
-           [java.lang Math]
-           [wfl.util UserException]
-           (java.time LocalDateTime)))
+            [wfl.jdbc                       :as jdbc]
+            [wfl.module.covid               :as covid]
+            [wfl.service.firecloud          :as firecloud]
+            [wfl.service.postgres           :as postgres]
+            [wfl.service.rawls              :as rawls]
+            [wfl.tools.fixtures             :as fixtures]
+            [wfl.tools.workloads            :as workloads]
+            [wfl.tools.resources            :as resources]
+            [wfl.util                       :as util])
+  (:import [java.lang Math]
+           [java.time LocalDateTime]
+           [java.util ArrayDeque UUID]
+           [wfl.util UserException]))
 
 ;; Snapshot creation mock
 (def ^:private mock-new-rows-size 2021)


### PR DESCRIPTION
RR: https://broadinstitute.atlassian.net/browse/GH-1357
I assumed (wrongly) the way Rawls represented workflows in a submission
was the same as how cromwell represented workflows. I also mocked these
representations incorrectly in tests. To fix this, only use the submission
to fetch workflow IDs, then use firecloud's workflow and workflow/outputs
endpoints so we don't have to adapt/mock multiple data models.