### PR TITLE
Remove trim-slashes and fix endpoints in wfl.tools namespace

### DIFF
--- a/api/src/wfl/util.clj
+++ b/api/src/wfl/util.clj
@@ -384,15 +384,6 @@
     (recur (subs url 0 (dec (count url))))
     url))
 
-(defn trim-slashes
-  "Trim the slashes from start and end of url part"
-  [part]
-  (let [new-start (if (and (str/starts-with? part "/") (not= part "/")) 1 0)
-        new-end (if (str/ends-with? part "/") (dec (count part)) (count part))]
-    (if (or (= new-start 1) (< new-end (count part)))
-      (recur (subs part new-start new-end))
-      part)))
-
 (defn bracket
   "`acquire`, `use` and `release` a resource in an exception-safe manner.
    Parameters

--- a/api/test/wfl/tools/endpoints.clj
+++ b/api/test/wfl/tools/endpoints.clj
@@ -10,12 +10,12 @@
   "The WFL server URL to test."
   [& parts]
   (let [url (util/de-slashify (env/getenv "WFL_WFL_URL"))]
-    (str/join "/" (cons url (map #(util/trim-slashes %) parts)))))
+    (str/join "/" (cons url parts))))
 
 (defn get-oauth2-id
   "Query oauth2 ID that the server is currently using"
   []
-  (-> (http/get (wfl-url "/oauth2id"))
+  (-> (http/get (wfl-url "oauth2id"))
       util/response-body-json
       first))
 
@@ -27,7 +27,7 @@
 (defn get-workload-status
   "Query v1 api for the status of the workload with UUID"
   [uuid]
-  (-> (wfl-url "/api/v1/workload")
+  (-> (wfl-url "api/v1/workload")
       (http/get {:headers (auth/get-auth-header) :query-params {:uuid uuid}})
       util/response-body-json
       first))
@@ -35,14 +35,14 @@
 (defn get-workloads
   "Query v1 api for all workloads"
   []
-  (-> (wfl-url "/api/v1/workload")
+  (-> (wfl-url "api/v1/workload")
       (http/get {:headers (auth/get-auth-header)})
       util/response-body-json))
 
 (defn get-workflows
   "Query v1 api for all workflows managed by `_workload`."
   [{:keys [uuid] :as _workload} & [status]]
-  (-> (wfl-url "/api/v1/workload/" uuid "/workflows")
+  (-> (wfl-url "api/v1/workload" uuid "workflows")
       (http/get (merge {:headers (auth/get-auth-header)}
                        (when status {:query-params {:status status}})))
       util/response-body-json))
@@ -50,7 +50,7 @@
 (defn create-workload
   "Create workload defined by WORKLOAD"
   [workload]
-  (-> (wfl-url "/api/v1/create")
+  (-> (wfl-url "api/v1/create")
       (http/post {:headers      (auth/get-auth-header)
                   :content-type :application/json
                   :body         (json/write-str workload :escape-slash false)})
@@ -61,7 +61,7 @@
   [workload]
   (let [payload (-> (select-keys workload [:uuid])
                     (json/write-str :escape-slash false))]
-    (-> (wfl-url "/api/v1/start")
+    (-> (wfl-url "api/v1/start")
         (http/post {:headers      (auth/get-auth-header)
                     :content-type :application/json
                     :body         payload})
@@ -71,7 +71,7 @@
   "Stop processing WORKLOAD. WORKLOAD must be known to the server."
   [workload]
   (let [payload (json/write-str (select-keys workload [:uuid]))]
-    (-> (wfl-url "/api/v1/stop")
+    (-> (wfl-url "api/v1/stop")
         (http/post {:headers      (auth/get-auth-header)
                     :content-type :application/json
                     :body         payload})
@@ -83,7 +83,7 @@
   (let [payload (-> (select-keys workload [:uuid])
                     (assoc :notifications samples)
                     (json/write-str :escape-slash false))]
-    (-> (wfl-url "/api/v1/append_to_aou")
+    (-> (wfl-url "api/v1/append_to_aou")
         (http/post {:headers      (auth/get-auth-header)
                     :content-type :application/json
                     :body         payload})
@@ -93,7 +93,7 @@
   "Create and start workload defined by `workload-request`."
   [workload-request]
   (let [payload (json/write-str workload-request :escape-slash false)]
-    (-> (wfl-url "/api/v1/exec")
+    (-> (wfl-url "api/v1/exec")
         (http/post {:headers      (auth/get-auth-header)
                     :content-type :application/json
                     :body         payload})
@@ -102,7 +102,7 @@
 (defn retry-workflows
   "Retry the workflows in `_workload` by `status`."
   [{:keys [uuid] :as _workload} status]
-  (-> (wfl-url "/api/v1/workload/" uuid "/retry")
+  (-> (wfl-url "api/v1/workload" uuid "retry")
       (http/post {:headers      (auth/get-auth-header)
                   :content-type :application/json
                   :body         (json/write-str {:status status})})

--- a/api/test/wfl/unit/utils_test.clj
+++ b/api/test/wfl/unit/utils_test.clj
@@ -74,11 +74,3 @@
                       [:membership "flowcell_set" membership]
                       [:membership "flowcell_set_id" membership]]]
       (run! go parameters))))
-
-(deftest test-trim-slashes
-  (is (= "wfl" (util/trim-slashes "/wfl")))
-  (is (= "wfl" (util/trim-slashes "/wfl/")))
-  (is (= "wfl" (util/trim-slashes "wfl/")))
-  (is (= "wfl" (util/trim-slashes "wfl")))
-  (is (= "" (util/trim-slashes "/")))
-  (is (= "" (util/trim-slashes "///"))))


### PR DESCRIPTION
### Purpose
Updates the wfl-url function in the endpoints namespace to not use trim-slashes and removes the trim-slashes function from util.

- No ticket is linked to this PR.

### Changes
- Remove trim-slashes function and unit test
- Remove use of trim-slashes from wfl-url
- Update endpoints in wfl.tools.endpoints by removing slashes from beginning and end of the url parts

### Review Instructions

- No instructions.
