### PR TITLE
Fix some namespace issues

### DIFF
--- a/api/src/wfl/api/spec.clj
+++ b/api/src/wfl/api/spec.clj
@@ -8,8 +8,9 @@
             [wfl.module.aou       :as aou]
             [wfl.module.copyfile  :as copyfile]
             [wfl.module.sg        :as sg]
-            [wfl.module.wgs       :as wgs]
             [wfl.module.xx        :as xx]
+            [wfl.module.wgs       :as wgs]
+            [wfl.source           :as source]
             [wfl.module.all       :as all]))
 
 (s/def ::workload-query (s/and (s/keys :opt-un [::all/uuid ::all/project])
@@ -26,7 +27,6 @@
                                            :version/user
                                            ::all/version]))
 
-;; compound
 (s/def ::items (s/* ::workload-inputs))
 (s/def ::workload-inputs (s/keys :req-un [::inputs]
                                  :opt-un [::all/options]))
@@ -39,9 +39,28 @@
 
 (s/def ::workflow  (s/keys :req-un [::inputs]
                            :opt-un [::all/status ::all/updated ::all/uuid ::all/options]))
+
+;; This is the wrong thing to do. See [1] for more information.
+;; As a consequence, I've included the keys for a covid pipeline as optional
+;; inputs for batch workloads so that these keys are not removed during
+;; coercion.
+;; [1]: https://github.com/metosin/reitit/issues/494
+(s/def :batch/workload-request
+  (s/keys :opt-un [::all/common
+                   ::all/input
+                   ::items
+                   ::all/labels
+                   ::all/output
+                   ::all/sink
+                   ::source/source
+                   ::all/watchers]
+          :req-un [(or ::all/cromwell ::batch/executor)
+                   ::all/pipeline
+                   ::all/project]))
+
 (s/def ::workflows (s/* ::workflow))
 
-(s/def ::workload-request (s/or :batch ::batch/workload-request
+(s/def ::workload-request (s/or :batch :batch/workload-request
                                 :covid ::covid/workload-request))
 
 (s/def ::workload-response (s/or :batch ::batch/workload-response

--- a/api/src/wfl/module/batch.clj
+++ b/api/src/wfl/module/batch.clj
@@ -20,24 +20,6 @@
 (s/def ::executor string?)
 (s/def ::creator string?)
 
-;; This is the wrong thing to do. See [1] for more information.
-;; As a consequence, I've included the keys for a covid pipeline as optional
-;; inputs for batch workloads so that these keys are not removed during
-;; coercion.
-;; [1]: https://github.com/metosin/reitit/issues/494
-(s/def ::workload-request
-  (s/keys :opt-un [::all/common
-                   ::all/input
-                   ::all/items
-                   ::all/labels
-                   ::all/output
-                   ::all/sink
-                   ::source/source
-                   ::all/watchers]
-          :req-un [(or ::all/cromwell ::executor)
-                   ::all/pipeline
-                   ::all/project]))
-
 (s/def ::workload-response (s/keys :opt-un [::all/finished
                                             ::all/input
                                             ::all/started

--- a/api/src/wfl/source.clj
+++ b/api/src/wfl/source.clj
@@ -31,7 +31,7 @@
           :opt-un [::snapshots]))
 
 (s/def ::snapshot-list-source
-  (s/keys :req-un [::name ::snapshots]))
+  (s/keys :req-un [::all/name ::snapshots]))
 
 (s/def ::source (s/or :dataset   ::tdr-source
                       :snapshots ::snapshot-list-source))


### PR DESCRIPTION
### Purpose
There were a few residual namespace issues resulting from splitting the specs out of the spec.clj file. This rectifies them.

- No ticket is linked to this PR.

### Changes
Fix straggler namespace issues

- No changes.

### Review Instructions


- No instructions.
