### PR TITLE
Logging added to source ns

### DIFF
--- a/api/resources/log4j2.xml
+++ b/api/resources/log4j2.xml
@@ -5,7 +5,7 @@ Its syntax is given by https://logging.apache.org/log4j/2.x/manual/configuration
 -->
 <Configuration status="WARN">
     <Properties>
-        <Property name="pattern">%d{hh:mm:ss} %-5level %logger{36} - %msg%n</Property>
+        <Property name="pattern">%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n</Property>
     </Properties>
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">

--- a/api/src/wfl/environment.clj
+++ b/api/src/wfl/environment.clj
@@ -69,4 +69,5 @@
 (defn getenv
   "Lookup the value of the environment variable specified by `name`."
   [name]
+  (log/tracef "Reading environment variable %s" name)
   (or (@testing name) (__getenv name)))

--- a/api/src/wfl/environment.clj
+++ b/api/src/wfl/environment.clj
@@ -69,5 +69,4 @@
 (defn getenv
   "Lookup the value of the environment variable specified by `name`."
   [name]
-  (log/debugf "Reading environment variable %s" name)
   (or (@testing name) (__getenv name)))

--- a/api/src/wfl/jdbc.clj
+++ b/api/src/wfl/jdbc.clj
@@ -134,9 +134,9 @@
   [binding & body]
   `(let [id#    (rand-int 10000)
          init# ~(second binding)]
-     (log/info "JDBC transaction" id# "started to" (format-db init#))
+     (log/trace "JDBC transaction" id# "started to" (format-db init#))
      (let [exe# (jdbc/with-db-transaction [~(first binding) init#] ~@body)]
-       (log/info "JDBC SQL transaction" id# "ended")
+       (log/trace "JDBC SQL transaction" id# "ended")
        exe#)))
 
 (defmacro prepare-statement

--- a/api/src/wfl/server.clj
+++ b/api/src/wfl/server.clj
@@ -89,6 +89,7 @@
             (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
               (let [{:keys [watchers] :as workload}
                     (workloads/load-workload-for-id tx id)]
+                (log/infof "Updating workload %s" uuid)
                 (try
                   (workloads/update-workload! tx workload)
                   (catch UserException e
@@ -99,11 +100,11 @@
             (try
               (do-update! workload)
               (catch Throwable t
-                (log/error "Failed to update workload %s" uuid)
+                (log/errorf "Failed to update workload %s" uuid)
                 (log/error t))))
           (update-workloads []
             (try
-              (log/info "updating workloads")
+              (log/info "Finding workloads to update...")
               (run! try-update
                     (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
                       (jdbc/query tx "SELECT id,uuid FROM workload

--- a/api/src/wfl/source.clj
+++ b/api/src/wfl/source.clj
@@ -259,10 +259,11 @@
   [{:keys [dataset table last_checked] :as source}
    utc-now]
   (let [[start end :as interval]
-        (->> [(timestamp-to-offsetdatetime last_checked) utc-now]
-             (mapv #(.format % bigquery-datetime-format)))
-        shards->jobs (->> (find-new-rows source interval)
-                          (create-snapshots source utc-now))]
+        (mapv
+         #(.format % bigquery-datetime-format)
+         [(timestamp-to-offsetdatetime last_checked) utc-now])
+        shards->jobs
+        (create-snapshots source utc-now (find-new-rows source interval))]
     (if (seq shards->jobs)
       (do (log/infof "%s Snapshots created from new rows in %s.%s."
                      (log-prefix source) (:name dataset) table)

--- a/api/src/wfl/stage.clj
+++ b/api/src/wfl/stage.clj
@@ -1,6 +1,6 @@
 (ns wfl.stage
-  "An interface for operations on a queue-based pipeline processing stage,
-  e.g. source, executor, or sink."
+  "Interface and methods for operations on a queue-based
+  pipeline processing stage, e.g. source, executor, or sink."
   (:require [wfl.util :as util])
   (:import [wfl.util UserException]))
 
@@ -28,3 +28,8 @@
 (defmulti done?
   "Test if the processing `stage` is complete and will not process any more data."
   :type)
+
+(defn log-prefix
+  "Prefix string for `stage` logs indicating the `type` (table) and row `id`."
+  [{:keys [type id] :as _stage}]
+  (format "[%s id=%s]" type id))


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1340

This PR adds meaningful `DEBUG` and `INFO` logs to the `source` namespace, with a focus on the `TerraDataRepoSource` update loop.  I will separately PR enhanced logging in the `executor` and `sink` namespaces after incorporating feedback received here.

- Added logging prefixes to flag source instance table and row ID where appropriate, e.g. `[TerraDataRepoSource id=2] …`
- Downgraded and removed logging where it did not provide value or buried meaningful logging
- Log timestamp altered to date plus 24 hour timestamp

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

An earlier version of this work yielded the following logs for a `TerraDataRepoSource` update loop run with no new rows to snapshot.  Environment variable reads and transaction opens / closes obscured useful information. 
```
01:19:15 INFO  wfl.server - Finding workloads to update...
01:19:15 DEBUG wfl.environment - Reading environment variable WFL_POSTGRES_URL
01:19:15 DEBUG wfl.environment - Reading environment variable WFL_POSTGRES_PASSWORD
01:19:15 DEBUG wfl.environment - Reading environment variable WFL_POSTGRES_USERNAME
01:19:15 DEBUG wfl.environment - Reading environment variable USER
01:19:15 DEBUG wfl.server - JDBC transaction 6648 started to "okotsopo@jdbc:postgresql:wfl#1733"
01:19:15 DEBUG wfl.server - JDBC SQL transaction 6648 ended
01:19:15 DEBUG wfl.environment - Reading environment variable WFL_POSTGRES_URL
01:19:15 DEBUG wfl.environment - Reading environment variable WFL_POSTGRES_PASSWORD
01:19:15 DEBUG wfl.environment - Reading environment variable WFL_POSTGRES_USERNAME
01:19:15 DEBUG wfl.environment - Reading environment variable USER
01:19:15 DEBUG wfl.server - JDBC transaction 6909 started to "okotsopo@jdbc:postgresql:wfl#1733"
01:19:15 DEBUG wfl.api.workloads - Loading workload id=1
01:19:15 INFO  wfl.server - Updating workload 2f282142-52bc-477b-a01c-60bfd5307179
01:19:15 DEBUG wfl.source - [TerraDataRepoSource id=1] Looking for new rows in ranthony_covid_bashing_20210527.flowcells between [2021-07-12T17:01:16, 2021-07-12T17:19:15]...
01:19:15 DEBUG wfl.environment - Reading environment variable GOOGLE_APPLICATION_CREDENTIALS
01:19:16 DEBUG wfl.source - [TerraDataRepoSource id=1] No new rows in ranthony_covid_bashing_20210527.flowcells since 2021-07-12 13:01:16.130205.
01:19:16 DEBUG wfl.source - [TerraDataRepoSource id=1] Updating running snapshot jobs...
01:19:16 DEBUG wfl.environment - Reading environment variable WFL_POSTGRES_URL
01:19:16 DEBUG wfl.environment - Reading environment variable WFL_POSTGRES_PASSWORD
01:19:16 DEBUG wfl.environment - Reading environment variable WFL_POSTGRES_USERNAME
01:19:16 DEBUG wfl.environment - Reading environment variable USER
01:19:16 DEBUG wfl.source - JDBC transaction 9355 started to "okotsopo@jdbc:postgresql:wfl#1733"
01:19:16 DEBUG wfl.source - JDBC SQL transaction 9355 ended
01:19:16 DEBUG wfl.source - [TerraDataRepoSource id=1] Running snapshot jobs updated.
01:19:16 DEBUG wfl.environment - Reading environment variable WFL_POSTGRES_URL
01:19:16 DEBUG wfl.environment - Reading environment variable WFL_POSTGRES_PASSWORD
01:19:16 DEBUG wfl.environment - Reading environment variable WFL_POSTGRES_USERNAME
01:19:16 DEBUG wfl.environment - Reading environment variable USER
01:19:16 DEBUG wfl.source - JDBC transaction 2942 started to "okotsopo@jdbc:postgresql:wfl#1733"
01:19:16 DEBUG wfl.source - JDBC SQL transaction 2942 ended
01:19:16 DEBUG wfl.environment - Reading environment variable WFL_POSTGRES_URL
01:19:16 DEBUG wfl.environment - Reading environment variable WFL_POSTGRES_PASSWORD
01:19:16 DEBUG wfl.environment - Reading environment variable WFL_POSTGRES_USERNAME
01:19:16 DEBUG wfl.environment - Reading environment variable USER
01:19:16 DEBUG wfl.source - JDBC transaction 4371 started to "okotsopo@jdbc:postgresql:wfl#1733"
01:19:16 DEBUG wfl.source - JDBC SQL transaction 4371 ended
01:19:16 DEBUG wfl.environment - Reading environment variable WFL_POSTGRES_URL
01:19:16 DEBUG wfl.environment - Reading environment variable WFL_POSTGRES_PASSWORD
01:19:16 DEBUG wfl.environment - Reading environment variable WFL_POSTGRES_USERNAME
01:19:16 DEBUG wfl.environment - Reading environment variable USER
01:19:16 DEBUG wfl.executor - JDBC transaction 6605 started to "okotsopo@jdbc:postgresql:wfl#1733"
01:19:16 DEBUG wfl.executor - JDBC SQL transaction 6605 ended
01:19:16 DEBUG wfl.environment - Reading environment variable WFL_POSTGRES_URL
01:19:16 DEBUG wfl.environment - Reading environment variable WFL_POSTGRES_PASSWORD
01:19:16 DEBUG wfl.environment - Reading environment variable WFL_POSTGRES_USERNAME
01:19:16 DEBUG wfl.environment - Reading environment variable USER
01:19:16 DEBUG wfl.executor - JDBC transaction 8966 started to "okotsopo@jdbc:postgresql:wfl#1733"
01:19:16 DEBUG wfl.executor - JDBC SQL transaction 8966 ended
01:19:16 DEBUG wfl.environment - Reading environment variable WFL_POSTGRES_URL
01:19:16 DEBUG wfl.environment - Reading environment variable WFL_POSTGRES_PASSWORD
01:19:16 DEBUG wfl.environment - Reading environment variable WFL_POSTGRES_USERNAME
01:19:16 DEBUG wfl.environment - Reading environment variable USER
01:19:16 DEBUG wfl.executor - JDBC transaction 2184 started to "okotsopo@jdbc:postgresql:wfl#1733"
01:19:16 DEBUG wfl.executor - JDBC SQL transaction 2184 ended
01:19:16 DEBUG wfl.environment - Reading environment variable WFL_POSTGRES_URL
01:19:16 DEBUG wfl.environment - Reading environment variable WFL_POSTGRES_PASSWORD
01:19:16 DEBUG wfl.environment - Reading environment variable WFL_POSTGRES_USERNAME
01:19:16 DEBUG wfl.environment - Reading environment variable USER
01:19:16 DEBUG wfl.executor - JDBC transaction 4262 started to "okotsopo@jdbc:postgresql:wfl#1733"
01:19:16 DEBUG wfl.executor - JDBC SQL transaction 4262 ended
01:19:16 INFO  wfl.module.covid - jdbc/update! "okotsopo@jdbc:postgresql:wfl#1733" :workload {:updated #object[java.time.OffsetDateTime 0xefcb992 "2021-07-12T17:19:15.713013Z"]} ["id = ?" 1]
01:19:16 DEBUG wfl.api.workloads - Loading workload id=1
01:19:16 DEBUG wfl.server - JDBC SQL transaction 6909 ended
```

New logging for `TerraDataRepoSource` update loop with no rows found, no snapshots to update:
```
2021-07-13 12:11:14 INFO  wfl.server - Finding workloads to update...
2021-07-13 12:11:14 DEBUG wfl.api.workloads - Loading workload id=1
2021-07-13 12:11:14 INFO  wfl.server - Updating workload cdc8dc81-ac5a-46c6-b258-3b556b373708
2021-07-13 12:11:14 DEBUG wfl.source - [TerraDataRepoSource id=1] Looking for rows in ranthony_covid_bashing_20210527.flowcells between [2021-07-13T16:11:12, 2021-07-13T16:11:14]...
2021-07-13 12:11:15 DEBUG wfl.source - [TerraDataRepoSource id=1] Looking for running snapshot jobs...
2021-07-13 12:11:15 INFO  wfl.module.covid - jdbc/update! "okotsopo@jdbc:postgresql:wfl#2604" :workload {:updated #object[java.time.OffsetDateTime 0x5fce54df "2021-07-13T16:11:14.522206Z"]} ["id = ?" 1]
2021-07-13 12:11:15 DEBUG wfl.api.workloads - Loading workload id=1
```

New logging for `TerraDataRepoSource` update loop with rows found to snapshot:
```
2021-07-13 12:11:35 INFO  wfl.server - Finding workloads to update...
2021-07-13 12:11:35 DEBUG wfl.api.workloads - Loading workload id=1
2021-07-13 12:11:35 INFO  wfl.server - Updating workload cdc8dc81-ac5a-46c6-b258-3b556b373708
2021-07-13 12:11:35 DEBUG wfl.source - [TerraDataRepoSource id=1] Looking for rows in ranthony_covid_bashing_20210527.flowcells between [2021-05-13T16:11:12, 2021-07-13T16:11:35]...
2021-07-13 12:11:37 INFO  wfl.source - [TerraDataRepoSource id=1] Snapshots created from new rows in ranthony_covid_bashing_20210527.flowcells.
2021-07-13 12:11:37 INFO  wfl.source - jdbc/insert-multi! "okotsopo@jdbc:postgresql:wfl#2604" "TerraDataRepoSource_000000001" ({:snapshot_creation_job_id "GEIOAUIORCqQ9KumDrzZsw", :snapshot_creation_job_status "running", :datarepo_row_ids ["af0a6b35-6531-4bd1-a295-c8580af4a636" "bcdd7564-792e-4aa8-96ec-f07bfaa95ec6" "aec85bf6-5bbd-4886-afb2-190fc3b1e983" "6e8305f6-645c-4b52-a25e-afbc6a23f02a"], :start_time #inst "2021-05-13T16:11:12.800985000-00:00", :end_time #object[java.time.OffsetDateTime 0x4708f4b6 "2021-07-13T16:11:35.970205Z"]})
2021-07-13 12:11:37 DEBUG wfl.source - [TerraDataRepoSource id=1] Snapshot creation jobs written.
2021-07-13 12:11:37 INFO  wfl.source - jdbc/update! "okotsopo@jdbc:postgresql:wfl#2604" "TerraDataRepoSource" {:last_checked #object[java.time.OffsetDateTime 0x4708f4b6 "2021-07-13T16:11:35.970205Z"]} ["id = ?" 1]
2021-07-13 12:11:37 DEBUG wfl.source - [TerraDataRepoSource id=1] Looking for running snapshot jobs...
2021-07-13 12:11:37 INFO  wfl.source - jdbc/update! "okotsopo@jdbc:postgresql:wfl#2604" "TerraDataRepoSource_000000001" {:snapshot_creation_job_status "running", :snapshot_id nil, :updated #object[java.time.OffsetDateTime 0x519612d1 "2021-07-13T16:11:37.727278Z"]} ["id = ?" 1]
2021-07-13 12:11:37 DEBUG wfl.source - [TerraDataRepoSource id=1] Running snapshot jobs updated.
2021-07-13 12:11:37 INFO  wfl.module.covid - jdbc/update! "okotsopo@jdbc:postgresql:wfl#2604" :workload {:updated #object[java.time.OffsetDateTime 0x4fbe9b "2021-07-13T16:11:35.970183Z"]} ["id = ?" 1]
2021-07-13 12:11:37 DEBUG wfl.api.workloads - Loading workload id=1
```

New logging for `TerraDataRepoSource` with no rows to snapshot but active snapshot jobs to update.
```
2021-07-13 12:13:02 INFO  wfl.server - Finding workloads to update...
2021-07-13 12:13:02 DEBUG wfl.api.workloads - Loading workload id=1
2021-07-13 12:13:02 INFO  wfl.server - Updating workload cdc8dc81-ac5a-46c6-b258-3b556b373708
2021-07-13 12:13:02 DEBUG wfl.source - [TerraDataRepoSource id=1] Looking for rows in ranthony_covid_bashing_20210527.flowcells between [2021-07-13T16:11:35, 2021-07-13T16:13:02]...
2021-07-13 12:13:03 DEBUG wfl.source - [TerraDataRepoSource id=1] Looking for running snapshot jobs...
2021-07-13 12:13:03 WARN  wfl.source - Snapshot creation job GEIOAUIORCqQ9KumDrzZsw failed!
2021-07-13 12:13:03 INFO  wfl.source - jdbc/update! "okotsopo@jdbc:postgresql:wfl#2604" "TerraDataRepoSource_000000001" {:snapshot_creation_job_status "failed", :snapshot_id nil, :updated #object[java.time.OffsetDateTime 0x5598f825 "2021-07-13T16:13:03.926488Z"]} ["id = ?" 1]
2021-07-13 12:13:03 DEBUG wfl.source - [TerraDataRepoSource id=1] Running snapshot jobs updated.
2021-07-13 12:13:03 INFO  wfl.module.covid - jdbc/update! "okotsopo@jdbc:postgresql:wfl#2604" :workload {:updated #object[java.time.OffsetDateTime 0x49c7d897 "2021-07-13T16:13:02.392945Z"]} ["id = ?" 1]
2021-07-13 12:13:03 DEBUG wfl.api.workloads - Loading workload id=1
```
**Question:** This snapshot creation job actually failed for reasons that I couldn't understand.  The failure was logged as a warning.  Is this the correct log level, or should it be escalated upwards in some way?

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

I encourage anyone with the inclination to check out this branch, enable debug logging…

- Change root level from `INFO` to `DEBUG` in our [log4j2 configuration](https://github.com/broadinstitute/wfl/blob/develop/api/resources/log4j2.xml#L23).
- Launch (or relaunch) a local WFL.  We cannot change the log level on a running WFL instance.

…and create / start a workload with a `TerraDataRepoSource` akin to what we did during [COVID bashing](https://broadinstitute.atlassian.net/wiki/spaces/GHConfluence/pages/2593194002/2021+05+24+SARSCoV2+Illumina+Full).

Observe the logs emitted.  Do they aide in your understanding, better enable you to debug?  Anything too noisy, or not noisy enough?  If you strip out the `DEBUG` logs such that only `INFO+` logs remain, are you satisfied?

Sometimes adding useful logging can make our code less readable.  Please speak up if you feel like I've leaned too far in this direction.

### Future Discussion

With an eye towards WFL being used at higher volume -- multiple workloads running at once, submissions with up to 500 workflows -- assess the feasibility of splitting off logs rather than logging everything to a common WFL log.
- Ex. a main WFL log with individual logs spun up per workload.

