### PR TITLE
[GH-1314] Start Implementing DataRepo Sink

### DIFF
--- a/api/src/wfl/executor.clj
+++ b/api/src/wfl/executor.clj
@@ -402,8 +402,7 @@
 (defn ^:private terra-executor-workflows
   "Return all the non-retried workflows executed by the `executor`."
   [tx {:keys [details] :as executor}]
-  (when-not (postgres/table-exists? tx details)
-    (throw (ex-info "Missing executor details table" {:table details})))
+  (postgres/throw-unless-table-exists tx details)
   (let [query "SELECT * FROM %s
                WHERE workflow IS NOT NULL
                AND   retry    IS NULL
@@ -416,8 +415,7 @@
   "Return all the non-retried workflows matching `status` executed by the
   `executor`."
   [tx {:keys [details] :as executor} status]
-  (when-not (postgres/table-exists? tx details)
-    (throw (ex-info "Missing executor details table" {:table details})))
+  (postgres/throw-unless-table-exists tx details)
   (let [query "SELECT * FROM %s
                WHERE workflow IS NOT NULL
                AND retry      IS NULL

--- a/api/src/wfl/jdbc.clj
+++ b/api/src/wfl/jdbc.clj
@@ -96,13 +96,13 @@
   ([db sql-commands]
    `(let [db#           ~db
           sql-commands# ~sql-commands]
-      (log/info "jbs/db-do-commands" (format-db db#) sql-commands#)
+      (log/info "jdbc/db-do-commands" (format-db db#) sql-commands#)
       (jdbc/db-do-commands db# sql-commands#)))
   ([db transaction? sql-commands]
    `(let [db#           ~db
           transaction?# ~transaction?
           sql-commands# ~sql-commands]
-      (log/info "jbs/db-do-commands" (format-db db#) transaction?# sql-commands#)
+      (log/info "jdbc/db-do-commands" (format-db db#) transaction?# sql-commands#)
       (jdbc/db-do-commands db# transaction?# sql-commands#))))
 
 (defmacro insert!

--- a/api/src/wfl/module/batch.clj
+++ b/api/src/wfl/module/batch.clj
@@ -6,12 +6,11 @@
             [wfl.api.workloads    :as workloads]
             [wfl.auth             :as auth]
             [wfl.jdbc             :as jdbc]
+            [wfl.module.all       :as all]
             [wfl.service.cromwell :as cromwell]
             [wfl.service.postgres :as postgres]
             [wfl.util             :as util]
-            [wfl.wfl              :as wfl]
-            [wfl.module.all       :as all]
-            [wfl.source           :as source])
+            [wfl.wfl              :as wfl])
   (:import [java.time OffsetDateTime]
            [java.util UUID]
            [wfl.util UserException]))
@@ -206,8 +205,7 @@
 (defn query-workflows-with-status
   "Return the workflows in the items `table` that match `status`."
   [tx table status]
-  (when-not (and table (postgres/table-exists? tx table))
-    (throw (ex-info "Table not found" {:table table})))
+  (postgres/throw-unless-table-exists tx table)
   (let [query-str "SELECT * FROM %s WHERE status = ? ORDER BY id ASC"]
     (jdbc/query tx [(format query-str table) status])))
 

--- a/api/src/wfl/service/datarepo.clj
+++ b/api/src/wfl/service/datarepo.clj
@@ -274,3 +274,29 @@
    (->> (map name columns)
         util/to-comma-separated-list
         (query-table-between-impl dataset table between interval))))
+
+
+;; utilities
+
+
+(defn ^:private id-and-name [{:keys [id name] :as _dataset}]
+  (util/make-map id name))
+
+(defn throw-unless-column-exists
+  "Throw if `table` does not have `column` in `dataset`."
+  [table column dataset]
+  (when (->> table :columns (filter (comp #{column} :name)) empty?)
+    (throw (UserException. "Column not found"
+                           {:column  column
+                            :table   table
+                            :dataset (id-and-name dataset)}))))
+
+(defn table-or-throw
+  "Throw or return the table with `table-name` in `dataset`."
+  [table-name {:keys [schema] :as dataset}]
+  (let [[table & _] (filter (comp #{table-name} :name) (:tables schema))]
+    (when-not table
+      (throw (UserException. "Table not found"
+                             {:table   table-name
+                              :dataset (id-and-name dataset)})))
+    table))

--- a/api/src/wfl/service/postgres.clj
+++ b/api/src/wfl/service/postgres.clj
@@ -33,18 +33,21 @@
        (count)
        (not= 0)))
 
+(defn throw-unless-table-exists
+  [tx table-name]
+  (when-not (and table-name (table-exists? tx table-name))
+    (throw (ex-info "Table not found" {:table table-name}))))
+
 (defn get-table
   "Return TABLE using transaction TX sorted by row id."
   [tx table]
-  (when-not (and table (table-exists? tx table))
-    (throw (ex-info "Table not found" {:table table})))
+  (throw-unless-table-exists tx table)
   (jdbc/query tx (format "SELECT * FROM %s ORDER BY id ASC" table)))
 
 (defn table-length
   "Use `tx` to return the number of records in `table-name`."
   [tx table-name]
-  (when-not (table-exists? tx table-name)
-    (throw (ex-info "No such table" {:table table-name})))
+  (throw-unless-table-exists tx table-name)
   (->> (format "SELECT COUNT(*) FROM %s" table-name)
        (jdbc/query tx)
        first
@@ -53,8 +56,7 @@
 (defn table-max
   "Use `tx` to return the maximum value of `column` in `table-name`."
   [tx table-name column]
-  (when-not (table-exists? tx table-name)
-    (throw (ex-info "No such table" {:table table-name})))
+  (throw-unless-table-exists tx table-name)
   (-> (format "SELECT MAX(%s) FROM %s" (name column) (name table-name))
       (->> (jdbc/query tx))
       first

--- a/api/src/wfl/sink.clj
+++ b/api/src/wfl/sink.clj
@@ -14,8 +14,8 @@
             [wfl.stage             :as stage]
             [wfl.util              :as util :refer [utc-now]])
   (:import [clojure.lang ExceptionInfo]
-           [wfl.util UserException]
-           [org.apache.commons.lang3 NotImplementedException]))
+           [org.apache.commons.lang3 NotImplementedException]
+           [wfl.util UserException]))
 
 ;; Interface
 (defmulti create-sink!
@@ -247,10 +247,10 @@
   (throw (NotImplementedException. "update-datarepo-sink")))
 
 (defn ^:private datarepo-sink-done? [{:keys [details] :as _sink}]
-  (let [query "SELECT COUNT(*) FROM %s WHERE consumed NOT NULL"]
+  (let [query "SELECT COUNT(*) FROM %s WHERE consumed IS NOT NULL"]
     (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
       (postgres/throw-unless-table-exists tx details)
-      (-> (jdbc/query tx (format query details)) :count pos?))))
+      (-> (jdbc/query tx (format query details)) first :count zero?))))
 
 (defn ^:private datarepo-sink-to-edn [sink]
   (-> sink

--- a/api/src/wfl/sink.clj
+++ b/api/src/wfl/sink.clj
@@ -247,7 +247,9 @@
   (throw (NotImplementedException. "update-datarepo-sink")))
 
 (defn ^:private datarepo-sink-done? [{:keys [details] :as _sink}]
-  (let [query "SELECT COUNT(*) FROM %s WHERE consumed IS NOT NULL"]
+  (let [query "SELECT COUNT(*) FROM %s
+               WHERE status   <> 'failed'
+               AND   consumed IS NOT NULL"]
     (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
       (postgres/throw-unless-table-exists tx details)
       (-> (jdbc/query tx (format query details)) first :count zero?))))

--- a/api/src/wfl/sink.clj
+++ b/api/src/wfl/sink.clj
@@ -196,7 +196,7 @@
         alter   "ALTER TABLE %s ALTER COLUMN id ADD GENERATED ALWAYS AS IDENTITY"
         details (format "%s_%09d" datarepo-sink-type id)]
     (jdbc/db-do-commands tx [(format create details) (format alter details)])
-    [terra-workspace-sink-type
+    [datarepo-sink-type
      (-> (select-keys request (keys datarepo-sink-serialized-fields))
          (update :dataset pr-str)
          (update :fromOutputs pr-str)

--- a/api/src/wfl/sink.clj
+++ b/api/src/wfl/sink.clj
@@ -7,13 +7,15 @@
             [clojure.tools.logging :as log]
             [wfl.api.workloads     :refer [defoverload]]
             [wfl.jdbc              :as jdbc]
+            [wfl.service.datarepo  :as datarepo]
             [wfl.service.firecloud :as firecloud]
             [wfl.service.postgres  :as postgres]
             [wfl.service.rawls     :as rawls]
             [wfl.stage             :as stage]
-            [wfl.util              :as util :refer [do-or-nil utc-now]])
+            [wfl.util              :as util :refer [utc-now]])
   (:import [clojure.lang ExceptionInfo]
-           [wfl.util UserException]))
+           [wfl.util UserException]
+           [org.apache.commons.lang3 NotImplementedException]))
 
 ;; Interface
 (defmulti create-sink!
@@ -78,7 +80,7 @@
 (def unknown-entity-type-error-message
   "The entityType was not found in workspace.")
 
-(def malformed-from-outputs-error-message
+(def terra-workspace-malformed-from-outputs-message
   (str/join " " ["fromOutputs must define a mapping from workflow outputs"
                  "to the attributes of entityType."]))
 
@@ -86,7 +88,7 @@
   (str/join " " ["Found additional attributes in fromOutputs that are not"
                  "present in the entityType."]))
 
-(defn ^:private verify-terra-sink!
+(defn ^:private verify-terra-workspace-sink!
   "Verify that the WFL has access the `workspace`."
   [{:keys [entityType fromOutputs skipValidation workspace] :as sink}]
   (when-not skipValidation
@@ -98,7 +100,7 @@
         (throw (UserException. unknown-entity-type-error-message
                                (util/make-map entityType types workspace))))
       (when-not (map? fromOutputs)
-        (throw (UserException. malformed-from-outputs-error-message
+        (throw (UserException. terra-workspace-malformed-from-outputs-message
                                (util/make-map entityType fromOutputs))))
       (let [attributes    (->> (get-in entity-types [entity-type :attributeNames])
                                (cons (str entityType "_id"))
@@ -171,12 +173,92 @@
       (util/select-non-nil-keys (keys terra-workspace-sink-serialized-fields))
       (assoc :name terra-workspace-sink-name)))
 
-(defoverload stage/validate-or-throw terra-workspace-sink-name verify-terra-sink!)
+(defoverload stage/validate-or-throw terra-workspace-sink-name verify-terra-workspace-sink!)
+(defoverload create-sink!            terra-workspace-sink-name create-terra-workspace-sink)
 
-(defoverload create-sink!  terra-workspace-sink-name create-terra-workspace-sink)
 (defoverload load-sink!    terra-workspace-sink-type load-terra-workspace-sink)
 (defoverload update-sink!  terra-workspace-sink-type update-terra-workspace-sink)
-
-(defoverload stage/done? terra-workspace-sink-type terra-workspace-sink-done?)
+(defoverload stage/done?   terra-workspace-sink-type terra-workspace-sink-done?)
 
 (defoverload util/to-edn terra-workspace-sink-type terra-workspace-sink-to-edn)
+
+;; TerraDataRepo Sink
+(def ^:private datarepo-sink-name  "Terra DataRepo Sink")
+(def ^:private datarepo-sink-type  "TerraDataRepoSink")
+(def ^:private datarepo-sink-table "TerraDataRepoSink")
+(def ^:private datarepo-sink-serialized-fields
+  {:dataset     :dataset
+   :table       :dataset_table
+   :fromOutputs :from_outputs})
+
+(defn ^:private create-datarepo-sink [tx id request]
+  (let [create  "CREATE TABLE %s OF TerraDataRepoSinkDetails (PRIMARY KEY (id))"
+        alter   "ALTER TABLE %s ALTER COLUMN id ADD GENERATED ALWAYS AS IDENTITY"
+        details (format "%s_%09d" datarepo-sink-type id)]
+    (jdbc/db-do-commands tx [(format create details) (format alter details)])
+    [terra-workspace-sink-type
+     (-> (select-keys request (keys datarepo-sink-serialized-fields))
+         (update :fromOutputs pr-str)
+         (set/rename-keys datarepo-sink-serialized-fields)
+         (assoc :details details)
+         (->> (jdbc/insert! tx datarepo-sink-table) first :id str))]))
+
+(defn ^:private load-datarepo-sink [tx {:keys [sink_items] :as workload}]
+  (if-let [id (util/parse-int sink_items)]
+    (-> (postgres/load-record-by-id! tx datarepo-sink-table id)
+        (set/rename-keys (set/map-invert datarepo-sink-serialized-fields))
+        (update :fromOutputs edn/read-string)
+        (assoc :type datarepo-sink-type))
+    (throw (ex-info "Invalid sink_items" {:workload workload}))))
+
+(def datarepo-malformed-from-outputs-message
+  (str/join " " ["fromOutputs must define a mapping from workflow outputs"
+                 "to columns in the table in the dataset."]))
+
+(def unknown-columns-error-message
+  (str/join " " ["Found column names in fromOutputs that are not columns of"
+                 "the table in the dataset."]))
+
+(defn ^:private verify-datarepo-sink!
+  "Verify that the WFL has access the `workspace`."
+  [{:keys [dataset table fromOutputs] :as sink}]
+  (let [dataset' (datarepo/dataset dataset)
+        ;; eagerly evaluate for effects
+        table'   (datarepo/table-or-throw table dataset')]
+    (when-not (map? fromOutputs)
+      (throw (UserException. datarepo-malformed-from-outputs-message
+                             (util/make-map dataset fromOutputs))))
+    (let [columns (map (comp keyword :name) (:columns table'))
+          [missing _ _] (data/diff (set (keys fromOutputs)) (set columns))]
+      (when (seq missing)
+        (throw (UserException. unknown-columns-error-message
+                               {:dataset     dataset
+                                :table       table
+                                :columns     (sort columns)
+                                :missing     (sort missing)
+                                :fromOutputs fromOutputs}))))
+    (assoc sink :dataset dataset')))
+
+(defn ^:private update-datarepo-sink
+  [_executor _sink]
+  (throw (NotImplementedException. "update-datarepo-sink")))
+
+(defn ^:private datarepo-sink-done? [{:keys [details] :as _sink}]
+  (let [query "SELECT COUNT(*) FROM %s WHERE consumed NOT NULL"]
+    (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+      (postgres/throw-unless-table-exists tx details)
+      (-> (jdbc/query tx (format query details)) :count pos?))))
+
+(defn ^:private datarepo-sink-to-edn [sink]
+  (-> sink
+      (util/select-non-nil-keys (keys datarepo-sink-serialized-fields))
+      (assoc :name datarepo-sink-name)))
+
+(defoverload stage/validate-or-throw datarepo-sink-name verify-datarepo-sink!)
+(defoverload create-sink!            datarepo-sink-name create-datarepo-sink)
+
+(defoverload load-sink!   datarepo-sink-type load-datarepo-sink)
+(defoverload update-sink! datarepo-sink-type update-datarepo-sink)
+(defoverload stage/done?  datarepo-sink-type datarepo-sink-done?)
+
+(defoverload util/to-edn datarepo-sink-type datarepo-sink-to-edn)

--- a/api/test/wfl/integration/sinks/datarepo_sink_test.clj
+++ b/api/test/wfl/integration/sinks/datarepo_sink_test.clj
@@ -105,7 +105,8 @@
 ;; Operation tests
 (def ^:private random (partial rand-int 1000000))
 
-(def datarepo-sink-config (comp stage/validate-or-throw datarepo-sink-request))
+(def ^:private datarepo-sink-config
+  (comp stage/validate-or-throw datarepo-sink-request))
 
 (deftest test-create-datarepo-sink
   (let [[type items] (evalT sink/create-sink! (random) (datarepo-sink-config))]
@@ -117,7 +118,7 @@
       (is (get-in sink [:dataset :defaultProfileId]))
       (is (evalT postgres/table-exists? (:details sink))))))
 
-(defn create-and-load-datarepo-sink []
+(defn ^:private create-and-load-datarepo-sink []
   (let [[type items] (evalT sink/create-sink! (random) (datarepo-sink-config))]
     (evalT sink/load-sink! {:sink_type type :sink_items items})))
 

--- a/api/test/wfl/integration/sinks/datarepo_sink_test.clj
+++ b/api/test/wfl/integration/sinks/datarepo_sink_test.clj
@@ -1,0 +1,181 @@
+(ns wfl.integration.sinks.datarepo-sink-test
+  "Test validation and operations on Sink stage implementations."
+  (:require [clojure.test          :refer [deftest is use-fixtures]]
+            [wfl.jdbc              :as jdbc]
+            [wfl.service.datarepo  :as datarepo]
+            [wfl.service.postgres  :as postgres]
+            [wfl.sink              :as sink]
+            [wfl.stage             :as stage]
+            [wfl.tools.fixtures    :as fixtures]
+            [wfl.tools.resources   :as resources])
+  (:import [java.util ArrayDeque]
+           [wfl.util UserException]))
+
+;; Queue mocks
+(def ^:private testing-queue-type "TestQueue")
+(defn ^:private make-queue-from-list [items]
+  {:type testing-queue-type :queue (ArrayDeque. items)})
+
+(defn ^:private testing-queue-peek [this]
+  (-> this :queue .getFirst))
+
+(defn ^:private testing-queue-pop [this]
+  (-> this :queue .removeFirst))
+
+(defn ^:private testing-queue-length [this]
+  (-> this :queue .size))
+
+(defn ^:private testing-queue-done? [this]
+  (-> this :queue .empty))
+
+(def ^:private ^:dynamic *dataset*)
+
+(use-fixtures :once
+  fixtures/temporary-postgresql-database
+  (fixtures/method-overload-fixture
+   stage/peek-queue testing-queue-type testing-queue-peek)
+  (fixtures/method-overload-fixture
+   stage/pop-queue! testing-queue-type testing-queue-pop)
+  (fixtures/method-overload-fixture
+   stage/queue-length testing-queue-type testing-queue-length)
+  (fixtures/method-overload-fixture
+   stage/done? testing-queue-type testing-queue-done?))
+
+;; Validation tests
+;
+;(deftest test-validate-datarepo-sink-with-valid-sink-request
+;  (is (stage/validate-or-throw
+;        {:name        @#'sink/datarepo-sink-name
+;         :dataset     testing-dataset
+;         :entityType  "assemblies"
+;         :identity    "Who cares?"
+;         :fromOutputs {:assemblies_id "foo"}})))
+;
+;(deftest test-validate-datarepo-sink-throws-on-invalid-sink-entity-type
+;  (is (thrown-with-msg?
+;        UserException (re-pattern sink/unknown-entity-type-error-message)
+;        (stage/validate-or-throw
+;          {:name        @#'sink/datarepo-sink-name
+;           :workspace   testing-workspace
+;           :entityType  "does_not_exist"
+;           :identity    "Who cares?"
+;           :fromOutputs {}}))))
+;
+;(deftest test-validate-datarepo-sink-throws-on-malformed-fromOutputs
+;  (is (thrown-with-msg?
+;        UserException (re-pattern sink/terra-workspace-malformed-from-outputs-message)
+;        (stage/validate-or-throw
+;          {:name        @#'sink/datarepo-sink-name
+;           :workspace   testing-workspace
+;           :entityType  "assemblies"
+;           :identity    "Who cares?"
+;           :fromOutputs "geoff"}))))
+;
+;(deftest test-validate-datarepo-sink-throws-on-unknown-fromOutputs-attributes
+;  (is (thrown-with-msg?
+;        UserException (re-pattern sink/unknown-attributes-error-message)
+;        (stage/validate-or-throw
+;          {:name        @#'sink/datarepo-sink-name
+;           :workspace   testing-workspace
+;           :entityType  "assemblies"
+;           :identity    "Who cares?"
+;           :fromOutputs {:does_not_exist "genbank_source_table"}}))))
+;
+;(deftest test-validate-datarepo-sink-throws-on-invalid-sink-workspace
+;  (is (thrown-with-msg?
+;        UserException #"Cannot access workspace"
+;        (stage/validate-or-throw
+;          {:name        @#'sink/datarepo-sink-name
+;           :workspace   "moo/moo"
+;           :entityType  "moo"
+;           :identity    "reads_id"
+;           :fromOutputs {:submission_xml "submission_xml"}}))))
+;
+;;; Operation tests
+;
+;(deftest test-update-datarepo-sink
+;  (let [workflow    {:uuid    "2768b29e-c808-4bd6-a46b-6c94fd2a67aa"
+;                     :status  "Succeeded"
+;                     :outputs (-> "sarscov2_illumina_full/outputs.edn"
+;                                resources/read-resource
+;                                (assoc :flowcell_id testing-entity-name))}
+;        executor    (make-queue-from-list [[nil workflow]])
+;        sink        (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+;                      (->> {:name           "Terra Workspace"
+;                            :workspace      "workspace-ns/workspace-name"
+;                            :entityType     testing-entity-type
+;                            :fromOutputs    (resources/read-resource
+;                                              "sarscov2_illumina_full/entity-from-outputs.edn")
+;                            :identifier     "flowcell_id"
+;                            :skipValidation true}
+;                        (sink/create-sink! tx (rand-int 1000000))
+;                        (zipmap [:sink_type :sink_items])
+;                        (sink/load-sink! tx)))]
+;    (letfn [(verify-upsert-request [workspace [[type name _]]]
+;              (is (= "workspace-ns/workspace-name" workspace))
+;              (is (= type testing-entity-type))
+;              (is (= name testing-entity-name)))
+;            (throw-if-called [fname & args]
+;              (throw (ex-info (str fname " should not have been called")
+;                       {:called-with args})))]
+;      (with-redefs-fn
+;        {#'rawls/batch-upsert        verify-upsert-request
+;         #'sink/entity-exists?       (constantly false)
+;         #'firecloud/delete-entities (partial throw-if-called "delete-entities")}
+;        #(sink/update-sink! executor sink))
+;      (is (zero? (stage/queue-length executor)) "The workflow was not consumed")
+;      (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+;        (let [[record & rest] (->> sink :details (postgres/get-table tx))]
+;          (is record "The record was not written to the database")
+;          (is (empty? rest) "More than one record was written")
+;          (is (= (:uuid workflow) (:workflow record))
+;            "The workflow UUID was not written")
+;          (is (= testing-entity-name (:entity record))
+;            "The entity was not correct"))))))
+;
+;(deftest test-sinking-resubmitted-workflow
+;  (fixtures/with-temporary-workspace
+;    (fn [workspace]
+;      (let [workflow1 {:uuid    "2768b29e-c808-4bd6-a46b-6c94fd2a67aa"
+;                       :status  "Succeeded"
+;                       :outputs {:run_id  testing-entity-name
+;                                 :results ["aligned-thing.cram"]}}
+;            workflow2 {:uuid    "2768b29e-c808-4bd6-a46b-6c94fd2a67ab"
+;                       :status  "Succeeded"
+;                       :outputs {:run_id  testing-entity-name
+;                                 :results ["another-aligned-thing.cram"]}}
+;            executor  (make-queue-from-list [[nil workflow1] [nil workflow2]])
+;            sink      (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+;                        (->> {:name           "Terra Workspace"
+;                              :workspace      workspace
+;                              :entityType     testing-entity-type
+;                              :fromOutputs    {:aligned_crams "results"}
+;                              :identifier     "run_id"
+;                              :skipValidation true}
+;                          (sink/create-sink! tx (rand-int 1000000))
+;                          (zipmap [:sink_type :sink_items])
+;                          (sink/load-sink! tx)))]
+;        (sink/update-sink! executor sink)
+;        (is (== 1 (stage/queue-length executor))
+;          "one workflow should have been consumed")
+;        (let [{:keys [entityType name attributes]}
+;              (firecloud/get-entity workspace [testing-entity-type testing-entity-name])]
+;          (is (= testing-entity-type entityType))
+;          (is (= testing-entity-name name))
+;          (is (== 1 (count attributes)))
+;          (is (= [:aligned_crams {:itemsType "AttributeValue" :items ["aligned-thing.cram"]}]
+;                (first attributes))))
+;        (sink/update-sink! executor sink)
+;        (is (zero? (stage/queue-length executor))
+;          "one workflow should have been consumed")
+;        (let [entites (firecloud/list-entities workspace testing-entity-type)]
+;          (is (== 1 (count entites))
+;            "No new entities should have been added"))
+;        (let [{:keys [entityType name attributes]}
+;              (firecloud/get-entity workspace [testing-entity-type testing-entity-name])]
+;          (is (= testing-entity-type entityType))
+;          (is (= testing-entity-name name))
+;          (is (== 1 (count attributes)))
+;          (is (= [:aligned_crams {:itemsType "AttributeValue" :items ["another-aligned-thing.cram"]}]
+;                (first attributes))
+;            "attributes should have been overwritten"))))))

--- a/api/test/wfl/integration/sinks/datarepo_sink_test.clj
+++ b/api/test/wfl/integration/sinks/datarepo_sink_test.clj
@@ -126,7 +126,7 @@
 
 (deftest test-update-datarepo-sink-is-not-yet-implemented
   (is (thrown?
-        NotImplementedException
-        (sink/update-sink!
-          (make-queue-from-list [])
-          (create-and-load-datarepo-sink)))))
+       NotImplementedException
+       (sink/update-sink!
+        (make-queue-from-list [])
+        (create-and-load-datarepo-sink)))))

--- a/api/test/wfl/integration/sinks/workspace_sink_test.clj
+++ b/api/test/wfl/integration/sinks/workspace_sink_test.clj
@@ -1,4 +1,4 @@
-(ns wfl.integration.sink-test
+(ns wfl.integration.sinks.workspace-sink-test
   "Test validation and operations on Sink stage implementations."
   (:require [clojure.test          :refer [deftest is use-fixtures]]
             [wfl.jdbc              :as jdbc]
@@ -73,7 +73,7 @@
 
 (deftest test-validate-terra-workspace-sink-throws-on-malformed-fromOutputs
   (is (thrown-with-msg?
-       UserException (re-pattern sink/malformed-from-outputs-error-message)
+       UserException (re-pattern sink/terra-workspace-malformed-from-outputs-message)
        (stage/validate-or-throw
         {:name        @#'sink/terra-workspace-sink-name
          :workspace   testing-workspace

--- a/api/test/wfl/tools/fixtures.clj
+++ b/api/test/wfl/tools/fixtures.clj
@@ -244,9 +244,9 @@
    `arguments`."
   [var with-fixture & arguments]
   `(fn [f#]
-     (log/infof "Setting up %s...\n" '~with-fixture)
+     (log/infof "Setting up %s..." '~with-fixture)
      (~with-fixture
-       ~@arguments
-       #(binding [~var %]
-          (try (f#)
-               (finally (log/infof "Tearing down %s...\n" '~with-fixture)))))))
+      ~@arguments
+      #(binding [~var %]
+         (try (f#)
+              (finally (log/infof "Tearing down %s..." '~with-fixture)))))))

--- a/api/test/wfl/tools/fixtures.clj
+++ b/api/test/wfl/tools/fixtures.clj
@@ -240,7 +240,7 @@
 
 (defmacro bind-fixture
   "Returns a closure that can be used with clojure.test/use-fixtures in which
-   `var` is bound to the resource created by applying `fixture` to its
+   `var` is bound to the resource created by applying `with-fixture` to its
    `arguments`."
   [var with-fixture & arguments]
   `(fn [f#]

--- a/api/test/wfl/tools/fixtures.clj
+++ b/api/test/wfl/tools/fixtures.clj
@@ -1,5 +1,6 @@
 (ns wfl.tools.fixtures
   (:require [clojure.java.jdbc]
+            [clojure.tools.logging      :as log]
             [wfl.service.datarepo       :as datarepo]
             [wfl.service.google.pubsub  :as pubsub]
             [wfl.service.google.storage :as gcs]
@@ -236,3 +237,16 @@
   "Adapter for clojure.test/use-fixtures"
   [env]
   (partial with-temporary-environment env))
+
+(defmacro bind-fixture
+  "Returns a closure that can be used with clojure.test/use-fixtures in which
+   `var` is bound to the resource created by applying `fixture` to its
+   `arguments`."
+  [var with-fixture & arguments]
+  `(fn [f#]
+     (log/infof "Setting up %s...\n" '~with-fixture)
+     (~with-fixture
+       ~@arguments
+       #(binding [~var %]
+          (try (f#)
+               (finally (log/infof "Tearing down %s...\n" '~with-fixture)))))))

--- a/api/test/wfl/tools/fixtures.clj
+++ b/api/test/wfl/tools/fixtures.clj
@@ -240,8 +240,8 @@
 
 (defmacro bind-fixture
   "Returns a closure that can be used with clojure.test/use-fixtures in which
-   `var` is bound to the resource created by applying `with-fixture` to its
-   `arguments`."
+   the ^:dynamic `var` is bound to the resource created by applying
+   `with-fixture` to its `arguments`."
   [var with-fixture & arguments]
   `(fn [f#]
      (log/infof "Setting up %s..." '~with-fixture)

--- a/api/test/wfl/tools/workloads.clj
+++ b/api/test/wfl/tools/workloads.clj
@@ -266,28 +266,28 @@
       polling-interval-seconds
       max-polling-attempts))))
 
-(defn liftT
-  "Lift `operation` into the context of a database transaction."
+(defn evalT
+  "Evaluate `operation` in the context of a database transaction."
   ([operation first & rest]
    (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
      (apply operation (conj rest first tx))))
   ([operation]
-   (partial liftT operation)))
+   (partial evalT operation)))
 
-(def create-workload!    (liftT wfl.api.workloads/create-workload!))
-(def start-workload!     (liftT wfl.api.workloads/start-workload!))
-(def stop-workload!      (liftT wfl.api.workloads/stop-workload!))
-(def execute-workload!   (liftT wfl.api.workloads/execute-workload!))
-(def update-workload!    (liftT wfl.api.workloads/update-workload!))
-(def workflows           (liftT wfl.api.workloads/workflows))
-(def workflows-by-status (liftT wfl.api.workloads/workflows-by-status))
+(def create-workload!    (evalT wfl.api.workloads/create-workload!))
+(def start-workload!     (evalT wfl.api.workloads/start-workload!))
+(def stop-workload!      (evalT wfl.api.workloads/stop-workload!))
+(def execute-workload!   (evalT wfl.api.workloads/execute-workload!))
+(def update-workload!    (evalT wfl.api.workloads/update-workload!))
+(def workflows           (evalT wfl.api.workloads/workflows))
+(def workflows-by-status (evalT wfl.api.workloads/workflows-by-status))
 
 (defn retry [& params] (apply wfl.api.workloads/retry params))
 
-(def load-workload-for-uuid      (liftT wfl.api.workloads/load-workload-for-uuid))
-(def load-workload-for-id        (liftT wfl.api.workloads/load-workload-for-id))
-(def load-workloads-with-project (liftT wfl.api.workloads/load-workloads-with-project))
-(def append-to-workload!         (liftT aou/append-to-workload!))
+(def load-workload-for-uuid      (evalT wfl.api.workloads/load-workload-for-uuid))
+(def load-workload-for-id        (evalT wfl.api.workloads/load-workload-for-id))
+(def load-workloads-with-project (evalT wfl.api.workloads/load-workloads-with-project))
+(def append-to-workload!         (evalT aou/append-to-workload!))
 
 (defmulti postcheck
   "Implement this to validate `workload` after all workflows complete."

--- a/api/test/wfl/tools/workloads.clj
+++ b/api/test/wfl/tools/workloads.clj
@@ -267,7 +267,11 @@
       max-polling-attempts))))
 
 (defn evalT
-  "Evaluate `operation` in the context of a database transaction."
+  "Evaluate `operation` in the context of a database transaction where
+   `operation` is a function that takes a database transaction as its first
+   argument followed by at least one additional argument. When no additional
+   arguments are supplied, returns a closure that evaluates `operation` with its
+   arguments in the context of a database transaction."
   ([operation first & rest]
    (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
      (apply operation (conj rest first tx))))


### PR DESCRIPTION
RR: https://broadinstitute.atlassian.net/browse/GH-1413
Add load/create functions for the data repo sink.

I'm leaving `update-sink` to another PR as I think that'll be a more complicated change that I'd like reviewed separately.
I'm also deferring how to disambiguate between `stage/validate` implementations to another PR as it may involve a slight redesign.