### PR TITLE
[GH-1363] Fix Sporadic Firecloud Test Failures

### DIFF
--- a/api/src/wfl/util.clj
+++ b/api/src/wfl/util.clj
@@ -417,7 +417,7 @@
    [default: 3]."
   ([task! seconds max-attempts]
    (loop [attempt 1]
-     (if-let [result (task!)]
+     (if-some [result (task!)]
        result
        (do (when (<= max-attempts attempt)
              (throw (TimeoutException. "Max number of attempts exceeded")))

--- a/api/test/wfl/integration/firecloud_test.clj
+++ b/api/test/wfl/integration/firecloud_test.clj
@@ -1,10 +1,9 @@
 (ns wfl.integration.firecloud-test
-  (:require [clojure.test :refer [deftest is testing]]
-            [wfl.service.cromwell :as cromwell]
+  (:require [clojure.string        :as str]
+            [clojure.test          :refer [deftest is testing]]
+            [wfl.service.cromwell  :as cromwell]
             [wfl.service.firecloud :as firecloud]
-            [wfl.util :as util]
-            [clojure.tools.logging.readable :as log]
-            [clojure.string :as str])
+            [wfl.util              :as util])
   (:import [java.util UUID]))
 
 ;; Of the form NAMESPACE/NAME


### PR DESCRIPTION
RR: https://broadinstitute.atlassian.net/browse/GH-1363
Caused by firecloud returning "Launching" as a workflow status - we were
testing that the status was in #{"Queued" "Submitted"}.
Fix `util/poll` so logical FALSE can be returned from the action.

