### PR TITLE
GH-1414 Executor falls back to fetching existing snapshot reference

### DIFF
--- a/api/src/wfl/executor.clj
+++ b/api/src/wfl/executor.clj
@@ -124,7 +124,7 @@
     (throw (ex-info "Unknown conversion from snapshot to workspace entity."
                     {:executor executor
                      :snapshot snapshot})))
-  (rawls/create-snapshot-reference workspace id name))
+  (rawls/create-or-get-snapshot-reference workspace id name))
 
 (defn ^:private from-source
   "Coerce `object` to form understood by `executor``."

--- a/api/test/wfl/integration/executor_test.clj
+++ b/api/test/wfl/integration/executor_test.clj
@@ -101,7 +101,7 @@
 
 (def ^:private snapshot-reference-id (str (UUID/randomUUID)))
 (def ^:private snapshot-reference-name (str (:name snapshot) "-ref"))
-(defn ^:private mock-rawls-create-snapshot-reference [& _]
+(defn ^:private mock-rawls-snapshot-reference [& _]
   {:referenceId snapshot-reference-id
    :name        snapshot-reference-name})
 
@@ -193,12 +193,12 @@
               (is (= (:id workflow) (:workflow record))
                   "The workflow ID was incorrect and should match corresponding record"))]
       (with-redefs-fn
-        {#'rawls/create-snapshot-reference       mock-rawls-create-snapshot-reference
-         #'firecloud/method-configuration        mock-firecloud-get-method-configuration
-         #'firecloud/update-method-configuration mock-firecloud-update-method-configuration
-         #'firecloud/submit-method               mock-firecloud-create-submission
-         #'firecloud/get-submission              mock-firecloud-get-submission
-         #'firecloud/get-workflow                mock-workflow-update-status}
+        {#'rawls/create-or-get-snapshot-reference mock-rawls-snapshot-reference
+         #'firecloud/method-configuration         mock-firecloud-get-method-configuration
+         #'firecloud/update-method-configuration  mock-firecloud-update-method-configuration
+         #'firecloud/submit-method                mock-firecloud-create-submission
+         #'firecloud/get-submission               mock-firecloud-get-submission
+         #'firecloud/get-workflow                 mock-workflow-update-status}
         #(executor/update-executor! source executor))
       (is (zero? (stage/queue-length source)) "The snapshot was not consumed.")
       (is (== 2 (stage/queue-length executor)) "Two workflows should be enqueued")
@@ -228,12 +228,12 @@
         source     (make-queue-from-list [[:datarepo/snapshot snapshot]])
         executor   (create-terra-executor (rand-int 1000000))]
     (with-redefs-fn
-      {#'rawls/create-snapshot-reference       mock-rawls-create-snapshot-reference
-       #'firecloud/method-configuration        mock-firecloud-get-method-configuration
-       #'firecloud/update-method-configuration mock-firecloud-update-method-configuration
-       #'firecloud/submit-method               mock-firecloud-create-submission
-       #'firecloud/get-submission              mock-firecloud-get-submission
-       #'firecloud/get-workflow                mock-workflow-keep-status}
+      {#'rawls/create-or-get-snapshot-reference mock-rawls-snapshot-reference
+       #'firecloud/method-configuration         mock-firecloud-get-method-configuration
+       #'firecloud/update-method-configuration  mock-firecloud-update-method-configuration
+       #'firecloud/submit-method                mock-firecloud-create-submission
+       #'firecloud/get-submission               mock-firecloud-get-submission
+       #'firecloud/get-workflow                 mock-workflow-keep-status}
       #(executor/update-executor! source executor))
     (with-redefs-fn
       {#'executor/describe-method       (constantly nil)
@@ -253,13 +253,13 @@
 
 (deftest test-terra-executor-get-retried-workflows
   (with-redefs-fn
-    {#'rawls/create-snapshot-reference       mock-rawls-create-snapshot-reference
-     #'firecloud/method-configuration        mock-firecloud-get-method-configuration
-     #'firecloud/update-method-configuration mock-firecloud-update-method-configuration
-     #'firecloud/submit-method               mock-firecloud-create-submission
-     #'firecloud/get-submission              mock-firecloud-get-submission
-     #'firecloud/get-workflow                mock-workflow-keep-status
-     #'firecloud/get-workflow-outputs        mock-firecloud-get-workflow-outputs}
+    {#'rawls/create-or-get-snapshot-reference mock-rawls-snapshot-reference
+     #'firecloud/method-configuration         mock-firecloud-get-method-configuration
+     #'firecloud/update-method-configuration  mock-firecloud-update-method-configuration
+     #'firecloud/submit-method                mock-firecloud-create-submission
+     #'firecloud/get-submission               mock-firecloud-get-submission
+     #'firecloud/get-workflow                 mock-workflow-keep-status
+     #'firecloud/get-workflow-outputs         mock-firecloud-get-workflow-outputs}
     #(let [source   (make-queue-from-list [[:datarepo/snapshot snapshot]])
            executor (create-terra-executor (rand-int 1000000))]
        (executor/update-executor! source executor)

--- a/api/test/wfl/integration/modules/covid_test.clj
+++ b/api/test/wfl/integration/modules/covid_test.clj
@@ -173,7 +173,7 @@
 
 (def ^:private snapshot-reference-id (str (UUID/randomUUID)))
 (def ^:private snapshot-reference-name (str (:name snapshot) "-ref"))
-(defn ^:private mock-rawls-create-snapshot-reference [& _]
+(defn ^:private mock-rawls-snapshot-reference [& _]
   {:referenceId snapshot-reference-id
    :name        snapshot-reference-name})
 
@@ -241,15 +241,15 @@
 
 (deftest test-workload-state-transition
   (with-redefs-fn
-    {#'source/find-new-rows                  mock-find-new-rows
-     #'source/create-snapshots               mock-create-snapshots
-     #'source/check-tdr-job                  mock-check-tdr-job
-     #'rawls/create-snapshot-reference       mock-rawls-create-snapshot-reference
-     #'firecloud/method-configuration        mock-firecloud-get-method-configuration
-     #'firecloud/update-method-configuration mock-firecloud-update-method-configuration
-     #'firecloud/submit-method               mock-firecloud-create-submission
-     #'firecloud/get-submission              mock-firecloud-get-submission
-     #'firecloud/get-workflow                mock-workflow-keep-status}
+    {#'source/find-new-rows                   mock-find-new-rows
+     #'source/create-snapshots                mock-create-snapshots
+     #'source/check-tdr-job                   mock-check-tdr-job
+     #'rawls/create-or-get-snapshot-reference mock-rawls-snapshot-reference
+     #'firecloud/method-configuration         mock-firecloud-get-method-configuration
+     #'firecloud/update-method-configuration  mock-firecloud-update-method-configuration
+     #'firecloud/submit-method                mock-firecloud-create-submission
+     #'firecloud/get-submission               mock-firecloud-get-submission
+     #'firecloud/get-workflow                 mock-workflow-keep-status}
     #(shared/run-workload-state-transition-test!
       (workloads/covid-workload-request
        {:skipValidation true}
@@ -273,14 +273,14 @@
 
 (deftest test-workload-state-transition-with-failed-workflow
   (with-redefs-fn
-    {#'source/find-new-rows                  mock-find-new-rows
-     #'source/create-snapshots               mock-create-snapshots
-     #'source/check-tdr-job                  mock-check-tdr-job
-     #'rawls/create-snapshot-reference       mock-rawls-create-snapshot-reference
-     #'firecloud/method-configuration        mock-firecloud-get-method-configuration
-     #'firecloud/update-method-configuration mock-firecloud-update-method-configuration
-     #'firecloud/submit-method               mock-firecloud-create-submission
-     #'firecloud/get-workflow                (constantly {:status "Failed"})}
+    {#'source/find-new-rows                   mock-find-new-rows
+     #'source/create-snapshots                mock-create-snapshots
+     #'source/check-tdr-job                   mock-check-tdr-job
+     #'rawls/create-or-get-snapshot-reference mock-rawls-snapshot-reference
+     #'firecloud/method-configuration         mock-firecloud-get-method-configuration
+     #'firecloud/update-method-configuration  mock-firecloud-update-method-configuration
+     #'firecloud/submit-method                mock-firecloud-create-submission
+     #'firecloud/get-workflow                 (constantly {:status "Failed"})}
     #(shared/run-workload-state-transition-test!
       (workloads/covid-workload-request
        {:skipValidation true}
@@ -333,14 +333,14 @@
 
 (deftest test-retry-workload-is-not-supported
   (with-redefs-fn
-    {#'source/find-new-rows                  mock-find-new-rows
-     #'source/create-snapshots               mock-create-snapshots
-     #'source/check-tdr-job                  mock-check-tdr-job
-     #'rawls/create-snapshot-reference       mock-rawls-create-snapshot-reference
-     #'firecloud/method-configuration        mock-firecloud-get-method-configuration
-     #'firecloud/update-method-configuration mock-firecloud-update-method-configuration
-     #'firecloud/submit-method               mock-firecloud-create-submission
-     #'firecloud/get-workflow                (constantly {:status "Failed"})}
+    {#'source/find-new-rows                   mock-find-new-rows
+     #'source/create-snapshots                mock-create-snapshots
+     #'source/check-tdr-job                   mock-check-tdr-job
+     #'rawls/create-or-get-snapshot-reference mock-rawls-snapshot-reference
+     #'firecloud/method-configuration         mock-firecloud-get-method-configuration
+     #'firecloud/update-method-configuration  mock-firecloud-update-method-configuration
+     #'firecloud/submit-method                mock-firecloud-create-submission
+     #'firecloud/get-workflow                 (constantly {:status "Failed"})}
     #(shared/run-retry-is-not-supported-test!
       (workloads/covid-workload-request
        {:skipValidation true}

--- a/api/test/wfl/system/cdc_covid19_surveillance_demo.clj
+++ b/api/test/wfl/system/cdc_covid19_surveillance_demo.clj
@@ -65,7 +65,7 @@
 
 (defn import-snapshot-into-workspace [workspace {:keys [name id] :as _snapshot}]
   (println "Importing snapshot" name "into" workspace)
-  (let [{:keys [name] :as ref} (rawls/create-snapshot-reference workspace id name)]
+  (let [{:keys [name] :as ref} (rawls/create-or-get-snapshot-reference workspace id name)]
     (println "Created snapshot reference" name)
     ref))
 


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1414

Fallback to importing an existing snapshot reference when creation fails with a 409 (duplicate resource exception) stopped working.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Calling `rawls/create-or-get-snapshot-reference` rather than `rawls/create-snapshot-reference` to fall back to fetching an existing snapshot reference on a 409 error.
- Mocking in testing updated to mock `rawls/create-or-get…` rather than `rawls/create…`.  This previous mocking allowed tests to pass as the creation method is called within the create-or-get, but we weren't mocking what was actually being called.  If this method call is incorrectly changed back in the future, tests will fail.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

I tested manually:
- Create and start a workload that tries to import a snapshot as a reference with the same name as one already in the workspace.  Observe that it succeeds.

And added new automated test `wfl.test.integration.executor-test/test-terra-executor-entity-from-snapshot`.