### PR TITLE
[GH-1409] Add Status Query String to workflows GET request

### DIFF
--- a/api/src/wfl/api/handlers.clj
+++ b/api/src/wfl/api/handlers.clj
@@ -66,11 +66,11 @@
   [request]
   (log/info (select-keys request [:request-method :uri :parameters]))
   (let [uuid (get-in request [:path-params :uuid])
-        {:keys [status]} (get-in request [:parameters :query])]
+        status (get-in request [:parameters :query :status])]
     (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
-      (->> (let [w (workloads/load-workload-for-uuid tx uuid)]
-             (cond status (workloads/workflows-by-status tx w status)
-                   :else  (workloads/workflows tx w)))
+      (->> (let [workload (workloads/load-workload-for-uuid tx uuid)]
+             (if status (workloads/workflows-by-status tx workload status)
+                 (workloads/workflows tx workload)))
            (mapv util/to-edn)
            succeed))))
 

--- a/api/src/wfl/api/handlers.clj
+++ b/api/src/wfl/api/handlers.clj
@@ -69,8 +69,7 @@
         status (get-in request [:parameters :query :status])]
     (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
       (->> (let [workload (workloads/load-workload-for-uuid tx uuid)]
-             (if status (workloads/workflows-by-status tx workload status)
-                 (workloads/workflows tx workload)))
+             (if status (workloads/workflows-by-status tx workload status) (workloads/workflows tx workload)))
            (mapv util/to-edn)
            succeed))))
 

--- a/api/src/wfl/api/routes.clj
+++ b/api/src/wfl/api/routes.clj
@@ -57,8 +57,7 @@
            :handler    handlers/get-workload}}]
    ["/api/v1/workload/:uuid/workflows"
     {:get {:summary    "Get workflows managed by the workload."
-           :parameters {:path {:uuid ::all/uuid} 
-                        :query ::spec/workflow-query}
+           :parameters {:path {:uuid ::all/uuid} :query ::spec/workflow-query}
            :responses  {200 {:body ::spec/workflows}}
            :handler    handlers/get-workflows}}]
    ["/api/v1/workload/:uuid/retry"

--- a/api/src/wfl/api/routes.clj
+++ b/api/src/wfl/api/routes.clj
@@ -57,7 +57,8 @@
            :handler    handlers/get-workload}}]
    ["/api/v1/workload/:uuid/workflows"
     {:get {:summary    "Get workflows managed by the workload."
-           :parameters {:path {:uuid ::all/uuid}}
+           :parameters {:path {:uuid ::all/uuid} 
+                        :query ::spec/workflow-query}
            :responses  {200 {:body ::spec/workflows}}
            :handler    handlers/get-workflows}}]
    ["/api/v1/workload/:uuid/retry"

--- a/api/src/wfl/api/spec.clj
+++ b/api/src/wfl/api/spec.clj
@@ -16,6 +16,8 @@
 (s/def ::workload-query (s/and (s/keys :opt-un [::all/uuid ::all/project])
                                #(not (and (:uuid %) (:project %)))))
 
+(s/def ::workflow-query (s/keys :opt-un [::all/status]))
+
 (s/def :version/built     util/datetime-string?)
 (s/def :version/commit    (s/and string? (comp not str/blank?)))
 (s/def :version/committed util/datetime-string?)

--- a/api/src/wfl/module/all.clj
+++ b/api/src/wfl/module/all.clj
@@ -112,7 +112,7 @@
 (s/def ::pipeline string?)
 (s/def ::project string?)
 (s/def ::release string?)
-(s/def ::status (set (conj (distinct (into cromwell/statuses rawls/statuses)) "skipped")))
+(s/def ::status (set (concat cromwell/statuses rawls/statuses ["skipped"])))
 (s/def ::started ::timestamp)
 (s/def ::stopped ::timestamp)
 (s/def ::updated ::timestamp)

--- a/api/src/wfl/module/all.clj
+++ b/api/src/wfl/module/all.clj
@@ -6,7 +6,8 @@
             [wfl.service.google.storage :as gcs]
             [wfl.util :as util]
             [wfl.wfl :as wfl]
-            [wfl.service.cromwell :as cromwell])
+            [wfl.service.cromwell :as cromwell]
+            [wfl.service.rawls :as rawls])
   (:import [java.util UUID]))
 
 (defn throw-when-output-exists-already!
@@ -111,7 +112,7 @@
 (s/def ::pipeline string?)
 (s/def ::project string?)
 (s/def ::release string?)
-(s/def ::status (set (conj cromwell/statuses "skipped")))
+(s/def ::status (set (conj (distinct (into cromwell/statuses rawls/statuses)) "skipped")))
 (s/def ::started ::timestamp)
 (s/def ::stopped ::timestamp)
 (s/def ::updated ::timestamp)

--- a/api/src/wfl/service/cromwell.clj
+++ b/api/src/wfl/service/cromwell.clj
@@ -20,10 +20,7 @@
   ["Aborting"
    "On Hold"
    "Running"
-   "Submitted"
-   "Queued",
-   "Launching",
-   "Unknown"])
+   "Submitted"])
 
 (def statuses
   "All the statuses a Cromwell workflow can have."

--- a/api/src/wfl/service/cromwell.clj
+++ b/api/src/wfl/service/cromwell.clj
@@ -18,9 +18,11 @@
 (def active-statuses
   "The statuses an active Cromwell workflow can have."
   ["Aborting"
-   "On Hold"
    "Running"
-   "Submitted"])
+   "Submitted"
+   "Queued",
+   "Launching",
+   "Unknown"])
 
 (def statuses
   "All the statuses a Cromwell workflow can have."

--- a/api/src/wfl/service/cromwell.clj
+++ b/api/src/wfl/service/cromwell.clj
@@ -18,6 +18,7 @@
 (def active-statuses
   "The statuses an active Cromwell workflow can have."
   ["Aborting"
+   "On Hold"
    "Running"
    "Submitted"
    "Queued",

--- a/api/src/wfl/service/rawls.clj
+++ b/api/src/wfl/service/rawls.clj
@@ -17,11 +17,11 @@
 
 (def active-statuses
   "The active statuses the Rawls workflow can have."
-  ["Queued"
+  ["Aborting"
    "Launching"
-   "Submitted"
+   "Queued"
    "Running"
-   "Aborting"
+   "Submitted"
    "Unknown"])
 
 (def statuses

--- a/api/src/wfl/service/rawls.clj
+++ b/api/src/wfl/service/rawls.clj
@@ -9,6 +9,25 @@
             [wfl.util             :as util])
   (:import [clojure.lang ExceptionInfo]))
 
+(def final-statuses 
+  "The final statuses the Rawls workflow can have."
+  ["Aborted"
+   "Failed"
+   "Succeeded"])
+
+(def active-statuses
+  "The active statuses the Rawls workflow can have."
+  ["Queued"
+   "Launching"
+   "Submitted"
+   "Running"
+   "Aborting"
+   "Unknown"])
+
+(def statuses
+  "All the statuses the Rawls workflow can have."
+  (into final-statuses active-statuses))
+
 (defn ^:private rawls-url [& parts]
   (let [url (util/de-slashify (env/getenv "WFL_RAWLS_URL"))]
     (str/join "/" (cons url parts))))

--- a/api/src/wfl/service/rawls.clj
+++ b/api/src/wfl/service/rawls.clj
@@ -9,8 +9,8 @@
             [wfl.util             :as util])
   (:import [clojure.lang ExceptionInfo]))
 
-(def final-statuses 
-  "The final statuses the Rawls workflow can have."
+(def final-statuses
+  "The final statuses a Rawls workflow can have."
   ["Aborted"
    "Failed"
    "Succeeded"])

--- a/api/src/wfl/util.clj
+++ b/api/src/wfl/util.clj
@@ -384,6 +384,15 @@
     (recur (subs url 0 (dec (count url))))
     url))
 
+(defn trim-slashes
+  "Trim the slashes from start and end of url part"
+  [part]
+  (let [new-start (if (and (str/starts-with? part "/") (not (= part "/"))) 1 0)
+        new-end (if (str/ends-with? part "/") (dec (count part)) (count part))]
+    (if (or (= new-start 1) (< new-end (count part)))
+      (recur (subs part new-start new-end))
+      part)))
+
 (defn bracket
   "`acquire`, `use` and `release` a resource in an exception-safe manner.
    Parameters

--- a/api/src/wfl/util.clj
+++ b/api/src/wfl/util.clj
@@ -387,7 +387,7 @@
 (defn trim-slashes
   "Trim the slashes from start and end of url part"
   [part]
-  (let [new-start (if (and (str/starts-with? part "/") (not (= part "/"))) 1 0)
+  (let [new-start (if (and (str/starts-with? part "/") (not= part "/")) 1 0)
         new-end (if (str/ends-with? part "/") (dec (count part)) (count part))]
     (if (or (= new-start 1) (< new-end (count part)))
       (recur (subs part new-start new-end))

--- a/api/test/wfl/system/v1_endpoint_test.clj
+++ b/api/test/wfl/system/v1_endpoint_test.clj
@@ -40,7 +40,7 @@
 
 (defn ^:private verify-workflows-by-status
   [workload status]
-  (run! #(is (= (:status %) status)) (endpoints/get-workflows-by-status workload status)))
+  (run! #(is (= (:status %) status)) (endpoints/get-workflows workload status)))
 
 (defn ^:private verify-internal-properties-removed [workload]
   (let [workflows (endpoints/get-workflows workload)]

--- a/api/test/wfl/system/v1_endpoint_test.clj
+++ b/api/test/wfl/system/v1_endpoint_test.clj
@@ -38,6 +38,10 @@
   (run! verify-succeeded-workflow (endpoints/get-workflows workload))
   (workloads/postcheck workload))
 
+(defn ^:private verify-workflows-by-status
+  [workload status]
+  (run! #(is (= (:status %) status)) (endpoints/get-workflows-by-status workload status)))
+
 (defn ^:private verify-internal-properties-removed [workload]
   (let [workflows (endpoints/get-workflows workload)]
     (letfn [(go! [key]
@@ -296,3 +300,11 @@
           (is (inst? created))
           (is (inst? started))
           (is (inst? stopped)))))))
+
+(deftest ^:parallel test-workflows-by-status
+  (testing "Get workflows by status"
+    (let [workload (first (endpoints/get-workloads))
+        workflows (endpoints/get-workflows workload)]
+    (->> (map #(get % :status) workflows)
+         (distinct)
+         (run! #(verify-workflows-by-status workload %))))))

--- a/api/test/wfl/system/v1_endpoint_test.clj
+++ b/api/test/wfl/system/v1_endpoint_test.clj
@@ -304,7 +304,7 @@
 (deftest ^:parallel test-workflows-by-status
   (testing "Get workflows by status"
     (let [workload (first (endpoints/get-workloads))
-        workflows (endpoints/get-workflows workload)]
-    (->> (map #(get % :status) workflows)
-         (distinct)
-         (run! #(verify-workflows-by-status workload %))))))
+          workflows (endpoints/get-workflows workload)]
+      (->> (map #(get % :status) workflows)
+           (distinct)
+           (run! #(verify-workflows-by-status workload %))))))

--- a/api/test/wfl/system/v1_endpoint_test.clj
+++ b/api/test/wfl/system/v1_endpoint_test.clj
@@ -38,10 +38,6 @@
   (run! verify-succeeded-workflow (endpoints/get-workflows workload))
   (workloads/postcheck workload))
 
-(defn ^:private verify-workflows-by-status
-  [workload status]
-  (run! #(is (= (:status %) status)) (endpoints/get-workflows workload status)))
-
 (defn ^:private verify-internal-properties-removed [workload]
   (let [workflows (endpoints/get-workflows workload)]
     (letfn [(go! [key]
@@ -301,10 +297,14 @@
           (is (inst? started))
           (is (inst? stopped)))))))
 
+(defn ^:private verify-workflows-by-status
+  [workload status]
+  (run! #(is (= (:status %) status)) (endpoints/get-workflows workload status)))
+
 (deftest ^:parallel test-workflows-by-status
   (testing "Get workflows by status"
     (let [workload (first (endpoints/get-workloads))
           workflows (endpoints/get-workflows workload)]
-      (->> (map #(get % :status) workflows)
+      (->> (map :status workflows)
            (distinct)
            (run! #(verify-workflows-by-status workload %))))))

--- a/api/test/wfl/tools/endpoints.clj
+++ b/api/test/wfl/tools/endpoints.clj
@@ -10,7 +10,7 @@
   "The WFL server URL to test."
   [& parts]
   (let [url (util/de-slashify (env/getenv "WFL_WFL_URL"))]
-    (str/join "/" (cons url parts))))
+    (str/join "/" (cons url (map #(util/trim-slashes %) parts)))))
 
 (defn get-oauth2-id
   "Query oauth2 ID that the server is currently using"
@@ -41,16 +41,9 @@
 
 (defn get-workflows
   "Query v1 api for all workflows managed by `_workload`."
-  [{:keys [uuid] :as _workload}]
+  [{:keys [uuid] :as _workload} & [status]]
   (-> (wfl-url "/api/v1/workload/" uuid "/workflows")
-      (http/get {:headers (auth/get-auth-header)})
-      util/response-body-json))
-
-(defn get-workflows-by-status
-  "Query v1 api for all workflows managed by `_workload` with a specific status."
-  [{:keys [uuid] :as _workload} status]
-  (-> (wfl-url "/api/v1/workload/" uuid "/workflows")
-      (http/get {:headers (auth/get-auth-header) :query-params {:status status}})
+      (http/get (merge {:headers (auth/get-auth-header)} (when status {:query-params {:status status}})))
       util/response-body-json))
 
 (defn create-workload

--- a/api/test/wfl/tools/endpoints.clj
+++ b/api/test/wfl/tools/endpoints.clj
@@ -46,6 +46,13 @@
       (http/get {:headers (auth/get-auth-header)})
       util/response-body-json))
 
+(defn get-workflows-by-status
+  "Query v1 api for all workflows managed by `_workload` with a specific status."
+  [{:keys [uuid] :as _workload} status]
+  (-> (wfl-url "/api/v1/workload/" uuid "/workflows?status=" status)
+      (http/get {:headers (auth/get-auth-header)})
+      util/response-body-json))
+
 (defn create-workload
   "Create workload defined by WORKLOAD"
   [workload]

--- a/api/test/wfl/tools/endpoints.clj
+++ b/api/test/wfl/tools/endpoints.clj
@@ -49,8 +49,8 @@
 (defn get-workflows-by-status
   "Query v1 api for all workflows managed by `_workload` with a specific status."
   [{:keys [uuid] :as _workload} status]
-  (-> (wfl-url "/api/v1/workload/" uuid "/workflows?status=" status)
-      (http/get {:headers (auth/get-auth-header)})
+  (-> (wfl-url "/api/v1/workload/" uuid "/workflows")
+      (http/get {:headers (auth/get-auth-header) :query-params {:status status}})
       util/response-body-json))
 
 (defn create-workload

--- a/api/test/wfl/tools/endpoints.clj
+++ b/api/test/wfl/tools/endpoints.clj
@@ -43,7 +43,8 @@
   "Query v1 api for all workflows managed by `_workload`."
   [{:keys [uuid] :as _workload} & [status]]
   (-> (wfl-url "/api/v1/workload/" uuid "/workflows")
-      (http/get (merge {:headers (auth/get-auth-header)} (when status {:query-params {:status status}})))
+      (http/get (merge {:headers (auth/get-auth-header)}
+                       (when status {:query-params {:status status}})))
       util/response-body-json))
 
 (defn create-workload

--- a/api/test/wfl/unit/utils_test.clj
+++ b/api/test/wfl/unit/utils_test.clj
@@ -74,3 +74,11 @@
                       [:membership "flowcell_set" membership]
                       [:membership "flowcell_set_id" membership]]]
       (run! go parameters))))
+
+(deftest test-trim-slashes
+  (is (= "wfl" (util/trim-slashes "/wfl")))
+  (is (= "wfl" (util/trim-slashes "/wfl/")))
+  (is (= "wfl" (util/trim-slashes "wfl/")))
+  (is (= "wfl" (util/trim-slashes "wfl")))
+  (is (= "" (util/trim-slashes "/")))
+  (is (= "" (util/trim-slashes "///"))))


### PR DESCRIPTION
### Purpose
Make it easier to filter workflows by status. Also in this PR is work to bring the cromwell statuses up to date.

- https://broadinstitute.atlassian.net/browse/GH-1409
- https://broadinstitute.atlassian.net/browse/GH-1410

### Changes

- Added new spec for a workflow query string
- Added query string to the route for GET workflows
- Modified the get-workflows handler function to call workflows-by-status if status is provided

### Review Instructions

- The workload/:uuid/workflows endpoint should work with status both provided and not provided. It should be verified that the endpoint returns results both when provided a status and not as well as verifying that it returns workflows with the correct status if it is provided.
