### PR TITLE
[GH-1139] Logging level and configuration

### DIFF
--- a/api/src/wfl/api/handlers.clj
+++ b/api/src/wfl/api/handlers.clj
@@ -32,7 +32,7 @@
   (log/info (select-keys request [:request-method :uri :body-params]))
   (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
     (letfn [(to-result [s] {:level s})]
-      (-> (config/load-logging-level tx)
+      (-> (config/get-config tx "LOGGING_LEVEL")
           to-result
           succeed))))
 

--- a/api/src/wfl/api/routes.clj
+++ b/api/src/wfl/api/routes.clj
@@ -45,6 +45,16 @@
                                 (env/getenv "WFL_OAUTH2_CLIENT_ID")}))
            :responses {200 {:body {:oauth2-client-id string?}}}
            :swagger   {:tags ["Informational"]}}}]
+   ["/api/v1/logging_level"
+    {:get  {:no-doc true
+            :summary "Get the current logging level"
+            :handler handlers/get-logging-level
+            :responses {200 {:body ::log/logging-level-response}}
+            :swagger {:tags ["Informational"]}}
+     :post {:summary    "Post a new logging level."
+            :parameters {:query ::log/logging-level-request}
+            :responses  {200 {:body ::log/logging-level-response}}
+            :handler    handlers/update-logging-level}}]
    ["/api/v1/append_to_aou"
     {:post {:summary    "Append to an existing AOU workload."
             :parameters {:body ::aou/append-to-aou-request}

--- a/api/src/wfl/configuration.clj
+++ b/api/src/wfl/configuration.clj
@@ -1,0 +1,27 @@
+(ns wfl.configuration
+  "Configuration for WFL. A configuration table exists as a simple key
+   value store for simple configuration."
+  (:require [clojure.string                 :as str]
+            [wfl.jdbc                       :as jdbc]))
+
+(def ^:private configuration-table "configuration")
+
+(defn load-logging-level
+  "Use transaction `tx` to load the current logging level of the application."
+  [tx]
+  (let [levels (jdbc/query tx ["SELECT value FROM configuration WHERE key = 'LOGGING_LEVEL' LIMIT 1"])]
+    (if (empty? levels)
+      (-> :info name str/upper-case)
+      (str/upper-case (get (first levels) :value)))))
+
+(defn upsert-config
+  "Use transaction `tx` to insert or update a configuration row."
+  [tx key value]
+  (letfn [(get-row [] (jdbc/query tx [(str "SELECT * FROM configuration WHERE key = '" key "' LIMIT 1")]))]
+    (if (empty? (get-row))
+      (if (empty? (jdbc/insert! tx configuration-table {:key key :value value}))
+        (throw (ex-info "Unable to insert " key))
+        (get-row))
+      (if (empty? (jdbc/update! tx configuration-table {:value value} ["key = ?" key]))
+        (throw (ex-info "Unable to update " key))
+        (get-row)))))

--- a/api/src/wfl/configuration.clj
+++ b/api/src/wfl/configuration.clj
@@ -17,7 +17,7 @@
 (defn upsert-config
   "Use transaction `tx` to insert or update a configuration row."
   [tx key value]
-  (letfn [(get-row [] (jdbc/query tx [(str "SELECT * FROM configuration WHERE key = '" key "' LIMIT 1")]))]
+  (letfn [(get-row [] (jdbc/query tx ["SELECT * FROM configuration WHERE key = ?" key]))]
     (if (empty? (get-row))
       (jdbc/insert! tx configuration-table {:key key :value value})
       (if (empty? (jdbc/update! tx configuration-table {:value value} ["key = ?" key]))

--- a/api/src/wfl/jdbc.clj
+++ b/api/src/wfl/jdbc.clj
@@ -2,7 +2,7 @@
   "wfl.log wrapping for clojure.java.jdbc"
   (:require [clojure.java.jdbc :as jdbc]
             [clojure.string    :as str]
-            [wfl.log           :as log])
+            [wfl.log           :as logger])
   (:import (clojure.lang IPersistentVector)
            (java.sql PreparedStatement Array)))
 
@@ -11,7 +11,7 @@
   (memoize (fn [{:keys [connection-uri user] :as db}]
              (let [random     (rand-int 10000)
                    identifier (str user "@" connection-uri "#" random)]
-               (log/info (dissoc db :password))
+               (logger/info (dissoc db :password))
                identifier))))
 
 (defn format-db
@@ -24,13 +24,13 @@
   ([db sql-params]
    `(let [db#         ~db
           sql-params# ~sql-params]
-      (log/debug (str/join " " ["jdbc/query:" (format-db db#) sql-params#]))
+      (logger/debug (str/join " " ["jdbc/query:" (format-db db#) sql-params#]))
       (jdbc/query db# sql-params#)))
   ([db sql-params opts]
    `(let [db#         ~db
           sql-params# ~sql-params
           opts#       ~opts]
-      (log/debug (str/join " " ["jdbc/query:" (format-db db#) sql-params# opts#]))
+      (logger/debug (str/join " " ["jdbc/query:" (format-db db#) sql-params# opts#]))
       (jdbc/query db# sql-params# opts#))))
 
 (defmacro update!
@@ -40,7 +40,7 @@
           table#        ~table
           set-map#      ~set-map
           where-clause# ~where-clause]
-      (log/info (str/join " " ["jdbc/update!" (format-db db#) table# set-map# where-clause#]))
+      (logger/info (str/join " " ["jdbc/update!" (format-db db#) table# set-map# where-clause#]))
       (jdbc/update! db# table# set-map# where-clause#)))
   ([db table set-map where-clause opts]
    `(let [db#           ~db
@@ -48,7 +48,7 @@
           set-map#      ~set-map
           where-clause# ~where-clause
           opts#         ~opts]
-      (log/info (str/join " " ["jdbc/update!" (format-db db#) table# set-map# where-clause# opts#]))
+      (logger/info (str/join " " ["jdbc/update!" (format-db db#) table# set-map# where-clause# opts#]))
       (jdbc/update! db# table# set-map# where-clause# opts#))))
 
 (defmacro insert-multi!
@@ -57,14 +57,14 @@
    `(let [db#    ~db
           table# ~table
           rows#  ~rows]
-      (log/info (str/join " " ["jdbc/insert-multi!" (format-db db#) table# rows#]))
+      (logger/info (str/join " " ["jdbc/insert-multi!" (format-db db#) table# rows#]))
       (jdbc/insert-multi! db# table# rows#)))
   ([db table cols-or-rows values-or-opts]
    `(let [db#             ~db
           table#          ~table
           cols-or-rows#   ~cols-or-rows
           values-or-opts# ~values-or-opts]
-      (log/info (str/join " " ["jdbc/insert-multi!" (format-db db#) table# cols-or-rows# values-or-opts#]))
+      (logger/info (str/join " " ["jdbc/insert-multi!" (format-db db#) table# cols-or-rows# values-or-opts#]))
       (jdbc/insert-multi! db# table# cols-or-rows# values-or-opts#)))
   ([db table cols values opts]
    `(let [db#     ~db
@@ -72,7 +72,7 @@
           cols#   ~cols
           values# ~values
           opts#   ~opts]
-      (log/info (str/join " " ["jdbc/insert-multi!" (format-db db#) table# cols# values# opts#]))
+      (logger/info (str/join " " ["jdbc/insert-multi!" (format-db db#) table# cols# values# opts#]))
       (jdbc/insert-multi! db# table# cols# values# opts#))))
 
 (defmacro execute!
@@ -80,13 +80,13 @@
   ([db sql-params]
    `(let [db#         ~db
           sql-params# ~sql-params]
-      (log/info (str/join " " ["jdbc/execute!" (format-db db#) sql-params#]))
+      (logger/info (str/join " " ["jdbc/execute!" (format-db db#) sql-params#]))
       (jdbc/execute! db# sql-params#)))
   ([db sql-params opts]
    `(let [db#         ~db
           sql-params# ~sql-params
           opts#       ~opts]
-      (log/info (str/join " " ["jdbc/execute!" (format-db db#) sql-params# opts#]))
+      (logger/info (str/join " " ["jdbc/execute!" (format-db db#) sql-params# opts#]))
       (jdbc/execute! db# sql-params# opts#))))
 
 (defmacro db-do-commands
@@ -94,13 +94,13 @@
   ([db sql-commands]
    `(let [db#           ~db
           sql-commands# ~sql-commands]
-      (log/info (str/join " " ["jbs/db-do-commands" (format-db db#) sql-commands#]))
+      (logger/info (str/join " " ["jbs/db-do-commands" (format-db db#) sql-commands#]))
       (jdbc/db-do-commands db# sql-commands#)))
   ([db transaction? sql-commands]
    `(let [db#           ~db
           transaction?# ~transaction?
           sql-commands# ~sql-commands]
-      (log/info (str/join " " ["jbs/db-do-commands" (format-db db#) transaction?# sql-commands#]))
+      (logger/info (str/join " " ["jbs/db-do-commands" (format-db db#) transaction?# sql-commands#]))
       (jdbc/db-do-commands db# transaction?# sql-commands#))))
 
 (defmacro insert!
@@ -109,14 +109,14 @@
    `(let [db#    ~db
           table# ~table
           row#   ~row]
-      (log/info (str/join " " ["jdbc/insert" (format-db db#) table# row#]))
+      (logger/info (str/join " " ["jdbc/insert" (format-db db#) table# row#]))
       (jdbc/insert! db# table# row#)))
   ([db table cols-or-row values-or-opts]
    `(let [db#             ~db
           table#          ~table
           cols-or-row#    ~cols-or-row
           values-or-opts# ~values-or-opts]
-      (log/info (str/join " " ["jdbc/insert" (format-db db#) table# cols-or-row# values-or-opts#]))
+      (logger/info (str/join " " ["jdbc/insert" (format-db db#) table# cols-or-row# values-or-opts#]))
       (jdbc/insert! db# table# cols-or-row# values-or-opts#)))
   ([db table cols values opts]
    `(let [db#     ~db
@@ -124,7 +124,7 @@
           cols#   ~cols
           values# ~values
           opts#   ~opts]
-      (log/info (str/join " " ["jdbc/insert" (format-db db#) table# cols# values# opts#]))
+      (logger/info (str/join " " ["jdbc/insert" (format-db db#) table# cols# values# opts#]))
       "jdbc/insert" db# table# cols# values# opts#)))
 
 (defmacro with-db-transaction
@@ -132,9 +132,9 @@
   [binding & body]
   `(let [id#    (rand-int 10000)
          init# ~(second binding)]
-     (log/info (str/join " " ["JDBC transaction" id# "started to" (format-db init#)]))
+     (logger/info (str/join " " ["JDBC transaction" id# "started to" (format-db init#)]))
      (let [exe# (jdbc/with-db-transaction [~(first binding) init#] ~@body)]
-       (log/info (str/join " " ["JDBC SQL transaction" id# "ended"]))
+       (logger/info (str/join " " ["JDBC SQL transaction" id# "ended"]))
        exe#)))
 
 (defmacro prepare-statement
@@ -149,11 +149,11 @@
   "Logged alias for [[clojure.java.jdbc/prepare-statement]]"
   ([db-spec]
    `(do
-      (log/info (str/join " " ["JBDC SQL connection made (no opts):" (format-db ~db-spec)]))
+      (logger/info (str/join " " ["JBDC SQL connection made (no opts):" (format-db ~db-spec)]))
       (jdbc/get-connection ~db-spec)))
   ([db-spec opts]
    `(do
-      (log/info (str/join " " ["JBDC SQL connection made:" (format-db ~db-spec) ~opts]))
+      (logger/info (str/join " " ["JBDC SQL connection made:" (format-db ~db-spec) ~opts]))
       (jdbc/get-connection ~db-spec ~opts))))
 
 ;; Expertly copied and pasted from Stack Overflow:

--- a/api/src/wfl/log.clj
+++ b/api/src/wfl/log.clj
@@ -2,9 +2,23 @@
   "Logging for WFL. The severity levels provided here are based off of
    the severity levels supported by GCP's Stackdriver. A list of the supported
    levels can be found here: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogSeverity"
-  (:require [clojure.data.json :as json]
-            [clojure.string    :as str])
+  (:require [clojure.data.json              :as json]
+            [clojure.string                 :as str]
+            [clojure.spec.alpha             :as s])
   (:import [java.time Instant]))
+
+(def levels
+  "A list of the available logging levels the application can use."
+  [:debug :info :notice :warning :error :alert :critical :emergency])
+
+(defn levels-contains?
+  "Validate that the provided label exists."
+  [s]
+  (let [level (-> s str/lower-case keyword)]
+    (some #(= level %) levels)))
+(s/def ::level (s/and string? levels-contains?))
+(s/def ::logging-level-request (s/keys :req-un [::level]))
+(s/def ::logging-level-response (s/keys :req-un [::level]))
 
 (defn ^:private key-fn
   "Preserve the namespace of `key` when qualified."
@@ -35,6 +49,28 @@
   "The logger now."
   stdout-logger)
 
+(def logging-level
+  "The current logging level of the application."
+  (atom {:debug false
+         :info true
+         :notice true
+         :warning true
+         :error true
+         :alert true
+         :critical true
+         :emergency true}))
+
+(defn to-logging-level-edn
+  "Takes a root logging level and converts into an edn."
+  [level]
+  (let [enabler (atom false)
+        edn     (atom {})]
+    (doseq [l levels]
+      (if (= l level)
+        (swap! edn assoc l (reset! enabler true))
+        (swap! edn assoc l @enabler)))
+    @edn))
+
 (defmacro log
   "Log `expression` with `severity` and a optional set of special
    fields to provide more information about a logging message.
@@ -56,13 +92,14 @@
   [severity expression & {:as additional-fields}]
   (let [{:keys [line]} (meta &form)]
     `(let [x# ~expression]
-       (-write *logger*
-               (merge {:timestamp (Instant/now)
-                       :severity ~(-> severity name str/upper-case)
-                       :message x#
-                       :logging.googleapis.com/sourceLocation
-                       {:file ~*file* :line ~line}}
-                      ~additional-fields))
+       (when (get @logging-level ~severity)
+         (-write *logger*
+                 (merge {:timestamp (Instant/now)
+                         :severity ~(-> severity name str/upper-case)
+                         :message x#
+                         :logging.googleapis.com/sourceLocation
+                         {:file ~*file* :line ~line}}
+                        ~additional-fields)))
        nil)))
 
 (defmacro debug

--- a/api/src/wfl/server.clj
+++ b/api/src/wfl/server.clj
@@ -125,12 +125,11 @@
   "Start polling for changes to the log level."
   []
   (letfn [(get-logging-level [] (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
-                                  (let [config (config/load-logging-level tx)]
-                                    (->> (if (empty? config)
-                                           :info
-                                           (-> config str/lower-case keyword))
-                                         (log/to-logging-level-edn)
-                                         (reset! log/logging-level)))))]
+                                  (let [config (config/get-config tx "LOGGING_LEVEL")]
+                                    (reset! log/logging-level
+                                            (if (empty? config)
+                                              :info
+                                              (-> config str/lower-case keyword))))))]
     (get-logging-level)
     (future
       (while true

--- a/api/src/wfl/server.clj
+++ b/api/src/wfl/server.clj
@@ -15,7 +15,8 @@
             [wfl.jdbc                       :as jdbc]
             [wfl.service.postgres           :as postgres]
             [wfl.util                       :as util]
-            [wfl.wfl                        :as wfl])
+            [wfl.wfl                        :as wfl]
+            [wfl.configuration              :as config])
   (:import (java.util.concurrent Future TimeUnit)
            (wfl.util UserException)))
 
@@ -57,7 +58,7 @@
     (try
       (handler request)
       (catch Throwable t
-        (log/error t)))))
+        (log/error (str t))))))
 
 ;; See https://stackoverflow.com/a/43075132
 ;;
@@ -101,7 +102,7 @@
               (do-update! workload)
               (catch Throwable t
                 (log/error (format "Failed to update workload %s" uuid))
-                (log/error t))))
+                (log/error (str t)))))
           (update-workloads []
             (try
               (log/info "Finding workloads to update...")
@@ -112,13 +113,29 @@
                                       AND finished IS NULL")))
               (catch Throwable t
                 (log/error "Failed to update workloads")
-                (log/error t))))]
+                (log/error (str t)))))]
     (log/info "starting workload update loop")
     (update-workloads)
     (future
       (while true
         (update-workloads)
         (.sleep TimeUnit/SECONDS 20)))))
+
+(defn ^:private start-logging-polling
+  "Start polling for changes to the log level."
+  []
+  (letfn [(get-logging-level [] (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+                                  (let [config (config/load-logging-level tx)]
+                                    (->> (if (empty? config)
+                                           :info
+                                           (-> config str/lower-case keyword))
+                                         (log/to-logging-level-edn)
+                                         (reset! log/logging-level)))))]
+    (get-logging-level)
+    (future
+      (while true
+        (get-logging-level)
+        (.sleep TimeUnit/SECONDS 60)))))
 
 (defn ^:private start-webserver
   "Start the jetty webserver asynchronously to serve http requests on the
@@ -149,5 +166,6 @@
   [& args]
   (log/info (str/join " " ["Run:" wfl/the-name "server" args]))
   (let [port    (util/is-non-negative! (first args))
-        manager (start-workload-manager)]
-    (await-some manager (start-webserver port))))
+        manager (start-workload-manager)
+        logger  (start-logging-polling)]
+    (await-some manager logger (start-webserver port))))

--- a/api/test/wfl/unit/logging_test.clj
+++ b/api/test/wfl/unit/logging_test.clj
@@ -25,24 +25,11 @@
     (and (= (get-in json ["severity"]) (-> severity name upper-case))
          (boolean (check-message? test (get-in json ["message"]))))))
 
-(deftest to-logging-level-edn-test
-  (testing "test the to-logging-level-edn function produces the correct end"
-    (let [info-level (log/to-logging-level-edn :info)
-          warning-level (log/to-logging-level-edn :warning)
-          error-level (log/to-logging-level-edn :error)]
-      (is (= false (get info-level :debug)))
-      (is (= true (get info-level :info)))
-      (is (= true (get info-level :notice)))
-      (is (= false (get warning-level :info)))
-      (is (= true (get warning-level :warning)))
-      (is (= false (get error-level :warning)))
-      (is (= true (get error-level :error))))))
-
 ;; Useful information on this file is in docs/logging.md#Testing
 
 (deftest level-test
   (testing "basic logging levels"
-    (with-redefs [log/logging-level (atom (log/to-logging-level-edn :debug))]
+    (with-redefs [log/logging-level (atom :debug)]
       (is (logged? (with-out-str (log/info "Hello World!")) :info "Hello World!"))
       (is (logged? (with-out-str (log/warn "This is a warning")) :warning "This is a warning"))
       (is (logged? (with-out-str (log/error "This is an error")) :error "This is an error"))
@@ -50,6 +37,6 @@
 
 (deftest severity-level-filtering-test
   (testing "test current logging level correctly ignores lesser levels"
-    (with-redefs [log/logging-level (atom (log/to-logging-level-edn :info))]
+    (with-redefs [log/logging-level (atom :info)]
       (is (blank? (with-out-str (log/debug "Debug Message"))))
       (is (logged? (with-out-str (log/info "Info Message")) :info "Info Message")))))

--- a/api/test/wfl/unit/logging_test.clj
+++ b/api/test/wfl/unit/logging_test.clj
@@ -4,7 +4,7 @@
    [wfl.log :as log]
    [clojure.data.json :refer [read-str]]
    [clojure.test :refer [is deftest testing]]
-   [clojure.string :refer [upper-case]])
+   [clojure.string :refer [upper-case blank?]])
   (:import java.util.regex.Pattern))
 
 (defmulti check-message?
@@ -25,11 +25,31 @@
     (and (= (get-in json ["severity"]) (-> severity name upper-case))
          (boolean (check-message? test (get-in json ["message"]))))))
 
+(deftest to-logging-level-edn-test
+  (testing "test the to-logging-level-edn function produces the correct end"
+    (let [info-level (log/to-logging-level-edn :info)
+          warning-level (log/to-logging-level-edn :warning)
+          error-level (log/to-logging-level-edn :error)]
+      (is (= false (get info-level :debug)))
+      (is (= true (get info-level :info)))
+      (is (= true (get info-level :notice)))
+      (is (= false (get warning-level :info)))
+      (is (= true (get warning-level :warning)))
+      (is (= false (get error-level :warning)))
+      (is (= true (get error-level :error))))))
+
 ;; Useful information on this file is in docs/logging.md#Testing
 
 (deftest level-test
   (testing "basic logging levels"
-    (is (logged? (with-out-str (log/info "Hello World!")) :info "Hello World!"))
-    (is (logged? (with-out-str (log/warn "This is a warning")) :warning "This is a warning"))
-    (is (logged? (with-out-str (log/error "This is an error")) :error "This is an error"))
-    (is (logged? (with-out-str (log/debug "This is just a debugging message")) :debug "This is just a debugging message"))))
+    (with-redefs [log/logging-level (atom (log/to-logging-level-edn :debug))]
+      (is (logged? (with-out-str (log/info "Hello World!")) :info "Hello World!"))
+      (is (logged? (with-out-str (log/warn "This is a warning")) :warning "This is a warning"))
+      (is (logged? (with-out-str (log/error "This is an error")) :error "This is an error"))
+      (is (logged? (with-out-str (log/debug "This is just a debugging message")) :debug "This is just a debugging message")))))
+
+(deftest severity-level-filtering-test
+  (testing "test current logging level correctly ignores lesser levels"
+    (with-redefs [log/logging-level (atom (log/to-logging-level-edn :info))]
+      (is (blank? (with-out-str (log/debug "Debug Message"))))
+      (is (logged? (with-out-str (log/info "Info Message")) :info "Info Message")))))

--- a/database/changelog.xml
+++ b/database/changelog.xml
@@ -40,4 +40,5 @@
     <include file="changesets/20210519_ListSourceType.xml"                            relativeToChangelogFile="true"/>
     <include file="changesets/20210519_TDRSnapshotListSourceEnum.xml"                 relativeToChangelogFile="true"/>
     <include file="changesets/20210624_AddRetryToTerraExecutorDetails.xml"            relativeToChangelogFile="true"/>
+    <include file="changesets/20210720_AddConfigurationTable.xml"                     relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/database/changesets/20210720_AddConfigurationTable.xml
+++ b/database/changesets/20210720_AddConfigurationTable.xml
@@ -1,0 +1,26 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext
+                        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
+                        http://www.liquibase.org/xml/ns/dbchangelog
+                        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+    <changeSet author="hornet@broadinstitute.org"
+               dbms="postgresql"
+               id="20210720"
+               logicalFilePath="20210720_AddConfigurationTable.xml"
+               runInTransaction="false">
+        <comment>
+            The Configuration table schema
+        </comment>
+        <sql>
+            CREATE TABLE Configuration (
+                key                           TEXT UNIQUE NOT NULL,
+                value                         TEXT NOT NULL,
+                CONSTRAINT CONFIGURATION_PKEY PRIMARY KEY (key)
+            )
+        </sql>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
### Purpose
Adds configuration for setting the severity level of logs that are printed to stdout.

### Changes
Added a configuration table for key value pairs. Currently used to hold a logging level config.
Added a logging-level atom to the log namespace to limit messages to only enabled severity levels.
Added endpoints for getting the current logging level and updating/inserting configurations.
Added a timed check for current level to set the current logging level from the configuration table.

### Review Instructions
Verify that all tests pass.
Verify that the logging_level GET and POST request return the current level and set the current level respectively.
Verify that no messages below the current level print to stdout (give time for the delay after changing the level).
