### PR TITLE
[GH-1401] Add `retry` Attribute to TerraExecutorDetails Type and Instances Thereof

### DIFF
--- a/api/src/wfl/executor.clj
+++ b/api/src/wfl/executor.clj
@@ -332,7 +332,10 @@
   [tx {:keys [details] :as executor}]
   (when-not (postgres/table-exists? tx details)
     (throw (ex-info "Missing executor details table" {:table details})))
-  (let [query "SELECT * FROM %s WHERE workflow IS NOT NULL ORDER BY id ASC"]
+  (let [query "SELECT * FROM %s
+               WHERE workflow IS NOT NULL
+               AND   retry    IS NULL
+               ORDER BY id ASC"]
     (terra-workflows-from-records
      executor
      (jdbc/query tx (format query details)))))
@@ -342,7 +345,9 @@
   (when-not (postgres/table-exists? tx details)
     (throw (ex-info "Missing executor details table" {:table details})))
   (let [query "SELECT * FROM %s
-               WHERE workflow IS NOT NULL AND status = ?
+               WHERE workflow IS NOT NULL
+               AND retry      IS NULL
+               AND status     = ?
                ORDER BY id ASC"]
     (terra-workflows-from-records
      executor

--- a/api/src/wfl/executor.clj
+++ b/api/src/wfl/executor.clj
@@ -331,7 +331,7 @@
 ;; terra-executor-workflows and terra-executor-workflows-by-status do not return
 ;; workflows that are being or have been retied. Why?
 ;;
-;; TL/DR: It's simpler.
+;; TL/DR: It's simpler maybe?
 ;;
 ;; The truth is I'm not sure of a *good* reason to do this.
 ;;

--- a/database/changelog.xml
+++ b/database/changelog.xml
@@ -39,4 +39,5 @@
     <include file="changesets/20210510_TerraWorkspaceSinkDetailsTable.xml"            relativeToChangelogFile="true"/>
     <include file="changesets/20210519_ListSourceType.xml"                            relativeToChangelogFile="true"/>
     <include file="changesets/20210519_TDRSnapshotListSourceEnum.xml"                 relativeToChangelogFile="true"/>
+    <include file="changesets/20210624_AddRetryToTerraExecutorDetails.xml"            relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/database/changesets/20210624_AddRetryToTerraExecutorDetails.xml
+++ b/database/changesets/20210624_AddRetryToTerraExecutorDetails.xml
@@ -1,0 +1,27 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext
+                        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
+                        http://www.liquibase.org/xml/ns/dbchangelog
+                        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+    <changeSet author="hornet@broadinstitute.org"
+               dbms="postgresql"
+               id="20210624"
+               logicalFilePath="20210624_AddRetryToTerraExecutorDetails.xml"
+               runInTransaction="false">
+        <comment>
+            Add a `retry` attribute to the `TerraExecutorDetails` type and all
+            instantiations thereof to support retries. This column holds the
+            row id of the workflow that the workflow was retied as, thus forming
+            a singly linked list tracing the retry history of a set of inputs.
+        </comment>
+        <sql>
+            ALTER TYPE TerraExecutorDetails
+            ADD ATTRIBUTE retry BIGINT
+            CASCADE;
+        </sql>
+    </changeSet>
+</databaseChangeLog>

--- a/makerules/modules.mk
+++ b/makerules/modules.mk
@@ -44,7 +44,7 @@ $(INTEGRATION): $(BUILD)
 $(IMAGES):      $(BUILD)
 $(SYSTEM):      $(BUILD)
 
-check: unit integration
+check: lint unit integration
 
 # Top level `make` targets depend on their corresponding time stamp.
 $(MAKE_TARGETS): % : $(DERIVED_MODULE_DIR)/%.$(TIMESTAMP)


### PR DESCRIPTION
RR: https://broadinstitute.atlassian.net/browse/GH-1401
Verified that this change affects all existing tables created from that type.
When workflows are requested, only the non-retried workflows are returned.
Note that unconsumed workflows are still visible to downstream. Note sure what the correct behaviour should be here.
