### PR TITLE
Changing order of executor block in docs

### DIFF
--- a/docs/md/modules-covid.md
+++ b/docs/md/modules-covid.md
@@ -81,11 +81,11 @@ To give more information, here are some example inputs to the above endpoints:
                     ]
                 },
                 "executor": {
+                    "name": "Terra",
                     "workspace": "wfl-dev/CDC_Viral_Sequencing _ranthony_bashing_copy",
                     "methodConfiguration": "wfl-dev/sarscov2_illumina_full",
                     "methodConfigurationVersion": 2,
-                    "fromSource": "importSnapshot",
-                    "name": "Terra"
+                    "fromSource": "importSnapshot"
                 },
                 "sink": {
                     "name": "Terra Workspace",

--- a/docs/md/workload.md
+++ b/docs/md/workload.md
@@ -39,11 +39,11 @@ The specific values below are from the COVID-19 Surveillance in Terra project. W
         ]
     },
     "executor": {
+        "name": "Terra",
         "workspace": "wfl-dev/CDC_Viral_Sequencing",
         "methodConfiguration": "wfl-dev/sarscov2_illumina_full",
         "methodConfigurationVersion": 1,
-        "fromSource": "importSnapshot",
-        "name": "Terra"
+        "fromSource": "importSnapshot"
     },
     "sink": {
         "name": "Terra Workspace",


### PR DESCRIPTION
### Purpose
This is to reorder the fields in the documentation of the executor block for clarity

### Review Instructions
Please make sure that I didn't delete anything. 
