### PR TITLE
[GH-1398] Fix `test-start-aou-workload` from polling forever

### DIFF
--- a/api/test/wfl/system/v1_endpoint_test.clj
+++ b/api/test/wfl/system/v1_endpoint_test.clj
@@ -102,7 +102,7 @@
         (is (every? :updated workflows))
         (is (every? :uuid workflows)))
       (verify-internal-properties-removed workload)
-      (workloads/when-done verify-succeeded-workload workload))))
+      (workloads/when-all-workflows verify-succeeded-workload workload))))
 
 (deftest ^:parallel test-start-wgs-workload
   (test-start-workload (create-wgs-workload)))
@@ -160,7 +160,7 @@
         (is (every? :updated workflows))
         (is (every? :uuid workflows)))
       (verify-internal-properties-removed workload)
-      (workloads/when-done verify-succeeded-workload workload))))
+      (workloads/when-all-workflows verify-succeeded-workload workload))))
 
 (deftest ^:parallel test-exec-wgs-workload
   (test-exec-workload (workloads/wgs-workload-request (UUID/randomUUID))))
@@ -211,7 +211,7 @@
                (map (comp await :uuid))
                (every? #{"Succeeded"})))
       (->> (endpoints/get-workload-status (:uuid workload))
-           (workloads/when-done verify-succeeded-workload)))))
+           (workloads/when-all-workflows verify-succeeded-workload)))))
 
 (deftest test-bad-pipeline
   (let [request (-> (workloads/copyfile-workload-request

--- a/api/test/wfl/system/v1_endpoint_test.clj
+++ b/api/test/wfl/system/v1_endpoint_test.clj
@@ -102,7 +102,7 @@
         (is (every? :updated workflows))
         (is (every? :uuid workflows)))
       (verify-internal-properties-removed workload)
-      (workloads/when-all-workflows verify-succeeded-workload workload))))
+      (workloads/when-all-workflows-finish verify-succeeded-workload workload))))
 
 (deftest ^:parallel test-start-wgs-workload
   (test-start-workload (create-wgs-workload)))
@@ -160,7 +160,7 @@
         (is (every? :updated workflows))
         (is (every? :uuid workflows)))
       (verify-internal-properties-removed workload)
-      (workloads/when-all-workflows verify-succeeded-workload workload))))
+      (workloads/when-all-workflows-finish verify-succeeded-workload workload))))
 
 (deftest ^:parallel test-exec-wgs-workload
   (test-exec-workload (workloads/wgs-workload-request (UUID/randomUUID))))
@@ -211,7 +211,7 @@
                (map (comp await :uuid))
                (every? #{"Succeeded"})))
       (->> (endpoints/get-workload-status (:uuid workload))
-           (workloads/when-all-workflows verify-succeeded-workload)))))
+           (workloads/when-all-workflows-finish verify-succeeded-workload)))))
 
 (deftest test-bad-pipeline
   (let [request (-> (workloads/copyfile-workload-request

--- a/api/test/wfl/tools/workloads.clj
+++ b/api/test/wfl/tools/workloads.clj
@@ -252,7 +252,7 @@
     polling-interval-seconds
     max-polling-attempts)))
 
-(defn when-all-workflows
+(defn when-all-workflows-finish
   "Call `done!` when all workflows in the `workload` have finished processing."
   [done! {:keys [uuid] :as workload}]
   (let [finished? (let [skipped?    #(-> % :uuid util/uuid-nil?)

--- a/api/test/wfl/tools/workloads.clj
+++ b/api/test/wfl/tools/workloads.clj
@@ -238,27 +238,33 @@
                   :dbsnp_vcf_index         (str dbsnp ".tbi")
                   :input_cram              cram_path}}]}))
 
-(defn when-done
+(def ^:private polling-interval-seconds 60)
+(def ^:private max-polling-attempts 120)
+
+(defn when-finished
+  "Call `done!` when the `workload` is `:finished`."
+  [done! {:keys [uuid] :as _workload}]
+  (done!
+   (util/poll
+    #(let [workload (endpoints/get-workload-status uuid)]
+       (when (:finished workload)
+         workload))
+    polling-interval-seconds
+    max-polling-attempts)))
+
+(defn when-all-workflows
   "Call `done!` when all workflows in the `workload` have finished processing."
   [done! {:keys [uuid] :as workload}]
-  (letfn [(finished? [{:keys [status] :as workflow}]
-            (let [skipped? #(-> % :uuid util/uuid-nil?)]
-              (or (skipped? workflow) ((set cromwell/final-statuses) status))))]
-    (let [interval 60
-          timeout  4800]                ; 80 minutes
-      (loop [elapsed 0 wl workload]
-        (when (> elapsed timeout)
-          (throw (TimeoutException.
-                  (format "Timed out waiting for workload %s" uuid))))
-        (let [workflows (endpoints/get-workflows wl)]
-          (if (or (:finished wl)
-                  (and (not-empty workflows) (every? finished? workflows)))
-            (done! wl)
-            (do
-              (log/infof "Waiting for workload %s to complete" uuid)
-              (util/sleep-seconds interval)
-              (recur (+ elapsed interval)
-                     (endpoints/get-workload-status uuid)))))))))
+  (let [finished? (let [skipped?    #(-> % :uuid util/uuid-nil?)
+                        terminated? (set cromwell/final-statuses)]
+                    (fn [{:keys [status] :as workflow}]
+                      (or (skipped? workflow) (terminated? status))))]
+    (done!
+     (util/poll
+      #(when (every? finished? (endpoints/get-workflows workload))
+         (endpoints/get-workload-status uuid))
+      polling-interval-seconds
+      max-polling-attempts))))
 
 (defn ^:private transacted
   "Lift `operation` into the context of a database transaction."


### PR DESCRIPTION
RR: https://broadinstitute.atlassian.net/browse/GH-1398
Split `workloads/when-done` into two functions:
- one that polls until the workload is :finished
- another that polls all the workflows
Add an assertion to the automation-test

