### PR TITLE
GH-1332 wfl.tools.workloads/when-done should not exit prematurely

### DIFF
--- a/api/test/wfl/system/automation_test.clj
+++ b/api/test/wfl/system/automation_test.clj
@@ -32,7 +32,7 @@
 
 (defn clone-workspace []
   (println "Cloning workspace" workspace-to-clone)
-  (let [clone-name (util/randomize "wfl-dev/CDC_Viral_Sequencing_GP")]
+  (let [clone-name (util/randomize workspace-to-clone)]
     (firecloud/clone-workspace workspace-to-clone clone-name firecloud-group)
     (println "Cloned new workspace " clone-name)
     clone-name))
@@ -47,7 +47,7 @@
               :snapshots ["f9242ab8-c522-4305-966d-7c51419377ab"]}
    :executor {:name                       "Terra"
               :workspace                  workspace
-              :methodConfiguration        "cdc-covid-surveillance/sarscov2_illumina_full"
+              :methodConfiguration        "wfl-dev/sarscov2_illumina_full"
               :methodConfigurationVersion 1
               :fromSource                 "importSnapshot"}
    :sink     {:name           "Terra Workspace"
@@ -66,8 +66,8 @@
     (fixtures/with-fixtures
       [(util/bracket clone-workspace delete-workspace)]
       (fn [[workspace]]
-        (let [workload (endpoints/create-workload
-                        (covid-workload-request workspace))]
+        (let [workload (-> (covid-workload-request workspace)
+                           (endpoints/create-workload))]
           (endpoints/start-workload workload)
           (workloads/when-done
            (comp pprint/pprint endpoints/get-workflows)

--- a/api/test/wfl/system/automation_test.clj
+++ b/api/test/wfl/system/automation_test.clj
@@ -67,7 +67,7 @@
       [(util/bracket clone-workspace delete-workspace)]
       (fn [[workspace]]
         (let [workload (endpoints/create-workload
-                         (covid-workload-request workspace))]
+                        (covid-workload-request workspace))]
           (endpoints/start-workload workload)
           (workloads/when-done
            (comp pprint/pprint endpoints/get-workflows)

--- a/api/test/wfl/system/automation_test.clj
+++ b/api/test/wfl/system/automation_test.clj
@@ -66,8 +66,8 @@
     (fixtures/with-fixtures
       [(util/bracket clone-workspace delete-workspace)]
       (fn [[workspace]]
-        (let [workload (-> (covid-workload-request workspace)
-                           (endpoints/create-workload))]
+        (let [workload (endpoints/create-workload
+                         (covid-workload-request workspace))]
           (endpoints/start-workload workload)
           (workloads/when-done
            (comp pprint/pprint endpoints/get-workflows)


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1332

Previously `wfl.tools.workloads/when-done` terminated prematurely if called immediately after starting a workload, when a workload does not yet have workflows.  This behavior was obscured when interacting with the test in debug mode with breakpoints. 


### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

Within `wfl.tools.workloads/when-done`:
- If checking that all workloads are finished, also check that the workload list is nonempty
- Fixed incorrect reference to static `workload` object from workload creation: we instead want to examine the latest version of the workload

Within `wfl.system.automation-test`:
- Method configuration name was incorrect for the specified source workspace
- Workspace clone name uses source workspace name as its base

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

Assumes a running local WFL and Postgres, and that you're on this branch.  Trigger `wfl.system.automation-test/test-automate-sarscov2-illumina-full` without breakpoints.

If you are fast enough to abort the workload before it has any running workflows, the test will print the empty list of workloads and exit successfully (this does not count as a premature exit).
```
Testing wfl.system.automation-test
Cloning workspace wfl-dev/CDC_Viral_Sequencing
Cloned new workspace  wfl-dev/CDC_Viral_Sequencing37fed8aacdcf4638a267dc3127210142
06:28:54 INFO  wfl.tools.workloads - Waiting for workload "2b78a8d8-8ed5-42d6-b1fe-d72ffd535eb2" to complete
…
<I abort workload before its workflow can run>
…
[]
Deleting wfl-dev/CDC_Viral_Sequencing37fed8aacdcf4638a267dc3127210142

Process finished with exit code 0
```

If you abort the workload once it has a running workflow, once the workload is in a terminal state per Job Manager, observe that the test prints the workload's workflows and exits successfully.
```
Testing wfl.system.automation-test
Cloning workspace wfl-dev/CDC_Viral_Sequencing
Cloned new workspace  wfl-dev/CDC_Viral_Sequencing46d6a3da26e2414a86b34884f270c1b7
06:42:46 INFO  wfl.tools.workloads - Waiting for workload "c99b798b-c888-4637-8247-0e6591a34377" to complete
…
<I abort workload while its workload is running>
…
[{:inputs
  {:biosample_to_genbank.docker
   "quay.io/broadinstitute/viral-phylo:2.1.19.1",
   …},
  :uuid "6dbe0e2d-51f7-4ef8-b61b-1c7911358326",
  :status "Aborted",
  :outputs {},
  :updated "2021-06-08T22:46:46Z"}]
Deleting wfl-dev/CDC_Viral_Sequencing46d6a3da26e2414a86b34884f270c1b7

Process finished with exit code 0
```

If you trigger the test without any additional manual intervention, it will time out since our test snapshot's flowcell runs long:
```
Cloning workspace wfl-dev/CDC_Viral_Sequencing
Cloned new workspace  wfl-dev/CDC_Viral_Sequencing2f5a8ba283d043659c511a75afc0dd13
02:45:51 INFO  wfl.tools.workloads - Waiting for workload "e52c1b3b-fe1b-4976-9628-67300369af39" to complete
…
04:07:07 INFO  wfl.tools.workloads - Waiting for workload "e52c1b3b-fe1b-4976-9628-67300369af39" to complete
Deleting wfl-dev/CDC_Viral_Sequencing2f5a8ba283d043659c511a75afc0dd13
java.util.concurrent.TimeoutException: Timed out waiting for workload e52c1b3b-fe1b-4976-9628-67300369af39
…
Assertion failed with error:
Uncaught exception, not in assertion.
```
