### PR TITLE
Fix broken requirement install command in docs readme

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -7,10 +7,10 @@
 You may wish to launch a local version of our documentation website
 to test changes for formatting, link resolution, etc.
 
-Python 3 is requred:
+Python 3 is required:
 ```
 cd /path/to/wfl/docs
-python3 pip install -r requirements.txt
+pip3 install -r requirements.txt
 mkdocs serve
 ```
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -10,7 +10,7 @@ to test changes for formatting, link resolution, etc.
 Python 3 is required:
 ```
 cd /path/to/wfl/docs
-pip3 install -r requirements.txt
+python3 -m pip install -r requirements.txt
 mkdocs serve
 ```
 


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

When reviewing the [release candidate](https://github.com/broadinstitute/wfl/pull/415) I found that the readme I added for building our GitHub Pages documentation site had a broken command.

```
docs okotsopo$ python3 pip install -r requirements.txt
/usr/local/bin/python3: can't open file '/Users/okotsopo/wfl/docs/pip': [Errno 2] No such file or directory
```

I've fixed it here and would like to cherry-pick to the release branch. 
```
docs okotsopo$ python3 -m pip install -r requirements.txt
Requirement already satisfied: pymdown-extensions>="8.0" in…
```

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Fix broken requirements install command in `docs/readme.md`

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
