### PR TITLE
[GH-1415] Implement `update-sink` for TerraDataRepoSink

### DIFF
--- a/api/src/wfl/service/datarepo.clj
+++ b/api/src/wfl/service/datarepo.clj
@@ -105,7 +105,7 @@
   ([job-id]
    (poll-job job-id 5)))
 
-(defn get-job-metadata
+(defn job-metadata
   "Return the metadata of job with `job-id` when done."
   [job-id]
   {:pre [(some? job-id)]}

--- a/api/src/wfl/sink.clj
+++ b/api/src/wfl/sink.clj
@@ -278,9 +278,10 @@
                             {:status status :updated (utc-now)}
                             ["id = ?" job-id])))]
     (doseq [[id job-id workflow] (read-active-jobs)]
-      (let [{:keys [job_status] :as job} (datarepo/job-metadata job-id)]
-        (write-job-status id job_status)
-        (when (= "failed" job_status)
+      (let [job    (datarepo/job-metadata job-id)
+            status (-> job :job_status str/lower-case)]
+        (write-job-status id status)
+        (when (= "failed" status)
           (throw (UserException. "A DataRepo ingest job failed"
                                  {:job      job
                                   :workflow workflow})))))))

--- a/api/src/wfl/sink.clj
+++ b/api/src/wfl/sink.clj
@@ -272,11 +272,11 @@
               (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
                 (map (juxt :id :job :workflow)
                      (jdbc/query tx (format query details))))))
-          (write-job-status [job-id status]
+          (write-job-status [id status]
             (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
               (jdbc/update! tx details
                             {:status status :updated (utc-now)}
-                            ["id = ?" job-id])))]
+                            ["id = ?" id])))]
     (doseq [[id job-id workflow] (read-active-jobs)]
       (let [job    (datarepo/job-metadata job-id)
             status (-> job :job_status str/lower-case)]

--- a/api/src/wfl/source.clj
+++ b/api/src/wfl/source.clj
@@ -172,7 +172,7 @@
   "Check TDR job status for `job-id`, return a map with job-id,
    snapshot_id and job_status if job has failed or succeeded, otherwise nil."
   [job-id]
-  (let [{:keys [job_status] :as result} (datarepo/get-job-metadata job-id)]
+  (let [{:keys [job_status] :as result} (datarepo/job-metadata job-id)]
     (case job_status
       "running"   result
       "succeeded" (assoc result :snapshot_id (:id (datarepo/get-job-result job-id)))

--- a/api/test/wfl/integration/datarepo_test.clj
+++ b/api/test/wfl/integration/datarepo_test.clj
@@ -11,8 +11,8 @@
             [wfl.tools.fixtures          :as fixtures]
             [wfl.tools.snapshots         :as snapshots]
             [wfl.tools.resources         :as resources]
-            [wfl.util                    :as util :refer [>>>]]
-            [wfl.workflows               :as workflows])
+            [wfl.tools.workflows         :as workflows]
+            [wfl.util                    :as util :refer [>>>]])
   (:import [java.util UUID]))
 
 (def ^:private testing-dataset {:id "4a5d30fe-1f99-42cd-998b-a979885dea00"

--- a/api/test/wfl/integration/datarepo_test.clj
+++ b/api/test/wfl/integration/datarepo_test.clj
@@ -74,7 +74,7 @@
         (let [table-url (str temp workflow-id "/table.json")]
           (-> (->> (workflows/get-files [outputs-type outputs])
                    (datasets/ingest-files tdr-profile dataset workflow-id))
-              (replace-urls-with-file-ids outputs-type outputs)
+              (replace-urls-with-file-ids [outputs-type outputs])
               (sink/rename-gather from-outputs)
               (json/write-str :escape-slash false)
               (gcs/upload-content table-url))

--- a/api/test/wfl/integration/executor_test.clj
+++ b/api/test/wfl/integration/executor_test.clj
@@ -33,7 +33,7 @@
   (-> this :queue .size))
 
 (defn ^:private testing-queue-done? [this]
-  (-> this :queue .empty))
+  (-> this :queue .isEmpty))
 
 (let [new-env {"WFL_FIRECLOUD_URL" "https://api.firecloud.org"
                "WFL_RAWLS_URL"     "https://rawls.dsde-prod.broadinstitute.org"}]

--- a/api/test/wfl/integration/executor_test.clj
+++ b/api/test/wfl/integration/executor_test.clj
@@ -8,8 +8,9 @@
             [wfl.service.rawls     :as rawls]
             [wfl.stage             :as stage]
             [wfl.tools.fixtures    :as fixtures]
+            [wfl.tools.queues      :refer [make-queue-from-list]]
             [wfl.util              :as util])
-  (:import [java.util ArrayDeque UUID]
+  (:import [java.util UUID]
            [wfl.util UserException]))
 
 (def ^:private testing-namespace "wfl-dev")
@@ -18,36 +19,11 @@
 (def ^:private testing-method-configuration (str testing-namespace "/" testing-method-name))
 (def ^:private testing-method-configuration-version 1)
 
-;; Queue mocks
-(def ^:private testing-queue-type "TestQueue")
-(defn ^:private make-queue-from-list [items]
-  {:type testing-queue-type :queue (ArrayDeque. items)})
-
-(defn ^:private testing-queue-peek [this]
-  (-> this :queue .peekFirst))
-
-(defn ^:private testing-queue-pop [this]
-  (-> this :queue .removeFirst))
-
-(defn ^:private testing-queue-length [this]
-  (-> this :queue .size))
-
-(defn ^:private testing-queue-done? [this]
-  (-> this :queue .isEmpty))
-
 (let [new-env {"WFL_FIRECLOUD_URL" "https://api.firecloud.org"
                "WFL_RAWLS_URL"     "https://rawls.dsde-prod.broadinstitute.org"}]
   (use-fixtures :once
     (fixtures/temporary-environment new-env)
-    fixtures/temporary-postgresql-database
-    (fixtures/method-overload-fixture
-     stage/peek-queue testing-queue-type testing-queue-peek)
-    (fixtures/method-overload-fixture
-     stage/pop-queue! testing-queue-type testing-queue-pop)
-    (fixtures/method-overload-fixture
-     stage/queue-length testing-queue-type testing-queue-length)
-    (fixtures/method-overload-fixture
-     stage/done? testing-queue-type testing-queue-done?)))
+    fixtures/temporary-postgresql-database))
 
 (deftest test-validate-terra-executor-with-valid-executor-request
   (is (stage/validate-or-throw

--- a/api/test/wfl/integration/executor_test.clj
+++ b/api/test/wfl/integration/executor_test.clj
@@ -24,7 +24,7 @@
   {:type testing-queue-type :queue (ArrayDeque. items)})
 
 (defn ^:private testing-queue-peek [this]
-  (-> this :queue .getFirst))
+  (-> this :queue .peekFirst))
 
 (defn ^:private testing-queue-pop [this]
   (-> this :queue .removeFirst))

--- a/api/test/wfl/integration/modules/covid_test.clj
+++ b/api/test/wfl/integration/modules/covid_test.clj
@@ -12,13 +12,13 @@
             [wfl.integration.modules.shared :as shared]
             [wfl.service.firecloud          :as firecloud]
             [wfl.service.rawls              :as rawls]
-            [wfl.stage                      :as stage]
             [wfl.source                     :as source]
             [wfl.tools.fixtures             :as fixtures]
+            [wfl.tools.queues               :refer [make-queue-from-list]]
             [wfl.tools.workloads            :as workloads]
             [wfl.util                       :as util])
   (:import [java.time LocalDateTime]
-           [java.util ArrayDeque UUID]
+           [java.util UUID]
            [wfl.util UserException]))
 
 ;; Snapshot creation mock
@@ -47,38 +47,13 @@
 (def ^:private testing-table-name "flowcells")
 (def ^:private testing-column-name "run_date")
 
-;; Queue mocks
-(def ^:private testing-queue-type "TestQueue")
-(defn ^:private make-queue-from-list [items]
-  {:type testing-queue-type :queue (ArrayDeque. items)})
-
-(defn ^:private testing-queue-peek [this]
-  (-> this :queue .getFirst))
-
-(defn ^:private testing-queue-pop [this]
-  (-> this :queue .removeFirst))
-
-(defn ^:private testing-queue-length [this]
-  (-> this :queue .size))
-
-(defn ^:private testing-queue-done? [this]
-  (-> this :queue .empty))
-
 (let [new-env {"WFL_FIRECLOUD_URL" "https://api.firecloud.org"
                "WFL_TDR_URL"       "https://data.terra.bio"
                "WFL_RAWLS_URL"     "https://rawls.dsde-prod.broadinstitute.org"}]
 
   (use-fixtures :once
     (fixtures/temporary-environment new-env)
-    fixtures/temporary-postgresql-database
-    (fixtures/method-overload-fixture
-     stage/peek-queue testing-queue-type testing-queue-peek)
-    (fixtures/method-overload-fixture
-     stage/pop-queue! testing-queue-type testing-queue-pop)
-    (fixtures/method-overload-fixture
-     stage/queue-length testing-queue-type testing-queue-length)
-    (fixtures/method-overload-fixture
-     stage/done? testing-queue-type testing-queue-done?)))
+    fixtures/temporary-postgresql-database))
 
 (deftest test-create-workload
   (letfn [(verify-source [{:keys [type last_checked details]}]

--- a/api/test/wfl/integration/sinks/datarepo_sink_test.clj
+++ b/api/test/wfl/integration/sinks/datarepo_sink_test.clj
@@ -141,9 +141,9 @@
   (let [task (gensym)]
     `(fn [~task] (is ~(list 'thrown? exception-type (list task))))))
 
-(defn eventually [assert task & opts]
+(defn eventually [assertion task & opts]
   (let [{:keys [interval times]} (apply hash-map opts)]
-    (assert #(util/poll task (or interval 1) (or times 5)))))
+    (assertion #(util/poll task (or interval 1) (or times 5)))))
 
 (deftest test-update-datarepo-sink
   (let [description (resources/read-resource "primitive.edn")

--- a/api/test/wfl/integration/sinks/datarepo_sink_test.clj
+++ b/api/test/wfl/integration/sinks/datarepo_sink_test.clj
@@ -153,6 +153,6 @@
     (sink/update-sink! upstream sink)
     (is (stage/done? upstream))
     (eventually (throws? UserException) #(sink/update-sink! upstream sink)
-                :interval 5)
+                :interval 5 :times 10)
     (is (stage/done? sink) "failed jobs are no longer considered")
     (is (or (sink/update-sink! upstream sink) true) "subsequent updates do nothing")))

--- a/api/test/wfl/integration/sinks/datarepo_sink_test.clj
+++ b/api/test/wfl/integration/sinks/datarepo_sink_test.clj
@@ -1,47 +1,23 @@
 (ns wfl.integration.sinks.datarepo-sink-test
   "Test validation and operations on Sink stage implementations."
-  (:require [clojure.test :refer [deftest is use-fixtures]]
-            [wfl.environment :as env]
+  (:require [clojure.test         :refer [deftest is use-fixtures]]
+            [wfl.environment      :as env]
             [wfl.service.postgres :as postgres]
-            [wfl.sink :as sink]
-            [wfl.stage :as stage]
-            [wfl.tools.datasets :as datasets]
-            [wfl.tools.fixtures :as fixtures]
-            [wfl.tools.resources :as resources]
-            [wfl.tools.workloads :refer [evalT]]
-            [wfl.util :as util])
-  (:import [java.util ArrayDeque UUID]
+            [wfl.sink             :as sink]
+            [wfl.stage            :as stage]
+            [wfl.tools.datasets   :as datasets]
+            [wfl.tools.fixtures   :as fixtures]
+            [wfl.tools.queues     :refer [make-queue-from-list]]
+            [wfl.tools.resources  :as resources]
+            [wfl.tools.workloads  :refer [evalT]]
+            [wfl.util             :as util])
+  (:import [java.util UUID]
            [wfl.util UserException]))
-
-;; Queue mocks
-(def ^:private testing-queue-type "TestQueue")
-(defn ^:private make-queue-from-list [items]
-  {:type testing-queue-type :queue (ArrayDeque. items)})
-
-(defn ^:private testing-queue-peek [this]
-  (-> this :queue .peekFirst))
-
-(defn ^:private testing-queue-pop [this]
-  (-> this :queue .removeFirst))
-
-(defn ^:private testing-queue-length [this]
-  (-> this :queue .size))
-
-(defn ^:private testing-queue-done? [this]
-  (-> this :queue .isEmpty))
 
 (def ^:private ^:dynamic *dataset*)
 
 (use-fixtures :once
   fixtures/temporary-postgresql-database
-  (fixtures/method-overload-fixture
-   stage/peek-queue testing-queue-type testing-queue-peek)
-  (fixtures/method-overload-fixture
-   stage/pop-queue! testing-queue-type testing-queue-pop)
-  (fixtures/method-overload-fixture
-   stage/queue-length testing-queue-type testing-queue-length)
-  (fixtures/method-overload-fixture
-   stage/done? testing-queue-type testing-queue-done?)
   (fixtures/bind-fixture
    *dataset*
    fixtures/with-temporary-dataset

--- a/api/test/wfl/integration/sinks/datarepo_sink_test.clj
+++ b/api/test/wfl/integration/sinks/datarepo_sink_test.clj
@@ -150,4 +150,5 @@
         upstream    (make-queue-from-list [[description workflow]])
         sink        (create-and-load-datarepo-sink)]
     (sink/update-sink! upstream sink)
-    (is (stage/done? upstream))))
+    (is (stage/done? upstream))
+    (is (stage/done? sink))))

--- a/api/test/wfl/integration/sinks/datarepo_sink_test.clj
+++ b/api/test/wfl/integration/sinks/datarepo_sink_test.clj
@@ -127,10 +127,10 @@
 
 (deftest test-data-repo-job-queue-operations
   (let [sink (create-and-load-datarepo-sink)]
-    (is (nil? (#'sink/peek-datarepo-sink-job-queue sink)))
+    (is (nil? (#'sink/peek-job-queue sink)))
     (is (thrown-with-msg?
          ExceptionInfo #"TerraDataRepoSink job queue is empty"
-         (#'sink/pop-datarepo-sink-job-queue! sink)))))
+         (#'sink/pop-job-queue! sink)))))
 
 (deftest test-datarepo-sink-to-edn
   (let [response (util/to-edn (create-and-load-datarepo-sink))]
@@ -151,4 +151,4 @@
         sink        (create-and-load-datarepo-sink)]
     (sink/update-sink! upstream sink)
     (is (stage/done? upstream))
-    (is (stage/done? sink))))
+    (is (not (stage/done? sink)))))

--- a/api/test/wfl/integration/sinks/workspace_sink_test.clj
+++ b/api/test/wfl/integration/sinks/workspace_sink_test.clj
@@ -26,7 +26,7 @@
   {:type testing-queue-type :queue (ArrayDeque. items)})
 
 (defn ^:private testing-queue-peek [this]
-  (-> this :queue .getFirst))
+  (-> this :queue .peekFirst))
 
 (defn ^:private testing-queue-pop [this]
   (-> this :queue .removeFirst))

--- a/api/test/wfl/integration/sinks/workspace_sink_test.clj
+++ b/api/test/wfl/integration/sinks/workspace_sink_test.clj
@@ -8,9 +8,9 @@
             [wfl.sink              :as sink]
             [wfl.stage             :as stage]
             [wfl.tools.fixtures    :as fixtures]
+            [wfl.tools.queues      :refer [make-queue-from-list]]
             [wfl.tools.resources   :as resources])
-  (:import [java.util ArrayDeque]
-           [wfl.util UserException]))
+  (:import [wfl.util UserException]))
 
 ;; Workspace
 (def ^:private testing-namespace "wfl-dev")
@@ -20,36 +20,11 @@
 (def ^:private testing-entity-type "flowcell")
 (def ^:private testing-entity-name "test")
 
-;; Queue mocks
-(def ^:private testing-queue-type "TestQueue")
-(defn ^:private make-queue-from-list [items]
-  {:type testing-queue-type :queue (ArrayDeque. items)})
-
-(defn ^:private testing-queue-peek [this]
-  (-> this :queue .peekFirst))
-
-(defn ^:private testing-queue-pop [this]
-  (-> this :queue .removeFirst))
-
-(defn ^:private testing-queue-length [this]
-  (-> this :queue .size))
-
-(defn ^:private testing-queue-done? [this]
-  (-> this :queue .isEmpty))
-
 (let [new-env {"WFL_FIRECLOUD_URL" "https://api.firecloud.org"
                "WFL_RAWLS_URL"     "https://rawls.dsde-prod.broadinstitute.org"}]
   (use-fixtures :once
     (fixtures/temporary-environment new-env)
-    fixtures/temporary-postgresql-database
-    (fixtures/method-overload-fixture
-     stage/peek-queue testing-queue-type testing-queue-peek)
-    (fixtures/method-overload-fixture
-     stage/pop-queue! testing-queue-type testing-queue-pop)
-    (fixtures/method-overload-fixture
-     stage/queue-length testing-queue-type testing-queue-length)
-    (fixtures/method-overload-fixture
-     stage/done? testing-queue-type testing-queue-done?)))
+    fixtures/temporary-postgresql-database))
 
 ;; Validation tests
 

--- a/api/test/wfl/integration/sinks/workspace_sink_test.clj
+++ b/api/test/wfl/integration/sinks/workspace_sink_test.clj
@@ -35,7 +35,7 @@
   (-> this :queue .size))
 
 (defn ^:private testing-queue-done? [this]
-  (-> this :queue .empty))
+  (-> this :queue .isEmpty))
 
 (let [new-env {"WFL_FIRECLOUD_URL" "https://api.firecloud.org"
                "WFL_RAWLS_URL"     "https://rawls.dsde-prod.broadinstitute.org"}]

--- a/api/test/wfl/tools/queues.clj
+++ b/api/test/wfl/tools/queues.clj
@@ -1,0 +1,13 @@
+(ns wfl.tools.queues
+  (:require [wfl.stage :as stage])
+  (:import [java.util ArrayDeque]))
+
+(def ^:private testing-queue-type "TestQueue")
+
+(defn make-queue-from-list [items]
+  {:type testing-queue-type :queue (ArrayDeque. items)})
+
+(defmethod stage/peek-queue   testing-queue-type [q] (-> q :queue .peekFirst))
+(defmethod stage/pop-queue!   testing-queue-type [q] (-> q :queue .removeFirst))
+(defmethod stage/queue-length testing-queue-type [q] (-> q :queue .size))
+(defmethod stage/done?        testing-queue-type [q] (-> q :queue .isEmpty))

--- a/api/test/wfl/tools/workflows.clj
+++ b/api/test/wfl/tools/workflows.clj
@@ -1,4 +1,4 @@
-(ns wfl.workflows
+(ns wfl.tools.workflows
   (:require [clojure.set :as set]))
 
 (defn make-object-type
@@ -52,17 +52,16 @@
          (reduce #(go %1 array-type %2) state value))
        "Map"
        (let [{:keys [keyType valueType]} (:mapType type)]
-         (reduce-kv #(-> (go %1 keyType %2) (go valueType %3)) state value))
+         (reduce-kv #(-> %1 (go keyType %2) (go valueType %3)) state value))
        "Object"
        (let [name->type (make-type-environment type)]
          (reduce-kv #(go %1 (name->type %2) %3) state value))
        "Optional"
        (if value (go state (:optionalType type) value) state)
        "Pair"
-       (let [{:keys [leftType rightType]} (:pairType type)]
-         (-> state
-             (go leftType  (first value))
-             (go rightType (second value))))
+       (let [{:keys [leftType rightType]} (:pairType type)
+             [leftValue rightValue]       value]
+         (-> state (go leftType leftValue) (go rightType rightValue)))
        (f state [(:typeName type) value])))
    init type value))
 

--- a/api/test/wfl/tools/workloads.clj
+++ b/api/test/wfl/tools/workloads.clj
@@ -17,7 +17,6 @@
             [wfl.tools.endpoints            :as endpoints]
             [wfl.util                       :as util])
   (:import [java.time OffsetDateTime]
-           [java.util.concurrent TimeoutException]
            [java.util UUID]))
 
 (def clio-url (delay (env/getenv "WFL_CLIO_URL")))

--- a/api/test/wfl/unit/mime_type_test.clj
+++ b/api/test/wfl/unit/mime_type_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test        :refer [deftest is]]
             [wfl.mime-type       :as mime-type]
             [wfl.tools.resources :as resources]
-            [wfl.workflows       :as workflows]))
+            [wfl.tools.workflows :as workflows]))
 
 (deftest test-mime-types
   (let [cases [[".bam"   "application/octet-stream"]

--- a/api/test/wfl/unit/mime_type_test.clj
+++ b/api/test/wfl/unit/mime_type_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test        :refer [deftest is]]
             [wfl.mime-type       :as mime-type]
             [wfl.tools.resources :as resources]
-            [wfl.tools.workflows :as workflows]))
+            [wfl.workflows       :as workflows]))
 
 (deftest test-mime-types
   (let [cases [[".bam"   "application/octet-stream"]
@@ -27,7 +27,7 @@
                 (-> "sarscov2_illumina_full.edn" resources/read-resource :outputs)]]]
     (doseq [[values description] cases]
       (let [type (workflows/make-object-type description)]
-        (doseq [filename (workflows/get-files type values)]
+        (doseq [filename (workflows/get-files [type values])]
           (let [ext (mime-type/ext-mime-type-no-default filename)]
             (is (or (some? ext) (exclude? filename))
                 (str filename " does not have a mime-type"))))))))

--- a/api/test/wfl/unit/sink_test.clj
+++ b/api/test/wfl/unit/sink_test.clj
@@ -1,5 +1,5 @@
 (ns wfl.unit.sink-test
-  (:require [clojure.test         :refer [deftest is testing]]
+  (:require [clojure.test         :refer [deftest is]]
             [wfl.sink             :as sink]
             [wfl.tools.resources  :as resources]))
 

--- a/api/test/wfl/unit/workflows_test.clj
+++ b/api/test/wfl/unit/workflows_test.clj
@@ -1,7 +1,7 @@
 (ns wfl.unit.workflows-test
   (:require [clojure.test        :refer [deftest is testing]]
             [wfl.tools.resources :as resources]
-            [wfl.workflows       :as workflows]
+            [wfl.tools.workflows :as workflows]
             [wfl.util            :as util])
   (:import (clojure.lang ExceptionInfo)))
 

--- a/api/test/wfl/unit/workflows_test.clj
+++ b/api/test/wfl/unit/workflows_test.clj
@@ -1,19 +1,19 @@
 (ns wfl.unit.workflows-test
   (:require [clojure.test        :refer [deftest is testing]]
-            [wfl.tools.workflows :as workflows]
             [wfl.tools.resources :as resources]
+            [wfl.workflows       :as workflows]
             [wfl.util            :as util])
   (:import (clojure.lang ExceptionInfo)))
 
-(defn ^:private filtering-type [test? type object]
-  (letfn [(f [vs t v] (if (test? t) (conj vs v) vs))]
-    (workflows/foldl f #{} type object)))
+(defn ^:private collect-values-where-type [test? object]
+  (letfn [(f [vs [t v]] (if (test? t) (conj vs v) vs))]
+    (workflows/foldl f #{} object)))
 
-(defn ^:private get-primitives [type object]
-  (letfn [(f [ts t _] (conj ts t))]
-    (workflows/foldl f #{} type object)))
+(def ^:private collect-primitives
+  (letfn [(f [ts [t _]] (conj ts t))]
+    (partial workflows/foldl f #{})))
 
-(defn ^:private lift-value [f] (fn [_ value] (f value)))
+(defn ^:private lift-value [f] (comp f second))
 (def ^:private  vectorize (partial workflows/traverse (lift-value vector)))
 
 (defn ^:private make-output-type [resource-file]
@@ -28,12 +28,12 @@
       (is (thrown-with-msg?
            ExceptionInfo
            #"No type definition found for name\."
-           (workflows/foldl (constantly nil) nil type {:no-such-name nil}))))
+           (workflows/foldl (constantly nil) nil [type {:no-such-name nil}]))))
     (testing "traverse"
       (is (thrown-with-msg?
            ExceptionInfo
            #"No type definition found for name\."
-           (workflows/traverse (constantly nil) type {:no-such-name nil}))))))
+           (workflows/traverse (constantly nil) [type {:no-such-name nil}]))))))
 
 (deftest test-primitive-types
   (let [type (make-output-type "primitive.edn")
@@ -44,67 +44,63 @@
                  :outstring "Hello, World!"}]
     (testing "foldl"
       (is (= #{"Boolean" "File" "Float" "Int" "String"}
-             (get-primitives type outputs)))
+             (collect-primitives [type outputs])))
       (is (= #{"Boolean" "File" "Float" "Int"}
-             (get-primitives type (dissoc outputs :outstring))))
-      (is (= #{"lolcats.txt"} (workflows/get-files type outputs))))
+             (collect-primitives [type (dissoc outputs :outstring)])))
+      (is (= #{"lolcats.txt"} (workflows/get-files [type outputs]))))
     (testing "traverse"
-      (is (= (util/map-vals vector outputs) (vectorize type outputs))))))
+      (is (= (util/map-vals vector outputs) (vectorize [type outputs]))))))
 
 (deftest test-array-types
-  (letfn [(typeless [p1 _p2 p3] (conj p1 p3))]
+  (letfn [(typeless [p1 [_p2 p3]] (conj p1 p3))]
     (let [type    (make-output-type "compound.edn")
           outputs {:outarray  ["clojure" "is" "fun"]}]
       (testing "foldl"
         (is (= (:outarray outputs)
-               (workflows/foldl typeless [] type outputs))))
+               (workflows/foldl typeless [] [type outputs]))))
       (testing "traverse"
         (is (= (util/map-vals #(map vector %) outputs)
-               (vectorize type outputs)))))))
+               (vectorize [type outputs])))))))
 
 (deftest test-map-types
   (let [type    (make-output-type "compound.edn")
         outputs {:outmap {"foo" "lolcats.txt" "bar" "in.gif"}}]
     (testing "foldl"
       (is (= #{"foo" "bar"}
-             (filtering-type #(= % "String") type outputs)))
+             (collect-values-where-type #(= % "String") [type outputs])))
       (is (= #{"lolcats.txt" "in.gif"}
-             (filtering-type #(= % "File") type outputs))))
+             (collect-values-where-type #(= % "File") [type outputs]))))
     (testing "traverse"
       (is (= {:outmap {["foo"] ["lolcats.txt"] ["bar"] ["in.gif"]}}
-             (vectorize type outputs))))))
+             (vectorize [type outputs]))))))
 
 (deftest test-optional-types
   (let [type    (make-output-type "compound.edn")
         without {:outoptional  nil}
         with    {:outoptional  "lolcats.txt"}]
     (testing "foldl"
-      (is (= 0 (count (workflows/get-files type without))))
-      (is (= 1 (count (workflows/get-files type with)))))
+      (is (= 0 (count (workflows/get-files [type without]))))
+      (is (= 1 (count (workflows/get-files [type with])))))
     (testing "traverse"
-      (is (= without (vectorize type without)))
-      (is (= (util/map-vals vector with) (vectorize type with))))))
+      (is (= without (vectorize [type without])))
+      (is (= (util/map-vals vector with) (vectorize [type with]))))))
 
 (deftest test-pair-types
-  (let [type    (make-output-type "compound.edn")
-        outputs {:outpair '(3 3.14)}]
+  (let [object [(make-output-type "compound.edn") {:outpair '(3 3.14)}]]
     (testing "foldl"
-      (is (= #{3.14} (filtering-type #(= % "Float") type outputs))))
+      (is (= #{3.14} (collect-values-where-type #(= % "Float") object))))
     (testing "traverse"
       (is (= {:outpair '(9 3.14)}
              (workflows/traverse
-              (fn [type v] (if (= type "Int") (* v v) v))
-              type
-              outputs))))))
+              (fn [[type v]] (if (= type "Int") (* v v) v))
+             object))))))
 
 (deftest test-struct-types
-  (let [type    (make-output-type "compound.edn")
-        outputs {:outstruct {:value 3}}]
+  (let [object [(make-output-type "compound.edn") {:outstruct {:value 3}}]]
     (testing "foldl"
-      (is (= #{3} (filtering-type #(= % "Int") type outputs))))
+      (is (= #{3} (collect-values-where-type #(= % "Int") object))))
     (testing "traverse"
       (is (= {:outstruct {:value 9}}
              (workflows/traverse
-              (fn [type v] (if (= type "Int") (* v v) v))
-              type
-              outputs))))))
+              (fn [[type v]] (if (= type "Int") (* v v) v))
+              object))))))

--- a/api/test/wfl/unit/workflows_test.clj
+++ b/api/test/wfl/unit/workflows_test.clj
@@ -93,7 +93,7 @@
       (is (= {:outpair '(9 3.14)}
              (workflows/traverse
               (fn [[type v]] (if (= type "Int") (* v v) v))
-             object))))))
+              object))))))
 
 (deftest test-struct-types
   (let [object [(make-output-type "compound.edn") {:outstruct {:value 3}}]]

--- a/database/changesets/20210709_TerraDataRepoSink.xml
+++ b/database/changesets/20210709_TerraDataRepoSink.xml
@@ -13,36 +13,14 @@
                logicalFilePath="20210709_TerraDataRepoSink.xml"
                runInTransaction="false">
         <comment>
-            A descriptor for the type of TDR job wfl started while ingesting
-            outputs
-        </comment>
-        <sql>
-            CREATE TYPE TDRJobType AS ENUM (
-                'FileLoad',
-                'MetadataIngest'
-            )
-        </sql>
-        <comment>
-            The status of the TDR job wfl started, as reported by TDR. See
-            https://data.terra.bio/swagger-ui.html#/repository/retrieveJob
-            for details.
-        </comment>
-        <sql>
-            CREATE TYPE TDRJobStatus AS ENUM (
-                'running',
-                'succeeded',
-                'failed'
-            )
-        </sql>
-        <comment>
             The TDR Job Queue used by the `TerraDataRepo` Sink
         </comment>
         <sql>
             CREATE TYPE TerraDataRepoSinkDetails AS (
                 id        BIGINT,       -- ALTER ADD GENERATED ALWAYS AS IDENTITY
-                type      TDRJobType,   -- For dispatching to right handler
+                type      TEXT,         -- For dispatching to right handler
                 job       TEXT,         -- UUID of the job created in TDR
-                status    TDRJobStatus, -- As reported by TDR
+                status    TEXT,         -- As reported by TDR
                 updated   TIMESTAMPTZ,  -- When this record was last updated
                 payload   TEXT,         -- generic JSON payload for the handler
                 consumed  TIMESTAMPTZ   -- when this job was "evicted" from the queue

--- a/database/changesets/20210709_TerraDataRepoSink.xml
+++ b/database/changesets/20210709_TerraDataRepoSink.xml
@@ -13,17 +13,16 @@
                logicalFilePath="20210709_TerraDataRepoSink.xml"
                runInTransaction="false">
         <comment>
-            The TDR Job Queue used by the `TerraDataRepo` Sink
+            The TDR Job list used by the `TerraDataRepo` Sink
         </comment>
         <sql>
             CREATE TYPE TerraDataRepoSinkDetails AS (
-                id        BIGINT,       -- ALTER ADD GENERATED ALWAYS AS IDENTITY
-                type      TEXT,         -- For dispatching to right handler
-                job       TEXT,         -- UUID of the job created in TDR
-                status    TEXT,         -- As reported by TDR
-                updated   TIMESTAMPTZ,  -- When this record was last updated
-                payload   TEXT,         -- generic JSON payload for the handler
-                consumed  TIMESTAMPTZ   -- when this job was "evicted" from the queue
+                id        BIGINT,      -- ALTER ADD GENERATED ALWAYS AS IDENTITY
+                job       TEXT,        -- ID of the job created in TDR
+                status    TEXT,        -- As reported by TDR
+                workflow  TEXT,        -- The UUID of the workflow this job relates to
+                updated   TIMESTAMPTZ, -- When this record was last updated
+                consumed  TIMESTAMPTZ  -- When this job was "popped"
             )
         </sql>
         <comment>
@@ -35,7 +34,7 @@
                 dataset       TEXT NOT NULL,                                     -- the serialized EDN of the TDR dataset schema
                 dataset_table TEXT NOT NULL,                                     -- the name of the dataset table
                 from_outputs  TEXT NOT NULL,                                     -- mapping of how to coerce the output of executor to whatever the sink understands in serialized EDN
-                details       TEXT NOT NULL,                                     -- the name of the sink details table
+                details       TEXT NOT NULL,                                     -- name of the job queue
                 CONSTRAINT TERRADATAREPOSINK_PKEY PRIMARY KEY (id)
             )
         </sql>


### PR DESCRIPTION
RR: https://broadinstitute.atlassian.net/browse/GH-1415

This change contains a rough implementation of the TerraDataRepo sink update functionality. After discovering certain hurdles in the original design, I've made some tweaks and incorporated TDR's work https://broadworkbench.atlassian.net/browse/DR-1960 so that we only need one ingest request instead of separately loading the output files and output metadata. At the time of writing, DR-1960 is work in progress so our ingests won't work just yet.

Some things to call out in this change that I'm deferring to a follow up change into the feature branch:
- I need to upload the json file for TDR to ingest. I'm currently using our test outputs bucket as a temporary folder for this which is obviously not a production-ready solution. Possible fixes include creating a scratch bucket for workflow-launcher, creating a bucket per workload, using the executor's execution bucket... etc. Suggestions welcome.
- Since the ingests always fail, I'm leaving some of the work post-ingest as a TODO.