### PR TITLE
GH-1397: Sweep and snapshot dataset row IDs that were missed when polling a dataset

### DIFF
--- a/api/src/wfl/debug.clj
+++ b/api/src/wfl/debug.clj
@@ -11,10 +11,19 @@
        x#)))
 
 (defmacro trace
-  "Like DUMP but include location metadata."
+  "Like `dump` but include location metadata."
   [expression]
   (let [{:keys [line column]} (meta &form)]
     `(let [x# ~expression]
        (do
          (pprint {:column ~column :file ~*file* :line ~line '~expression x#})
+         x#))))
+
+(defmacro tap
+  "Like `trace` but use `clojure.core/tap>`."
+  [expression]
+  (let [{:keys [line column]} (meta &form)]
+    `(let [x# ~expression]
+       (do
+         (tap> {:column ~column :file ~*file* :line ~line '~expression x#})
          x#))))

--- a/api/src/wfl/debug.clj
+++ b/api/src/wfl/debug.clj
@@ -18,12 +18,3 @@
        (do
          (pprint {:column ~column :file ~*file* :line ~line '~expression x#})
          x#))))
-
-(defmacro tap
-  "Like `trace` but use `clojure.core/tap>`."
-  [expression]
-  (let [{:keys [line column]} (meta &form)]
-    `(let [x# ~expression]
-       (do
-         (tap> {:column ~column :file ~*file* :line ~line '~expression x#})
-         x#))))

--- a/api/src/wfl/server.clj
+++ b/api/src/wfl/server.clj
@@ -145,7 +145,7 @@
           (recur)))))
 
 (defn run
-  "Run child server in ENVIRONMENT on PORT."
+  "Run server in ENVIRONMENT on PORT."
   [& args]
   (log/info (str/join " " ["Run:" wfl/the-name "server" args]))
   (let [port    (util/is-non-negative! (first args))

--- a/api/src/wfl/source.clj
+++ b/api/src/wfl/source.clj
@@ -511,5 +511,4 @@
                  :end_time #inst "2021-07-21T18:12:58.077575000-00:00",
                  :id 3,
                  :consumed nil,
-                 :snapshot_creation_job_id "mock_job_id_2"}])
-  )
+                 :snapshot_creation_job_id "mock_job_id_2"}]))

--- a/api/src/wfl/source.clj
+++ b/api/src/wfl/source.clj
@@ -13,7 +13,7 @@
             [wfl.module.all        :as all])
   (:import [clojure.lang ExceptionInfo]
            [java.sql Timestamp]
-           [java.time Instant OffsetDateTime ZoneId]
+           [java.time OffsetDateTime ZoneId]
            [java.time.format DateTimeFormatter]
            [java.time.temporal ChronoUnit]
            [wfl.util UserException]))
@@ -158,9 +158,9 @@
       (assoc source :dataset dataset))))
 
 (defn combine-tdr-source-details
-  "Reduce to `result` by combining the Terra Data Repo source `detail`."
+  "Reduce to `result` by combining the Terra Data Repo source `_detail`."
   [result {:keys [datarepo_row_ids end_time snapshot_creation_job_status
-                  start_time] :as detail}]
+                  start_time] :as _detail}]
   (if (= "succeeded" snapshot_creation_job_status)
     (-> result
         (update :datarepo_row_ids into          datarepo_row_ids)
@@ -169,9 +169,9 @@
     result))
 
 (defn ^:private find-new-rows
-  "Query TDR for rows within `interval` that are new to `source`."
+  "Query TDR for rows within `_interval` that are new to `source`."
   [{:keys [dataset details table column] :as source}
-   [begin end                            :as interval]]
+   [begin end                            :as _interval]]
   (log/debug (format "%s Looking for rows in %s.%s between [%s, %s]..."
                      (log-prefix source) (:name dataset) table begin end))
   (let [wfl   (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]

--- a/api/src/wfl/source.clj
+++ b/api/src/wfl/source.clj
@@ -158,7 +158,9 @@
       (assoc source :dataset dataset))))
 
 (defn combine-tdr-source-details
-  "Reduce to `result` by combining the Terra Data Repo source `_detail`."
+  "Reduce to `result` by combining the Terra Data Repo source `_detail`.
+  Collect `datarepo_row_ids` already seen while preserving the latest
+  `end_time` and the earliest `start_time`."
   [result {:keys [datarepo_row_ids end_time snapshot_creation_job_status
                   start_time] :as _detail}]
   (if (#{"running" "succeeded"} snapshot_creation_job_status)
@@ -474,41 +476,3 @@
 (defoverload stage/done? tdr-snapshot-list-type  tdr-snapshot-list-done?)
 
 (defoverload util/to-edn tdr-snapshot-list-type tdr-snapshot-list-to-edn)
-
-(comment
-  (def details [{:updated #inst "2021-07-21T18:12:58.578753000-00:00",
-                 :start_time #inst "2021-07-21T18:12:58.068140000-00:00",
-                 :snapshot_id "47cd816d-5c9f-4468-bc2a-cee00cfffe89",
-                 :datarepo_row_ids
-                 ["e60f8156-c35c-4f10-b8cf-21fb5905d68b"
-                  ,,,
-                  "8730e957-8e55-4f8a-9c27-eb6816098e5c"],
-                 :snapshot_creation_job_status "succeeded",
-                 :end_time #inst "2021-07-21T18:12:58.077575000-00:00",
-                 :id 1,
-                 :consumed nil,
-                 :snapshot_creation_job_id "mock_job_id_0"}
-                {:updated #inst "2021-07-21T18:12:58.709609000-00:00",
-                 :start_time #inst "2021-07-21T18:12:58.068140000-00:00",
-                 :snapshot_id "17c00f44-3404-4401-aa11-c6f1c84b7192",
-                 :datarepo_row_ids
-                 ["4eab02fb-4d63-4fc1-b487-22db54a90d2f"
-                  ,,,
-                  "5f5862ae-f579-4083-9b25-b039780e1b6d"],
-                 :snapshot_creation_job_status "succeeded",
-                 :end_time #inst "2021-07-21T18:12:58.077575000-00:00",
-                 :id 2,
-                 :consumed nil,
-                 :snapshot_creation_job_id "mock_job_id_1"}
-                {:updated #inst "2021-07-21T18:12:58.775861000-00:00",
-                 :start_time #inst "2021-07-21T18:12:58.068140000-00:00",
-                 :snapshot_id "dac97a4d-ef77-46da-8956-8d2354d68bcd",
-                 :datarepo_row_ids
-                 ["f25f0764-5fcc-4376-b9dc-6e78f5d8e6cf"
-                  ,,,
-                  "6ce89f55-6d27-4146-9ff7-bd47226818b9"],
-                 :snapshot_creation_job_status "succeeded",
-                 :end_time #inst "2021-07-21T18:12:58.077575000-00:00",
-                 :id 3,
-                 :consumed nil,
-                 :snapshot_creation_job_id "mock_job_id_2"}]))

--- a/api/src/wfl/source.clj
+++ b/api/src/wfl/source.clj
@@ -161,7 +161,7 @@
   "Reduce to `result` by combining the Terra Data Repo source `_detail`."
   [result {:keys [datarepo_row_ids end_time snapshot_creation_job_status
                   start_time] :as _detail}]
-  (if (= "succeeded" snapshot_creation_job_status)
+  (if (#{"running" "succeeded"} snapshot_creation_job_status)
     (-> result
         (update :datarepo_row_ids into          datarepo_row_ids)
         (update :end_time         util/latest   end_time)

--- a/api/src/wfl/source.clj
+++ b/api/src/wfl/source.clj
@@ -151,7 +151,7 @@
 (defn ^:private find-new-rows
   "Query TDR for rows within `interval` that are new to `source`."
   [{:keys [dataset details table column] :as source}
-   [       start   end                   :as interval]]
+   [start   end                   :as interval]]
   (log/debug (format "%s Looking for rows in %s.%s between [%s, %s]..."
                      (log-prefix source) (:name dataset) table start end))
   (let [tdr (-> dataset

--- a/api/src/wfl/source.clj
+++ b/api/src/wfl/source.clj
@@ -259,7 +259,7 @@
   "Create and enqueue snapshots from new rows in the `source` dataset."
   [{:keys [dataset table last_checked] :as source} utc-now]
   (let [checked      (timestamp-to-offsetdatetime last_checked)
-        hours-ago    (* 2 (max 1 (. ChronoUnit/HOURS between checked utc-now)))
+        hours-ago    (* 2 (max 1 (.between ChronoUnit/HOURS checked utc-now)))
         then         (.minusHours utc-now hours-ago)
         shards->jobs (->> [then utc-now]
                           (mapv #(.format % bigquery-datetime-format))

--- a/api/src/wfl/util.clj
+++ b/api/src/wfl/util.clj
@@ -1,13 +1,13 @@
 (ns wfl.util
   "Some utilities shared across this program."
-  (:require [clojure.data.csv      :as csv]
-            [clojure.data.json     :as json]
-            [clojure.java.io       :as io]
-            [clojure.java.shell    :as shell]
-            [clojure.spec.alpha    :as s]
-            [clojure.string        :as str]
-            [wfl.log               :as log]
-            [wfl.wfl               :as wfl])
+  (:require [clojure.data.csv   :as csv]
+            [clojure.data.json  :as json]
+            [clojure.java.io    :as io]
+            [clojure.java.shell :as shell]
+            [clojure.spec.alpha :as s]
+            [clojure.string     :as str]
+            [wfl.log            :as log]
+            [wfl.wfl            :as wfl])
   (:import [java.io File IOException StringWriter Writer]
            [java.nio.file Files]
            [java.nio.file.attribute FileAttribute]
@@ -15,10 +15,6 @@
            [java.time.temporal ChronoUnit]
            [java.util ArrayList Collections Random UUID]
            [java.util.concurrent TimeUnit TimeoutException]
-           [java.util.zip ZipOutputStream ZipEntry]
-           [org.apache.commons.io FilenameUtils]
-           [java.time OffsetDateTime]
-           [java.util UUID]
            [javax.mail.internet InternetAddress]
            [org.apache.commons.io FilenameUtils])
   (:gen-class))
@@ -139,17 +135,6 @@
         (let [target (io/file dest (unprefix (.getPath file) prefix))]
           (io/make-parents target)
           (io/copy file target))))))
-
-(defn zip-files
-  "Return ZIP with named FILES zipped into it."
-  [^File zip & files]
-  (with-open [out (ZipOutputStream. (io/output-stream zip))]
-    (doseq [file files]
-      (let [import (io/file file)]
-        (with-open [in (io/reader import)]
-          (.putNextEntry out (ZipEntry. (.getName import)))
-          (io/copy in out)))))
-  zip)
 
 (defn sleep-seconds
   "Sleep for N seconds."
@@ -603,3 +588,13 @@
   "Return OffsetDateTime/now in UTC."
   []
   (OffsetDateTime/now (ZoneId/of "UTC")))
+
+(defn earliest
+  "Return the earliest time of `instants`."
+  [& instants]
+  (first (sort instants)))
+
+(defn latest
+  "Return the latest time of `instants`."
+  [& instants]
+  (last (sort instants)))

--- a/api/test/wfl/integration/datarepo_test.clj
+++ b/api/test/wfl/integration/datarepo_test.clj
@@ -17,8 +17,9 @@
 
 (def ^:private testing-dataset {:id "4a5d30fe-1f99-42cd-998b-a979885dea00"
                                 :name "workflow_launcher_testing_dataset"})
-(def ^:private testing-snapshot {:id "0ef4bc30-b8a0-4782-b178-e6145b777404"
-                                 :name "workflow_launcher_testing_dataset7561609c9bb54ca6b34a12156dc947c1"})
+(def ^:private testing-snapshot
+  {:id "0ef4bc30-b8a0-4782-b178-e6145b777404"
+   :name "workflow_launcher_testing_dataset7561609c9bb54ca6b34a12156dc947c1"})
 
 (deftest test-create-dataset
   ;; To test that your dataset json file is valid, add its path to the list!
@@ -150,9 +151,8 @@
   (let [dataset-table "flowcells"
         entity        "flowcell"
         from-dataset  (resources/read-resource "entity-from-dataset.edn")
-        columns       (-> (firecloud/list-entity-types "pathogen-genomic-surveillance/CDC_Viral_Sequencing_dev")
-                          :flowcell
-                          entity-columns)]
+        columns       (-> "pathogen-genomic-surveillance/CDC_Viral_Sequencing_dev"
+                          firecloud/list-entity-types :flowcell entity-columns)]
     (fixtures/with-temporary-workspace
       (fn [workspace]
         (let [entities (-> (datarepo/snapshot (:id testing-snapshot))

--- a/api/test/wfl/integration/modules/covid_test.clj
+++ b/api/test/wfl/integration/modules/covid_test.clj
@@ -23,9 +23,11 @@
 
 ;; Snapshot creation mock
 (def ^:private mock-new-rows-size 2021)
+
 (defn ^:private mock-find-new-rows [_ interval]
   (is (every? #(LocalDateTime/parse % @#'source/bigquery-datetime-format) interval))
   (take mock-new-rows-size (range)))
+
 (defn ^:private mock-create-snapshots [_ _ row-ids]
   (letfn [(f [idx shard] [(vec shard) (format "mock_job_id_%s" idx)])]
     (->> (partition-all 500 row-ids)

--- a/api/test/wfl/integration/modules/covid_test.clj
+++ b/api/test/wfl/integration/modules/covid_test.clj
@@ -23,11 +23,9 @@
 
 ;; Snapshot creation mock
 (def ^:private mock-new-rows-size 2021)
-
 (defn ^:private mock-find-new-rows [_ interval]
   (is (every? #(LocalDateTime/parse % @#'source/bigquery-datetime-format) interval))
   (take mock-new-rows-size (range)))
-
 (defn ^:private mock-create-snapshots [_ _ row-ids]
   (letfn [(f [idx shard] [(vec shard) (format "mock_job_id_%s" idx)])]
     (->> (partition-all 500 row-ids)

--- a/api/test/wfl/integration/modules/covid_test.clj
+++ b/api/test/wfl/integration/modules/covid_test.clj
@@ -18,8 +18,8 @@
             [wfl.tools.workloads            :as workloads]
             [wfl.util                       :as util])
   (:import [java.time LocalDateTime]
-           [java.util ArrayDeque UUID]
-           [wfl.util UserException]))
+           [java.util UUID]
+           [wfl.util  UserException]))
 
 ;; Snapshot creation mock
 (def ^:private mock-new-rows-size 2021)

--- a/api/test/wfl/integration/source_test.clj
+++ b/api/test/wfl/integration/source_test.clj
@@ -91,14 +91,6 @@
         (update-in [:rows 0] replace keys)
         (assoc :totalRows (str (count keys))))))
 
-(comment
-  (clojure.string/join
-   \space ["clojure" "-M:test" "--no-capture-output"
-           "--reporter" "documentation"
-           "--focus" "wfl.integration.source-test/test-backfill-tdr-source"])
-  (clojure.test/test-vars  [#'test-backfill-tdr-source])
-  :fnord)
-
 (deftest test-backfill-tdr-source
   (letfn [(rows-from [source]
             (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]

--- a/api/test/wfl/integration/source_test.clj
+++ b/api/test/wfl/integration/source_test.clj
@@ -108,7 +108,7 @@
           (make-bigquery-timestamp []
             (-> (Instant/now) str (subs 0 (count "2021-07-14T15:47:02"))))
           (total-rows [query args]
-            (-> query (apply args) :totalRows Integer.))
+            (-> query (apply args) :totalRows Integer/parseInt))
           (update-source [source mock-query-table-between]
             (with-redefs [datarepo/query-table-between mock-query-table-between
                           source/check-tdr-job         mock-check-tdr-job

--- a/api/test/wfl/integration/source_test.clj
+++ b/api/test/wfl/integration/source_test.clj
@@ -3,7 +3,6 @@
             [clojure.java.jdbc     :as jdbc]
             [clojure.set           :as set]
             [clojure.spec.alpha    :as s]
-            [wfl.debug]
             [wfl.service.datarepo  :as datarepo]
             [wfl.service.postgres  :as postgres]
             [wfl.source            :as source]
@@ -129,12 +128,9 @@
             (let [all-rows (rows-from source)
                   all-set  (set all-rows)
                   missing  (set/difference all-set miss-set)]
-              (wfl.debug/trace missing)
               (is (== (inc record-count) (stage/queue-length source)))
               (is (== mock-new-rows-size (total-rows datarepo-query-table-between-all args)))
               (is (=  (first missing) (last all-rows)))
-              (wfl.debug/trace (first missing))
-              (wfl.debug/trace (last all-rows))
               (is (== 1 (count missing))))))))))
 
 (deftest test-create-tdr-source-from-valid-request

--- a/api/test/wfl/integration/source_test.clj
+++ b/api/test/wfl/integration/source_test.clj
@@ -85,7 +85,6 @@
       (update-in [:rows 0] butlast)
       (assoc :totalRows (str (dec mock-new-rows-size)))))
 
-;;234567890123456789012345678901234567890123456789012345678901234567890123456789
 (deftest test-backfill-tdr-source
   (letfn [(rows-from [source]
             (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]

--- a/api/test/wfl/integration/source_test.clj
+++ b/api/test/wfl/integration/source_test.clj
@@ -11,7 +11,7 @@
             [wfl.util              :as util])
   (:import [java.time Instant LocalDateTime]
            [java.util UUID]
-           [wfl.util UserException]))
+           [wfl.util  UserException]))
 
 (def ^:private testing-dataset "cd25d59e-1451-44d0-8a24-7669edb9a8f8")
 (def ^:private testing-snapshot "e8f1675e-1e7c-48b4-92ab-3598425c149d")

--- a/api/test/wfl/integration/source_test.clj
+++ b/api/test/wfl/integration/source_test.clj
@@ -3,7 +3,6 @@
             [clojure.java.jdbc     :as jdbc]
             [clojure.set           :as set]
             [clojure.spec.alpha    :as s]
-            [wfl.debug]
             [wfl.service.datarepo  :as datarepo]
             [wfl.service.postgres  :as postgres]
             [wfl.source            :as source]
@@ -70,7 +69,6 @@
 (defn ^:private mock-query-table-between-all
   "Mock datarepo/query-table-between to find all rows."
   [_dataset _table _between interval columns]
-  (wfl.debug/trace interval)
   (is (every? parse-timestamp interval))
   (letfn [(field [column] {:mode "NULLABLE" :name column :type "STRING"})
           (fields [columns] (mapv field columns))]

--- a/api/test/wfl/integration/source_test.clj
+++ b/api/test/wfl/integration/source_test.clj
@@ -18,9 +18,11 @@
 
 ;; Snapshot creation mock
 (def ^:private mock-new-rows-size 2021)
+
 (defn ^:private mock-find-new-rows [_ interval]
   (is (every? #(LocalDateTime/parse % @#'source/bigquery-datetime-format) interval))
-  (take mock-new-rows-size (range)))
+  (range mock-new-rows-size))
+
 (defn ^:private mock-create-snapshots [_ _ row-ids]
   (letfn [(f [idx shard] [(vec shard) (format "mock_job_id_%s" idx)])]
     (->> (partition-all 500 row-ids)

--- a/api/test/wfl/integration/source_test.clj
+++ b/api/test/wfl/integration/source_test.clj
@@ -140,7 +140,7 @@
               (is (== all-count (count all-set)))
               (is (== (-> (partial > mock-new-rows-size)
                           (take-while fibonacci)
-                          set count)
+                          distinct count)
                       (count (set/difference all-set miss-set)))))))))))
 
 (deftest test-create-tdr-source-from-valid-request

--- a/api/test/wfl/integration/source_test.clj
+++ b/api/test/wfl/integration/source_test.clj
@@ -89,7 +89,7 @@
         keys (remove (set miss) (range mock-new-rows-size))]
     (-> (datarepo-query-table-between-all dataset table between interval columns)
         (update-in [:rows 0] replace keys)
-        (assoc :totalRows (str (count keys)))))  )
+        (assoc :totalRows (str (count keys))))))
 
 (comment
   (clojure.string/join
@@ -111,7 +111,7 @@
             (-> query (apply args) :totalRows Integer.))
           (update-source [source mock-query-table-between]
             (with-redefs [datarepo/query-table-between mock-query-table-between
-                          source/check-tdr-job         mock-check-tdr-job        
+                          source/check-tdr-job         mock-check-tdr-job
                           source/create-snapshots      mock-create-snapshots]
               (source/update-source!
                (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
@@ -181,10 +181,6 @@
       (source/start-source! tx source)
       (is (:last_checked (reload-source tx source))
           ":last_checked was not updated"))))
-
-(comment
-  (clojure.test/test-vars  [#'test-update-tdr-source])
-  )
 
 (deftest test-update-tdr-source
   (let [source               (create-tdr-source)

--- a/api/test/wfl/tools/fixtures.clj
+++ b/api/test/wfl/tools/fixtures.clj
@@ -1,15 +1,14 @@
 (ns wfl.tools.fixtures
   (:require [clojure.java.jdbc]
-            [clojure.pprint             :as pprint]
+            [wfl.environment            :as env]
+            [wfl.jdbc                   :as jdbc]
             [wfl.service.datarepo       :as datarepo]
+            [wfl.service.firecloud      :as firecloud]
             [wfl.service.google.pubsub  :as pubsub]
             [wfl.service.google.storage :as gcs]
             [wfl.service.postgres       :as postgres]
             [wfl.tools.liquibase        :as liquibase]
-            [wfl.jdbc                   :as jdbc]
-            [wfl.util                   :as util]
-            [wfl.environment            :as env]
-            [wfl.service.firecloud      :as firecloud])
+            [wfl.util                   :as util])
   (:import [java.nio.file.attribute FileAttribute]
            [java.nio.file Files]
            [java.util UUID]
@@ -237,11 +236,3 @@
   "Adapter for clojure.test/use-fixtures"
   [env]
   (partial with-temporary-environment env))
-
-(defn pprint-tap
-  "Pretty-print the `tap>` stream."
-  [f]
-  (let [pprint (bound-fn* pprint/pprint)]
-    (try (add-tap pprint)
-         (f)
-         (finally (remove-tap pprint)))))

--- a/api/test/wfl/tools/fixtures.clj
+++ b/api/test/wfl/tools/fixtures.clj
@@ -1,5 +1,6 @@
 (ns wfl.tools.fixtures
   (:require [clojure.java.jdbc]
+            [clojure.pprint             :as pprint]
             [wfl.service.datarepo       :as datarepo]
             [wfl.service.google.pubsub  :as pubsub]
             [wfl.service.google.storage :as gcs]
@@ -236,3 +237,11 @@
   "Adapter for clojure.test/use-fixtures"
   [env]
   (partial with-temporary-environment env))
+
+(defn pprint-tap
+  "Pretty-print the `tap>` stream."
+  [f]
+  (let [pprint (bound-fn* pprint/pprint)]
+    (try (add-tap pprint)
+         (f)
+         (finally (remove-tap pprint)))))

--- a/docs/md/dev-process.md
+++ b/docs/md/dev-process.md
@@ -131,7 +131,6 @@ For the release process, please refer to the [release guide](./dev-release.md).
 11. Merge the PR.
 
 
-
 ## Development Tips
 
 Here are some tips for WFL development.
@@ -224,6 +223,44 @@ If an API references an undefined spec, HTTP requests and responses might
 silently fail or the Swagger page will fail to render. Check the
 `clojure.spec.alpha/def`s in `wfl.api.routes` for typos before tearing your
 hair out.
+
+You can quickly check that the Swagger page renders
+by first starting a local WFL server.
+
+``` shell
+./ops/server.sh
+```
+
+Then open this URL in a browser.
+
+``` shell
+open http://localhost:3000/swagger/swagger.json
+```
+
+You should see a page of valid Swagger JSON
+describing the API.
+
+You need to start the UI server too
+if you want to see the swagger page rendered.
+With the local WFL server running on port 3000 as above,
+start the UI this way.
+
+``` shell
+cd ./ui
+npm run serve
+```
+
+With the UI running,
+open this URL in the browser.
+
+``` shell
+open http://localhost:8080/
+```
+
+Click the `LOGIN WITH GOOGLE` button if necessary,
+Then the `SWAGGER API` button at the upper right.
+You should see an interactive Swagger API page.
+
 
 ### debugging Liquibase locally
 


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1397

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Document Swagger validation of API specs.
- Mock snapshot missing TDR rows.
- Expand query interval and filter out old rows.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- Start with wfl.integration.source-test/test-backfill-tdr-source.
- Evaluate how it mocks the problem.
- In wfl.source, evaluate how changes to find-new-rows and find-and-snapshot-new-rows address the problem.
- Perhaps back out wfl.source commits and watch the test-backfill-tdr-source test fail for more understanding.
