### PR TITLE
[GH-1394] TerraExecutor retry implementation and Sarscov2IlluminaFull integration

### DIFF
--- a/api/src/wfl/api/handlers.clj
+++ b/api/src/wfl/api/handlers.clj
@@ -98,7 +98,7 @@
            (mapv util/to-edn)
            succeed))))
 
-;; Visible for wfl.system.v1-endpoint-test/test-retry-workload
+;; Visible for testing
 (def retry-unsupported-status-error-message
   "Retry unsupported for requested status.")
 (def retry-no-workflows-error-message

--- a/api/src/wfl/api/handlers.clj
+++ b/api/src/wfl/api/handlers.clj
@@ -102,6 +102,8 @@
   (log/info (select-keys request [:request-method :uri :parameters]))
   (let [uuid   (get-in request [:path-params :uuid])
         status (get-in request [:body-params :status])]
+    ;; TODO: if status='Succeeded', no op / error?
+    ;; TODO: if no workflows found, no op / error?
     (->> (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
            (let [w (workloads/load-workload-for-uuid tx uuid)]
              [w (workloads/workflows-by-status tx w status)]))

--- a/api/src/wfl/api/handlers.clj
+++ b/api/src/wfl/api/handlers.clj
@@ -12,6 +12,7 @@
             [wfl.module.sg]
             [wfl.module.wgs]
             [wfl.module.xx]
+            [wfl.service.cromwell           :as cromwell]
             [wfl.service.google.storage     :as gcs]
             [wfl.service.postgres           :as postgres]
             [wfl.util                       :as util])
@@ -97,22 +98,33 @@
            (mapv util/to-edn)
            succeed))))
 
+;; Visible for wfl.system.v1-endpoint-test/test-retry-workload
+(def retry-unsupported-status-error-message
+  "Retry unsupported for requested status.")
+(def retry-no-workflows-error-message
+  "No workflows to retry for requested status.")
+
 (defn post-retry
   "Retry the workflows identified in `request`."
   [request]
   (log/info (select-keys request [:request-method :uri :parameters]))
-  (let [uuid   (get-in request [:path-params :uuid])
-        status (get-in request [:body-params :status])]
-    ;; TODO: Refactor to workflow-status whitelist
-    ;; https://broadinstitute.atlassian.net/browse/GH-1424
-    (when (= "Succeeded" status)
-      (throw (UserException. "Retry unsupported for workflow status."
-                             {:uuid            uuid
-                              :workflow-status status
-                              :status          400})))
+  (let [uuid       (get-in request [:path-params :uuid])
+        status     (get-in request [:body-params :status])
+        supported? (cromwell/retry-status? status)]
+    (when-not supported?
+      (throw (UserException. retry-unsupported-status-error-message
+                             {:uuid               uuid
+                              :supported-statuses cromwell/retry-status?
+                              :requested-status   status
+                              :status             400})))
     (->> (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
            (let [workload  (workloads/load-workload-for-uuid tx uuid)
                  workflows (workloads/workflows-by-status tx workload status)]
+             (when (empty? workflows)
+               (throw (UserException. retry-no-workflows-error-message
+                                      {:uuid             uuid
+                                       :requested-status status
+                                       :status           400})))
              [workload workflows]))
          (apply workloads/retry)
          util/to-edn

--- a/api/src/wfl/executor.clj
+++ b/api/src/wfl/executor.clj
@@ -10,8 +10,7 @@
             [wfl.service.firecloud :as firecloud]
             [wfl.service.postgres  :as postgres]
             [wfl.service.rawls     :as rawls]
-            [wfl.stage             :as stage :refer [log-prefix
-                                                     throw-if-no-details-table]]
+            [wfl.stage             :as stage :refer [log-prefix]]
             [wfl.util              :as util :refer [map-keys utc-now]])
   (:import [wfl.util UserException]))
 
@@ -423,7 +422,7 @@
 (defn ^:private terra-executor-workflows
   "Return all the non-retried workflows executed by the `executor`."
   [tx {:keys [details] :as executor}]
-  (throw-if-no-details-table tx executor)
+  (postgres/throw-unless-table-exists tx details)
   (let [query "SELECT * FROM %s
                WHERE workflow IS NOT NULL
                AND   retry    IS NULL
@@ -436,7 +435,7 @@
   "Return all the non-retried workflows matching `status` executed by the
   `executor`."
   [tx {:keys [details] :as executor} status]
-  (throw-if-no-details-table tx executor)
+  (postgres/throw-unless-table-exists tx details)
   (let [query "SELECT * FROM %s
                WHERE workflow IS NOT NULL
                AND retry      IS NULL
@@ -451,7 +450,7 @@
   Return a mapping of the submission reference (ex. snapshot reference id)
   to their associated workflow records."
   [tx {:keys [details] :as executor} workflows]
-  (throw-if-no-details-table tx executor)
+  (postgres/throw-unless-table-exists tx details)
   (let [workflow-ids (util/to-quoted-comma-separated-list (map :uuid workflows))
         _            (-> "%s Fetching submission IDs linked to workflows %s"
                          (format (log-prefix executor) workflow-ids)

--- a/api/src/wfl/module/covid.clj
+++ b/api/src/wfl/module/covid.clj
@@ -4,7 +4,7 @@
             [clojure.spec.alpha :as s]
             [wfl.executor :as executor]
             [wfl.jdbc :as jdbc]
-            [wfl.module.batch :as batch]
+            [wfl.service.postgres  :as postgres]
             [wfl.sink :as sink]
             [wfl.source :as source]
             [wfl.stage :as stage]
@@ -152,6 +152,22 @@
                              {:workload workload})))
     (if-not (or stopped finished) (stop! workload (utc-now)) workload)))
 
+(defn ^:private retry-covid-workload
+  "Retry/resubmit the `workflows` managed by the `workload` and return the
+   workload that manages the new workflows."
+  [{:keys [finished id executor] :as workload} workflows]
+  (when-not finished
+    (throw (UserException. "Cannot retry workload before it's finished."
+                           {:workload workload})))
+  ;; TODO: validate executor and sink.
+  ;; Existing stage/validate-or-throw dispatches on :name.
+  ;; The workload's executor and sink have :type at this stage, not :name.
+  (executor/retry-executor! executor workflows)
+  (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+    (when-not (stage/done? executor)
+      (patch-workload tx workload {:finished nil :updated (utc-now)}))
+    (workloads/load-workload-for-id tx id)))
+
 (defn ^:private workload-to-edn [workload]
   (-> workload
       (util/select-non-nil-keys workload-metadata-keys)
@@ -164,7 +180,6 @@
 (defoverload workloads/start-workload!     pipeline start-covid-workload)
 (defoverload workloads/update-workload!    pipeline update-covid-workload)
 (defoverload workloads/stop-workload!      pipeline stop-covid-workload)
-(defoverload workloads/retry               pipeline batch/retry-unsupported)
 (defoverload workloads/load-workload-impl  pipeline load-covid-workload-impl)
 (defmethod   workloads/workflows           pipeline
   [tx {:keys [executor] :as _workload}]
@@ -172,4 +187,5 @@
 (defmethod   workloads/workflows-by-status pipeline
   [tx {:keys [executor] :as _workload} status]
   (executor/executor-workflows-by-status tx executor status))
+(defoverload workloads/retry              pipeline retry-covid-workload)
 (defoverload workloads/to-edn             pipeline workload-to-edn)

--- a/api/src/wfl/module/covid.clj
+++ b/api/src/wfl/module/covid.clj
@@ -4,7 +4,7 @@
             [clojure.spec.alpha :as s]
             [wfl.executor :as executor]
             [wfl.jdbc :as jdbc]
-            [wfl.service.postgres  :as postgres]
+            [wfl.service.postgres :as postgres]
             [wfl.sink :as sink]
             [wfl.source :as source]
             [wfl.stage :as stage]

--- a/api/src/wfl/module/covid.clj
+++ b/api/src/wfl/module/covid.clj
@@ -159,9 +159,6 @@
   (when-not started
     (throw (UserException. "Cannot retry workload before it's been started."
                            {:workload workload})))
-  (when (empty? workflows)
-    (throw (UserException. "No workflows specified to retry in workload."
-                           {:workload workload})))
   ;; TODO: validate workload's executor and sink objects.
   ;; https://broadinstitute.atlassian.net/browse/GH-1421
   (executor/retry-executor! executor workflows)

--- a/api/src/wfl/module/covid.clj
+++ b/api/src/wfl/module/covid.clj
@@ -161,7 +161,7 @@
                            {:workload workload})))
   ;; TODO: validate workload's executor and sink objects.
   ;; https://broadinstitute.atlassian.net/browse/GH-1421
-  (executor/retry-executor! executor workflows)
+  (executor/executor-retry-workflows! executor workflows)
   (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
     (when-not (stage/done? executor)
       (patch-workload tx workload {:finished nil :updated (utc-now)}))

--- a/api/src/wfl/service/cromwell.clj
+++ b/api/src/wfl/service/cromwell.clj
@@ -9,9 +9,13 @@
             [wfl.util :as util]
             [wfl.wfl :as wfl]))
 
+(def retry-status?
+  "Cromwell workflow statuses eligible for retry."
+  #{"Aborted" "Failed"})
+
 (def final?
   "The final statuses a Cromwell workflow can have."
-  #{"Aborted" "Failed" "Succeeded"})
+  (conj retry-status? "Succeeded"))
 
 (def active?
   "The statuses an active Cromwell workflow can have."

--- a/api/src/wfl/service/postgres.clj
+++ b/api/src/wfl/service/postgres.clj
@@ -33,6 +33,11 @@
        (count)
        (not= 0)))
 
+(defn throw-unless-table-exists
+  [tx table-name]
+  (when-not (and table-name (table-exists? tx table-name))
+    (throw (ex-info "Table not found" {:table table-name}))))
+
 (defn get-table
   "Return TABLE using transaction TX sorted by row id."
   [tx table]

--- a/api/src/wfl/stage.clj
+++ b/api/src/wfl/stage.clj
@@ -1,7 +1,8 @@
 (ns wfl.stage
   "Interface and methods for operations on a queue-based
   pipeline processing stage, e.g. source, executor, or sink."
-  (:require [wfl.util :as util])
+  (:require [wfl.service.postgres :as postgres]
+            [wfl.util             :as util])
   (:import [wfl.util UserException]))
 
 (defmulti validate-or-throw
@@ -33,3 +34,9 @@
   "Prefix string for `stage` logs indicating the `type` (table) and row `id`."
   [{:keys [type id] :as _stage}]
   (format "[%s id=%s]" type id))
+
+(defn throw-if-no-details-table
+  "Throw if `details` table does not exist."
+  [tx {:keys [details type] :as _stage}]
+  (when-not (postgres/table-exists? tx details)
+    (throw (ex-info "Missing details table" {:type type :details details}))))

--- a/api/src/wfl/stage.clj
+++ b/api/src/wfl/stage.clj
@@ -1,8 +1,7 @@
 (ns wfl.stage
   "Interface and methods for operations on a queue-based
   pipeline processing stage, e.g. source, executor, or sink."
-  (:require [wfl.service.postgres :as postgres]
-            [wfl.util             :as util])
+  (:require [wfl.util :as util])
   (:import [wfl.util UserException]))
 
 (defmulti validate-or-throw
@@ -35,8 +34,3 @@
   [{:keys [type id] :as _stage}]
   (format "[%s id=%s]" type id))
 
-(defn throw-if-no-details-table
-  "Throw if `details` table does not exist."
-  [tx {:keys [details type] :as _stage}]
-  (when-not (postgres/table-exists? tx details)
-    (throw (ex-info "Missing details table" {:type type :details details}))))

--- a/api/test/wfl/integration/executor_test.clj
+++ b/api/test/wfl/integration/executor_test.clj
@@ -309,7 +309,7 @@
          (is (== 1 (stage/queue-length executor)))
          (is (not (stage/done? executor)))))))
 
-(deftest test-retry-terra-executor
+(deftest test-terra-executor-retry-workflows
   (let [source   (make-queue-from-list [[:datarepo/snapshot snapshot]])
         executor (create-terra-executor (rand-int 1000000))]
     (with-redefs-fn
@@ -338,7 +338,7 @@
                  (executor/executor-workflows-by-status tx executor "Running"))]
            (is (== 1 (count workflows-to-retry))
                "Should have one running workflow to retry.")
-           (executor/retry-executor! executor workflows-to-retry)))
+           (executor/executor-retry-workflows! executor workflows-to-retry)))
       ;; We only specify 1 workflow to retry,
       ;; but must retry both workflows from its submission.
       (is (== 4 (stage/queue-length executor))

--- a/api/test/wfl/integration/executor_test.clj
+++ b/api/test/wfl/integration/executor_test.clj
@@ -1,6 +1,5 @@
 (ns wfl.integration.executor-test
-  (:require [clojure.set           :refer [rename-keys]]
-            [clojure.test          :refer [deftest is testing use-fixtures]]
+  (:require [clojure.test          :refer [deftest is use-fixtures]]
             [wfl.executor          :as executor]
             [wfl.jdbc              :as jdbc]
             [wfl.service.firecloud :as firecloud]

--- a/api/test/wfl/integration/executor_test.clj
+++ b/api/test/wfl/integration/executor_test.clj
@@ -1,5 +1,6 @@
 (ns wfl.integration.executor-test
-  (:require [clojure.test          :refer [deftest is use-fixtures]]
+  (:require [clojure.set           :refer [rename-keys]]
+            [clojure.test          :refer [deftest is testing use-fixtures]]
             [wfl.executor          :as executor]
             [wfl.jdbc              :as jdbc]
             [wfl.service.firecloud :as firecloud]
@@ -92,8 +93,7 @@
          :fromSource          "importSnapshot"}))))
 
 ;; Mocks
-(def ^:private fake-method-name "method-name")
-(def ^:private fake-method-config (str "method-namespace/" fake-method-name))
+
 ;; Snapshot and snapshot reference mocks
 (def ^:private snapshot
   {:name "test-snapshot-name" :id (str (UUID/randomUUID))})
@@ -104,80 +104,114 @@
   {:referenceId snapshot-reference-id
    :name        snapshot-reference-name})
 
-(def ^:private method-config-version-mock 1)
+;; Method configuration
+(def ^:private fake-method-name "method-name")
+(def ^:private fake-method-config (str "method-namespace/" fake-method-name))
 
-(defn ^:private mock-firecloud-get-method-configuration [& _]
-  {:methodConfigVersion method-config-version-mock})
+(def ^:private method-config-version-init 1)
+(def ^:private method-config-version-post-update 2)
 
-(defn ^:private mock-firecloud-update-method-configuration
-  [_ _ {:keys [dataReferenceName methodConfigVersion]}]
-  (is (= dataReferenceName snapshot-reference-name)
-      "Snapshot reference name should be passed to method config update")
-  (is (= methodConfigVersion (inc method-config-version-mock))
-      "Incremented version should be passed to method config update")
-  nil)
+(defn ^:private mock-firecloud-get-method-configuration [method-config-version]
+  {:methodConfigVersion method-config-version})
 
-(def ^:private submission-id-mock         (str (UUID/randomUUID)))
-(def ^:private running-workflow-id-mock   (str (UUID/randomUUID)))
-(def ^:private succeeded-workflow-id-mock (str (UUID/randomUUID)))
+(defn ^:private mock-firecloud-get-method-configuration-init [& _]
+  (mock-firecloud-get-method-configuration method-config-version-init))
+(defn ^:private mock-firecloud-get-method-configuration-post-update [& _]
+  (mock-firecloud-get-method-configuration method-config-version-post-update))
+
+(defn ^:private mock-firecloud-update-method-configuration [method-config-version]
+  (fn [_ _ {:keys [dataReferenceName methodConfigVersion]}]
+    (is (= dataReferenceName snapshot-reference-name)
+        "Snapshot reference name should be passed to method config update")
+    (is (= methodConfigVersion (inc method-config-version))
+        "Incremented version should be passed to method config update")
+    nil))
+
+(defn ^:private mock-firecloud-update-method-configuration-init [& _]
+  (mock-firecloud-update-method-configuration method-config-version-init))
+(defn ^:private mock-firecloud-update-method-configuration-post-update [& _]
+  (mock-firecloud-update-method-configuration method-config-version-post-update))
+
+;; Submissions and workflows
+
+(defn ^:private workflow-base [entity status]
+  {:entity      entity
+   :workflow-id (str (UUID/randomUUID))
+   :status      status})
+
+(def ^:private init-submission-id  "init-submission-id")
+(def ^:private retry-submission-id "retry-submission-id")
+
+(def ^:private submission-base
+  (let [running-entity   "running-entity"
+        succeeded-entity "succeeded-entity"]
+    {init-submission-id  {:running   (workflow-base running-entity "Running")
+                          :succeeded (workflow-base succeeded-entity "Succeeded")}
+     retry-submission-id {:running   (workflow-base running-entity "Running")
+                          :succeeded (workflow-base succeeded-entity "Succeeded")}}))
 
 ;; Firecloud workflow format differs based on whether it is fetched
 ;; at the submission level or the workflow level.
-(defn ^:private mock-firecloud-get-submission-workflow [workflow-id status]
-  {:entityName       "entity"
+(defn ^:private mock-firecloud-get-submission-workflow
+  [{:keys [entity workflow-id status] :as _workflow-base}]
+  {:entityName       entity
    :inputResolutions {:inputName (str fake-method-name ".input")
                       :value     "value"}
    :status           status
    :workflowId       workflow-id})
 
-(defn ^:private mock-firecloud-get-workflow [workflow-id status]
+(defn ^:private mock-firecloud-get-workflow
+  [{:keys [workflow-id status] :as _workflow-base}]
   {:id           workflow-id
    :inputs       {:input "value"}
    :status       status
    :workflowName fake-method-name})
 
-(def ^:private running-workflow-from-submission
-  (mock-firecloud-get-submission-workflow running-workflow-id-mock "Running"))
+(defn ^:private running-workflow-from-submission [submission-id]
+  (mock-firecloud-get-submission-workflow (get-in submission-base [submission-id :running])))
 
-(def ^:private succeeded-workflow-from-submission
-  (mock-firecloud-get-submission-workflow succeeded-workflow-id-mock "Succeeded"))
+(defn ^:private succeeded-workflow-from-submission [submission-id]
+  (mock-firecloud-get-submission-workflow (get-in submission-base [submission-id :succeeded])))
 
 ;; When we create submissions, workflows have no uuid or status.
-(defn ^:private mock-firecloud-create-submission [& _]
-  (let [enqueue #(dissoc % :workflowId :status)]
-    {:submissionId submission-id-mock
-     :workflows    (map enqueue [running-workflow-from-submission
-                                 succeeded-workflow-from-submission])}))
+(defn ^:private mock-firecloud-create-submission [submission-id]
+  (fn [& _]
+    (let [enqueue #(dissoc % :workflowId :status)]
+      {:submissionId submission-id
+       :workflows    (map enqueue [(running-workflow-from-submission submission-id)
+                                   (succeeded-workflow-from-submission submission-id)])})))
 
 ;; When we get the submission later, the workflows may have a uuid and status assigned.
-(defn ^:private mock-firecloud-get-submission [& _]
+(defn ^:private mock-firecloud-get-submission [_ submission-id]
   (letfn [(add-workflow-entity [{:keys [entityName] :as workflow}]
             (-> workflow
                 (assoc :workflowEntity {:entityType "test" :entityName entityName})
                 (dissoc :entityName)))]
-    {:submissionId submission-id-mock
-     :workflows    (map add-workflow-entity [running-workflow-from-submission
-                                             succeeded-workflow-from-submission])}))
+    {:submissionId submission-id
+     :workflows    (map add-workflow-entity [(running-workflow-from-submission submission-id)
+                                             (succeeded-workflow-from-submission submission-id)])}))
 
 ;; Workflow fetch mocks within update-workflow-statuses!
-(defn ^:private mock-firecloud-get-running-workflow-update-status [_ _ workflow-id]
-  (is (= running-workflow-id-mock workflow-id)
-      "Expecting to fetch and update status for running workflow")
-  (mock-firecloud-get-workflow workflow-id "Succeeded"))
+(defn ^:private mock-firecloud-get-running-workflow-update-status [_ submission-id workflow-id]
+  (let [workflow-base (get-in submission-base [submission-id :running])]
+    (is (= (:workflow-id workflow-base) workflow-id)
+        "Expecting to fetch and update status for running workflow")
+    (assoc (mock-firecloud-get-workflow workflow-base) :status "Succeeded")))
 
-(defn ^:private mock-firecloud-get-known-workflow [_ _ workflow-id]
-  (mock-firecloud-get-workflow
-   workflow-id
-   (cond (= workflow-id running-workflow-id-mock)   "Running"
-         (= workflow-id succeeded-workflow-id-mock) "Succeeded"
-         :else (throw
-                (ex-info "Workflow ID does not match known workflow"
-                         {:running-workflow-id-mock   running-workflow-id-mock
-                          :succeeded-workflow-id-mock succeeded-workflow-id-mock
-                          :actual                     workflow-id})))))
+(defn ^:private mock-firecloud-get-known-workflow [_ submission-id workflow-id]
+  (if-let [workflow-base (->> (get submission-base submission-id)
+                              vals
+                              (filter #(= workflow-id (:workflow-id %)))
+                              first)]
+    (mock-firecloud-get-workflow workflow-base)
+    (throw
+     (ex-info "Workflow ID does not match known workflow"
+              {:known-submissions submission-base
+               :submission-id     submission-id
+               :workflow-id       workflow-id}))))
 
-(defn ^:private mock-firecloud-get-workflow-outputs [_ _ workflow-id]
-  (is (= succeeded-workflow-id-mock workflow-id)
+(defn ^:private mock-firecloud-get-workflow-outputs [_ submission-id workflow-id]
+  (is (= (get-in submission-base [submission-id :succeeded :workflow-id]) workflow-id)
       "Expecting to fetch outputs for successful workflow")
   {:tasks
    {:noise
@@ -191,12 +225,19 @@
     (->> {:name                       "Terra"
           :workspace                  "workspace-ns/workspace-name"
           :methodConfiguration        fake-method-config
-          :methodConfigurationVersion method-config-version-mock
+          :methodConfigurationVersion method-config-version-init
           :fromSource                 "importSnapshot"
           :skipValidation             true}
          (executor/create-executor! tx id)
          (zipmap [:executor_type :executor_items])
          (executor/load-executor! tx))))
+
+(defn ^:private reload-terra-executor
+  "Reload an established `executor` object."
+  [{:keys [type id] :as _executor}]
+  (let [workload (zipmap [:executor_type :executor_items] [type (str id)])]
+    (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+      (executor/load-executor! tx workload))))
 
 (deftest test-update-terra-executor
   (let [source   (make-queue-from-list [[:datarepo/snapshot snapshot]])
@@ -208,9 +249,9 @@
                   "The workflow ID was incorrect and should match corresponding record"))]
       (with-redefs-fn
         {#'rawls/create-or-get-snapshot-reference mock-rawls-snapshot-reference
-         #'firecloud/method-configuration         mock-firecloud-get-method-configuration
-         #'firecloud/update-method-configuration  mock-firecloud-update-method-configuration
-         #'firecloud/submit-method                mock-firecloud-create-submission
+         #'firecloud/method-configuration         mock-firecloud-get-method-configuration-init
+         #'firecloud/update-method-configuration  mock-firecloud-update-method-configuration-init
+         #'firecloud/submit-method                (mock-firecloud-create-submission init-submission-id)
          #'firecloud/get-submission               mock-firecloud-get-submission
          #'firecloud/get-workflow                 mock-firecloud-get-running-workflow-update-status}
         #(executor/update-executor! source executor))
@@ -220,23 +261,23 @@
         (let [[running-record succeeded-record & _ :as records]
               (->> executor :details (postgres/get-table tx) (sort-by :id))
               executor-record
-              (#'postgres/load-record-by-id! tx "TerraExecutor" (:id executor))]
+              (#'postgres/load-record-by-id! tx "TerraExecutor" (:id executor))
+              running-workflow (running-workflow-from-submission init-submission-id)
+              succeeded-workflow (succeeded-workflow-from-submission init-submission-id)]
           (is (== 2 (count records))
               "Exactly 2 workflows should have been written to the database")
           (is (every? #(= snapshot-reference-id (:reference %)) records)
               "The snapshot reference ID was incorrect and should match all records")
-          (is (every? #(= submission-id-mock (:submission %)) records)
+          (is (every? #(= init-submission-id (:submission %)) records)
               "The submission ID was incorrect and should match all records")
           (is (every? #(= "Succeeded" (:status %)) records)
               "Status update mock should have marked running workflow as succeeded")
           (is (every? #(nil? (:consumed %)) records)
               "All records should be unconsumed")
           (is (not (stage/done? executor)) "executor should not have finished processing")
-          (verify-record-against-workflow
-           running-record running-workflow-from-submission 1)
-          (verify-record-against-workflow
-           succeeded-record succeeded-workflow-from-submission 2)
-          (is (== (inc method-config-version-mock) (:method_configuration_version executor-record))
+          (verify-record-against-workflow running-record running-workflow 1)
+          (verify-record-against-workflow succeeded-record succeeded-workflow 2)
+          (is (== method-config-version-post-update (:method_configuration_version executor-record))
               "Method configuration version was not incremented."))))))
 
 (deftest test-peek-terra-executor-queue
@@ -245,9 +286,9 @@
         executor   (create-terra-executor (rand-int 1000000))]
     (with-redefs-fn
       {#'rawls/create-or-get-snapshot-reference mock-rawls-snapshot-reference
-       #'firecloud/method-configuration         mock-firecloud-get-method-configuration
-       #'firecloud/update-method-configuration  mock-firecloud-update-method-configuration
-       #'firecloud/submit-method                mock-firecloud-create-submission
+       #'firecloud/method-configuration         mock-firecloud-get-method-configuration-init
+       #'firecloud/update-method-configuration  mock-firecloud-update-method-configuration-init
+       #'firecloud/submit-method                (mock-firecloud-create-submission init-submission-id)
        #'firecloud/get-submission               mock-firecloud-get-submission
        #'firecloud/get-workflow                 mock-firecloud-get-known-workflow}
       #(executor/update-executor! source executor))
@@ -255,9 +296,11 @@
       {#'executor/describe-method       (constantly nil)
        #'firecloud/get-workflow         mock-firecloud-get-known-workflow
        #'firecloud/get-workflow-outputs mock-firecloud-get-workflow-outputs}
-      #(let [[_ workflow] (stage/peek-queue executor)]
+      #(let [[_ workflow] (stage/peek-queue executor)
+             succeeded-workflow-id
+             (get-in submission-base [init-submission-id :succeeded :workflow-id])]
          (is (succeeded? (:status workflow)))
-         (is (= (:workflowId succeeded-workflow-from-submission) (:uuid workflow)))
+         (is (= succeeded-workflow-id (:uuid workflow)))
          (is (contains? workflow :updated))
          (is (= "value" (-> workflow :inputs :input)))
          (is (= "value" (-> workflow :outputs :output)))
@@ -267,12 +310,83 @@
          (is (== 1 (stage/queue-length executor)))
          (is (not (stage/done? executor)))))))
 
+(deftest test-retry-terra-executor
+  (let [source   (make-queue-from-list [[:datarepo/snapshot snapshot]])
+        executor (create-terra-executor (rand-int 1000000))]
+    (with-redefs-fn
+      {#'rawls/create-or-get-snapshot-reference mock-rawls-snapshot-reference
+       #'firecloud/method-configuration         mock-firecloud-get-method-configuration-init
+       #'firecloud/update-method-configuration  mock-firecloud-update-method-configuration-init
+       #'firecloud/submit-method                (mock-firecloud-create-submission init-submission-id)
+       #'firecloud/get-submission               mock-firecloud-get-submission
+       #'firecloud/get-workflow                 mock-firecloud-get-known-workflow}
+      #(executor/update-executor! source executor))
+    (is (zero? (stage/queue-length source)) "The snapshot was not consumed.")
+    (is (== 2 (stage/queue-length executor))
+        "Two workflows should be enqueued prior to retry.")
+    (let [executor           (reload-terra-executor executor)]
+      (is (== 2 (:methodConfigurationVersion executor))
+          "Reloaded executor's method config should have version 2 post-update.")
+      (with-redefs-fn
+        {#'rawls/get-snapshot-reference           mock-rawls-snapshot-reference
+         #'firecloud/method-configuration         mock-firecloud-get-method-configuration-post-update
+         #'firecloud/update-method-configuration  mock-firecloud-update-method-configuration-post-update
+         #'firecloud/submit-method                (mock-firecloud-create-submission retry-submission-id)
+         #'firecloud/get-submission               mock-firecloud-get-submission
+         #'firecloud/get-workflow                 mock-firecloud-get-known-workflow}
+        #(let [workflows-to-retry
+               (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+                 (executor/executor-workflows-by-status tx executor "Running"))]
+           (is (== 1 (count workflows-to-retry))
+               "Should have one running workflow to retry.")
+           (executor/retry-executor! executor workflows-to-retry)))
+      ;; We only specify 1 workflow to retry,
+      ;; but must retry both workflows from its submission.
+      (is (== 4 (stage/queue-length executor))
+          "Four workflows should be enqueued following retry.")
+      (let [[running succeeded retry-running retry-succeeded & _ :as records]
+            (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+              (->> executor :details (postgres/get-table tx) (sort-by :id)))
+            executor-record
+            (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+              (#'postgres/load-record-by-id! tx "TerraExecutor" (:id executor)))
+            compare-original-with-retry
+            (fn [original retry status-kw]
+              (is (= (:retry original) (:id retry))
+                  (str status-kw " - original record should be linked to its retry."))
+              (is (= init-submission-id (:submission original))
+                  (str status-kw " - original record has incorrect submission id."))
+              (is (= retry-submission-id (:submission retry))
+                  (str status-kw " - retry record has incorrect submission id."))
+              (is (= (get-in submission-base [init-submission-id
+                                              status-kw
+                                              :workflow-id])
+                     (:workflow original))
+                  (str status-kw " - original record has incorrect workflow id."))
+              (is (nil? (:workflow retry))
+                  (str status-kw " - retry record should not have workflow id "
+                       "populated prior to update loop."))
+              (is (every? #(= (get-in submission-base [init-submission-id
+                                                       status-kw
+                                                       :entity])
+                              (:entity %)) [original retry])
+                  (str status-kw " - original record should have "
+                       "same entity as its retry.")))]
+        (is (== 4 (count records))
+            "Exactly 4 workflows should be visible in the database")
+        (is (every? #(= snapshot-reference-id (:reference %)) records)
+            "The snapshot reference ID was incorrect and should match all records")
+        (compare-original-with-retry running retry-running :running)
+        (compare-original-with-retry succeeded retry-succeeded :succeeded)
+        (is (== (inc method-config-version-post-update) (:method_configuration_version executor-record))
+            "Method configuration version was not incremented.")))))
+
 (deftest test-terra-executor-get-retried-workflows
   (with-redefs-fn
     {#'rawls/create-or-get-snapshot-reference mock-rawls-snapshot-reference
-     #'firecloud/method-configuration         mock-firecloud-get-method-configuration
-     #'firecloud/update-method-configuration  mock-firecloud-update-method-configuration
-     #'firecloud/submit-method                mock-firecloud-create-submission
+     #'firecloud/method-configuration         mock-firecloud-get-method-configuration-init
+     #'firecloud/update-method-configuration  mock-firecloud-update-method-configuration-init
+     #'firecloud/submit-method                (mock-firecloud-create-submission init-submission-id)
      #'firecloud/get-submission               mock-firecloud-get-submission
      #'firecloud/get-workflow                 mock-firecloud-get-known-workflow
      #'firecloud/get-workflow-outputs         mock-firecloud-get-workflow-outputs}
@@ -291,17 +405,18 @@
 (deftest test-terra-executor-queue-length
   (with-redefs-fn
     {#'rawls/create-or-get-snapshot-reference mock-rawls-snapshot-reference
-     #'firecloud/method-configuration         mock-firecloud-get-method-configuration
-     #'firecloud/update-method-configuration  mock-firecloud-update-method-configuration
-     #'firecloud/submit-method                mock-firecloud-create-submission
+     #'firecloud/method-configuration         mock-firecloud-get-method-configuration-init
+     #'firecloud/update-method-configuration  mock-firecloud-update-method-configuration-init
+     #'firecloud/submit-method                (mock-firecloud-create-submission init-submission-id)
      #'firecloud/get-submission               mock-firecloud-get-submission
      #'firecloud/get-workflow                 mock-firecloud-get-known-workflow
      #'firecloud/get-workflow-outputs         mock-firecloud-get-workflow-outputs}
-    #(let [source   (make-queue-from-list [[:datarepo/snapshot snapshot]])
-           executor (create-terra-executor (rand-int 1000000))
-           _        (executor/update-executor! source executor)
-           record   (#'executor/peek-terra-executor-details executor)]
-       (is (= succeeded-workflow-id-mock (:workflow record))
+    #(let [source                (make-queue-from-list [[:datarepo/snapshot snapshot]])
+           executor              (create-terra-executor (rand-int 1000000))
+           _                     (executor/update-executor! source executor)
+           record                (#'executor/peek-terra-executor-details executor)
+           succeeded-workflow-id (get-in submission-base [init-submission-id :succeeded :workflow-id])]
+       (is (= succeeded-workflow-id (:workflow record))
            "Peeked record's workflow uuid should match succeeded workflow's")
        (is (= "Succeeded" (:status record))
            "Peeked record's status should match succeeded workflow's")

--- a/api/test/wfl/integration/modules/covid_test.clj
+++ b/api/test/wfl/integration/modules/covid_test.clj
@@ -347,9 +347,9 @@
        (testing "Workload not started"
          (is (not (:started workload)))
          (is (thrown-with-msg?
-               UserException #"Cannot retry workload before it's been started."
-               (workloads/retry workload []))))
+              UserException #"Cannot retry workload before it's been started."
+              (workloads/retry workload []))))
        (testing "No workflows"
          (is (thrown-with-msg?
-               UserException #"No workflows specified to retry in workload."
-               (workloads/retry (workloads/start-workload! workload) [])))))))
+              UserException #"No workflows specified to retry in workload."
+              (workloads/retry (workloads/start-workload! workload) [])))))))

--- a/api/test/wfl/integration/modules/covid_test.clj
+++ b/api/test/wfl/integration/modules/covid_test.clj
@@ -329,7 +329,7 @@
                  app)]
         (is (== 200 status) (pr-str body))))))
 
-(deftest test-retry-workload-throws-on-bad-inputs
+(deftest test-retry-workload-throws-when-not-started
   (with-redefs-fn
     {#'source/find-new-rows                   mock-find-new-rows
      #'source/create-snapshots                mock-create-snapshots
@@ -344,12 +344,7 @@
                              {:skipValidation true}
                              {:skipValidation true})
            workload         (workloads/create-workload! workload-request)]
-       (testing "Workload not started"
-         (is (not (:started workload)))
-         (is (thrown-with-msg?
-              UserException #"Cannot retry workload before it's been started."
-              (workloads/retry workload []))))
-       (testing "No workflows"
-         (is (thrown-with-msg?
-              UserException #"No workflows specified to retry in workload."
-              (workloads/retry (workloads/start-workload! workload) [])))))))
+       (is (not (:started workload)))
+       (is (thrown-with-msg?
+             UserException #"Cannot retry workload before it's been started."
+             (workloads/retry workload []))))))

--- a/api/test/wfl/integration/modules/covid_test.clj
+++ b/api/test/wfl/integration/modules/covid_test.clj
@@ -340,12 +340,12 @@
      #'firecloud/submit-method                mock-firecloud-create-submission
      #'firecloud/get-workflow                 (constantly {:status "Failed"})}
     #(let [workload-request (workloads/covid-workload-request
-                              {:skipValidation true}
-                              {:skipValidation true}
-                              {:skipValidation true})
+                             {:skipValidation true}
+                             {:skipValidation true}
+                             {:skipValidation true})
            workload         (workloads/execute-workload! workload-request)
            failed           (workloads/workflows-by-status workload "Failed")]
        (is (not (:finished workload)))
        (is (thrown-with-msg?
-             UserException #"Cannot retry workload before it's finished."
-              (workloads/retry workload failed))))))
+            UserException #"Cannot retry workload before it's finished."
+            (workloads/retry workload failed))))))

--- a/api/test/wfl/integration/modules/covid_test.clj
+++ b/api/test/wfl/integration/modules/covid_test.clj
@@ -346,5 +346,5 @@
            workload         (workloads/create-workload! workload-request)]
        (is (not (:started workload)))
        (is (thrown-with-msg?
-             UserException #"Cannot retry workload before it's been started."
-             (workloads/retry workload []))))))
+            UserException #"Cannot retry workload before it's been started."
+            (workloads/retry workload []))))))

--- a/api/test/wfl/system/v1_endpoint_test.clj
+++ b/api/test/wfl/system/v1_endpoint_test.clj
@@ -189,13 +189,13 @@
   (let [workload  (endpoints/exec-workload request)]
     (testing "retry-workflows fails (400) with unsupported workflow status"
       (is (thrown-with-msg?
-            ExceptionInfo #"clj-http: status 400"
-            (endpoints/retry-workflows workload "Succeeded"))))
+           ExceptionInfo #"clj-http: status 400"
+           (endpoints/retry-workflows workload "Succeeded"))))
     (when-not implemented?
       (testing "retry-workflows fails (501) when unimplemented for pipeline"
         (is (thrown-with-msg?
-              ExceptionInfo #"clj-http: status 501"
-              (endpoints/retry-workflows workload "Failed")))))))
+             ExceptionInfo #"clj-http: status 501"
+             (endpoints/retry-workflows workload "Failed")))))))
 
 (deftest ^:parallel test-retry-wgs-workload
   (test-retry-workload (workloads/wgs-workload-request (UUID/randomUUID)) false))


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- Ticket [GH-1394](https://broadinstitute.atlassian.net/browse/GH-1394)
- @tbl3rd's [spike doc](https://broadinstitute.atlassian.net/wiki/spaces/GHConfluence/pages/2674393095/Retries+in+Terra+WFL) -- thanks!
- Rhian's [original PR](https://github.com/broadinstitute/wfl/pull/472) which this replaces -- thanks!

Retry functionality is now supported in staged workflows within their executors, with COVID workloads altered to take advantage.

`TerraExecutor` retry resubmits the snapshot reference associated with the specified workflows, and updates each original workflow record to point to its retry record.  The existing update loop will handle updating workflow uuids and statuses for us.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

In `wfl.handlers/post-retry`:
- Raise HTTP 400 if passing in an unsupported status, or if no workflows available for a supported status

In `wfl.executor`:
- Added multimethod `executor-retry-workflows!` dispatched on `:type` with `TerraExecutor` implementation `terra-executor-retry-workflows`
- Added logging throughout

In `wfl.module.covid`, previously retries were unsupported.  Now we dispatch to `retry-covid-workload` which...
- Confirms that the workload has started
- Retries via the executor
- Reanimates the workload if needed so that it will be visible to the update loop
- Returns the updated workload

In `wfl.integration.executor-test`:
- Added new automated test `test-terra-executor-retry-workflows` and adjusted existing mock utilities to accommodate 

In `wfl.system.v1_endpoint_test/test-retry-workload`:
- Checking for expected errors if status unsupported or no workflows available for a supported status

### Manual Testing

I created a workload associated with workspace [okotsopo/CDC_Viral_Sequencing_okotsopo_20210707](https://app.terra.bio/#workspaces/wfl-dev/CDC_Viral_Sequencing_okotsopo_20210707/) and started it.  Then I aborted the resulting running workflow and observed that the workload was marked as finished.

I was then able to trigger a retry of the workflow with the following:
```
(jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
  (let [workload-uuid "e66c86b2-120d-4f7f-9c3a-b9eaadeb1919"
         workload           (workloads/load-workload-for-uuid tx workload-uuid)
         status                "Aborted"
         workflows         (workloads/workflows-by-status tx workload status)]
    (workloads/retry workload workflows)))
```

And observed the new workflow running in the Terra UI, and its record linked to its original via the `retry` column.
<img width="1328" alt="Screen Shot 2021-07-28 at 2 33 28 PM" src="https://user-images.githubusercontent.com/79769153/127404509-32b87d59-78d2-45be-a16c-f4749e62fe1f.png">

I also observed that the workload update loop took care of updating retry workflow uuids and statuses, and appropriately remarked the workload as failed once they had finished.

Same behavior confirmed when hitting the endpoint:

```
wm111-e35:wfl okotsopo$ curl -X POST "http://localhost:3000/api/v1/workload/e66c86b2-120d-4f7f-9c3a-b9eaadeb1919/retry" \
> -H "Content-Type: application/json" \
> -d '{ "status": "Failed" }'
{
  "started" : "2021-07-14T15:36:47Z",
  "watchers" : [ "okotsopo@broadinstitute.org" ],
  "labels" : [ "hornet:test", "project:okotsopo testing enhanced source, executor, sink logging", "project:wfl-dev/CDC_Viral_Sequencing_okotsopo_20210707" ],
  "creator" : "okotsopo@broadinstitute.org",
  "updated" : "2021-07-28T22:49:30Z",
  "created" : "2021-07-14T15:36:07Z",
  "source" : {
    …
  },
  "commit" : "9719eda7424bf5b0804f5493875681fa014cdb29",
  "uuid" : "e66c86b2-120d-4f7f-9c3a-b9eaadeb1919",
  "executor" : {
    "workspace" : "wfl-dev/CDC_Viral_Sequencing_okotsopo_20210707",
    "methodConfiguration" : "wfl-dev/sarscov2_illumina_full",
    "methodConfigurationVersion" : 38,
    "fromSource" : "importSnapshot",
    "name" : "Terra"
  },
  "version" : "0.8.0",
  "sink" : {
    …
    },
    "identifier" : "run_id",
    "name" : "Terra Workspace"
  }
}
```

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- Please confirm that implementation matches spike doc's specifications
- I was looking at this existing system test **[test-automate-sarscov2-illumina-full](https://github.com/broadinstitute/wfl/blob/develop/api/test/wfl/system/automation_test.clj)** to see if it could be altered to retry as well.  But I wasn't convinced that in its current form it's useful / doing what we want.  Notably, it never stops the workload, so will it ever finish / possibly clog up the DB?

### TODO

In separate PRs:
- Update [WFL GitHub page](https://github.com/broadinstitute/wfl/blob/develop/docs/md/modules-covid.md) for Sarscov2IlluminaFull to include info on new `/retry` endpoint.
- Tweak logging, see if new log functions accept maps.  More discussion [here](https://github.com/broadinstitute/wfl/pull/482#discussion_r683643315).

### Spin-Off Tickets

[GH-1421](https://broadinstitute.atlassian.net/browse/GH-1421) - `stage/validate-or-throw` redesigned to accommodate workload retry as well as creation
[GH-1422](https://broadinstitute.atlassian.net/browse/GH-1422) - Terra Executor should deal in generic entities and not assume snapshot references
[GH-1423](https://broadinstitute.atlassian.net/browse/GH-1423) - Terra Executor retry should be thread-safe