### PR TITLE
[GH-1359] Overwrite Workspace Entity On Sink

### DIFF
--- a/api/src/wfl/service/firecloud.clj
+++ b/api/src/wfl/service/firecloud.clj
@@ -130,6 +130,11 @@
          first
          :status)))
 
+(defn get-entity
+  "Fetch the `entity` metadata from the `workspace`."
+  [workspace [type name :as _entity]]
+  (get-workspace-json workspace "entities" type name))
+
 (defn delete-entities
   "Delete the `entities` from the Terra `workspace`.
    Parameters
@@ -137,7 +142,7 @@
      workspace - Terra Workspace to delete entities from
      entities  - list of entity `[type name]` pairs"
   [workspace entities]
-  (letfn [(make-entity [[type name]] {:entityType type :entityName name})]
+  (let [make-entity (partial zipmap [:entityType :entityName])]
     (-> (workspace-api-url workspace "entities" "delete")
         (http/post {:headers      (auth/get-auth-header)
                     :content-type :application/json

--- a/api/src/wfl/service/rawls.clj
+++ b/api/src/wfl/service/rawls.clj
@@ -100,7 +100,7 @@
 
 (defn batch-upsert
   "Batch update and insert entities into a `workspace`."
-  [workspace [[_name _type _attributes] & _ :as entities]]
+  [workspace [[_type _name _attributes] & _ :as entities]]
   {:pre [(string? workspace) (not-empty entities)]}
   (letfn [(add-scalar [k v]
             [{:op                 "AddUpdateAttribute"
@@ -127,8 +127,8 @@
                      (coll?   v) (add-list   k v)
                      (nil?    v) (no-op)
                      :else       (on-unhandled-attribute k v)))))
-          (make-request [[name type attributes]]
-            {:name name :entityType type :operations (to-operations attributes)})]
+          (make-request [[type name attributes]]
+            {:entityType type :name name :operations (to-operations attributes)})]
     (-> (workspace-api-url workspace "entities/batchUpsert")
         (http/post {:headers      (auth/get-auth-header)
                     :content-type :application/json

--- a/api/test/wfl/integration/rawls_test.clj
+++ b/api/test/wfl/integration/rawls_test.clj
@@ -60,7 +60,7 @@
       "general-dev-billing-account/test-workspace"
       "hornet-eng"
       (fn [workspace]
-        (rawls/batch-upsert workspace [[entity-name entity-type outputs]])
+        (rawls/batch-upsert workspace [[entity-type entity-name outputs]])
         (let [[{:keys [name attributes]} & _]
               (util/poll
                #(not-empty (firecloud/list-entities workspace entity-type)))]

--- a/api/test/wfl/system/cdc_covid19_surveillance_demo.clj
+++ b/api/test/wfl/system/cdc_covid19_surveillance_demo.clj
@@ -100,7 +100,7 @@
                          (util/unprefix-keys (keyword (str pipeline "."))))
         attributes   (covid/rename-gather outputs from-outputs)
         entity-name  "test"]
-    (rawls/batch-upsert workspace [[entity-name workspace-table attributes]])))
+    (rawls/batch-upsert workspace [[workspace-table entity-name attributes]])))
 
 (defn delete-snapshot [{:keys [name id] :as _snapshot}]
   (println "Deleting snapshot" name)


### PR DESCRIPTION
RR: https://broadinstitute.atlassian.net/browse/GH-1359
When sinking a resubmitted workflow, the TerraWorkspaceSink would
append to the existing entity in the workspace. This leaves the entity
in an even more wrong state than the reason the sample was reanalysed.
Our fix (as agreed with cloreth) is to clobber the entity in the
workspace by deleting the entity if it exists then upserting the new one.
