### PR TITLE
[GH-1361] Disable Failing Tests for v0.7.0 Release

### DIFF
--- a/api/test/wfl/integration/modules/arrays_test.clj
+++ b/api/test/wfl/integration/modules/arrays_test.clj
@@ -71,7 +71,7 @@
          (run! check-inputs workflows)
          (run! check-workflow workflows)))))
 
-(deftest test-update-arrays-workload!
+(deftest ^:excluded test-update-arrays-workload!
   (letfn [(check-status [status workflow]
             (is (= status (:status workflow))))]
     (with-redefs-fn {#'terra/get-workflow-status-by-entity mock-get-workflow-status-by-entity}


### PR DESCRIPTION
RR: https://broadinstitute.atlassian.net/browse/GH-1361
This is a low risk change for v0.7.0 as this test doess not exercise
reachable product code.
Disabling:
- wfl.integration.modules.arrays-test/test-update-arrays-workload!