### PR TITLE
[GH-1395] GitHub Pages updates: COVID, staged workflows, retry functionality

### DIFF
--- a/docs/md/executor.md
+++ b/docs/md/executor.md
@@ -134,7 +134,13 @@ An executor is a `Queue` that satisfies the `Executor` protocol below:
      ^String     status       ;; workflow status to match
     ]
     "Use database `transaction` to return workflows created by the `executor`
-     matching the workflow `status`."))
+     matching the workflow `status`.")
+  (executor-retry-workflows!
+    ;; Executed for side effects
+    [^Executor          executor   ;; This executor instance
+     ^IPersistentVector workflows  ;; Workflows to retry
+    ]
+    "Retry/resubmit the `workflows` managed by the `executor`."))
 ```
 
 !!! note

--- a/docs/md/index.md
+++ b/docs/md/index.md
@@ -8,13 +8,20 @@
 ## Overview
 
 [WorkFlow Launcher (WFL)](https://github.com/broadinstitute/wfl.git)
-is a [workload](./workload.md) manager.
+is a workload manager.
 
-For example, a [workload](./workload.md) could be a set of Whole Genome samples to be reprocessed in a
+For example, a workload could be a set of Whole Genome samples to be reprocessed in a
 given project/bucket, the workflow is the processing of an individual sample
 in that workload running WGS reprocessing; a workload could also be a queue of
 incoming notifications that describe all of the required inputs to launch Arrays
 scientific pipelines in Cromwell.
+
+Most recent efforts leverage the general applicability of a
+[staged workload](staged-workload.md) model
+which automates fetching data from a [source](./source.md),
+pushing it into a workflow [executor](./executor.md) for analysis,
+and delivering the results of the analysis to an output location
+(also known as a [sink](./sink.md)).
 
 WFL is designed to be deployed to run as a service in the cloud, primarily
 on Kubernetes clusters.

--- a/docs/md/modules-covid.md
+++ b/docs/md/modules-covid.md
@@ -1,8 +1,11 @@
-# COVID namespace
+# COVID module
 
-WorkFlow Launcher (WFL) runs within the `covid` namespace to process workflows using the `Sarscov2IlluminaFull` pipeline. 
+WorkFlow Launcher (WFL) uses the `covid` module to automate the sequencing
+of COVID-positive samples in Terra workspaces for better understanding
+of SARS-CoV-2 spread and evolution.
 
-Workflow Launcher uses a model which includes a source, a sink and an executor. Within the `covid` namespace, the source at the time of this writing is either directly from the Terra Data Repository (`TerraDataRepo`), or a list of snapshots which are passed to WFL (`TDR Snapshots`). 
+For this processing, WFL follows a [staged workload](./staged-workload.md) model
+which includes a source, executor, and sink.
 
 ### API
 
@@ -11,6 +14,8 @@ The `covid` module supports the following API endpoints:
 | Verb | Endpoint                            | Description                                                              |
 |------|-------------------------------------|--------------------------------------------------------------------------|
 | GET  | `/api/v1/workload`                  | List all workloads, optionally filtering by uuid or project              |
+| GET  | `/api/v1/workload/{uuid}/workflows` | List all workflows for workload `uuid`, optionally filtering by status   |
+| POST | `/api/v1/workload/{uuid}/retry`     | Retry workflows matching a given status in workload `uuid`               |
 | POST | `/api/v1/create`                    | Create a new workload                                                    |
 | POST | `/api/v1/start`                     | Start a workload                                                         |
 | POST | `/api/v1/stop`                      | Stop a running workload                                                  |
@@ -18,50 +23,256 @@ The `covid` module supports the following API endpoints:
 
 The life-cycle of a workload is a multi-stage process:
 
-1. The caller needs to create a workload and specify the source, sink and executor.
+1. The caller needs to [create](#create-workload) a workload
+   and specify the source, executor, and sink.
 
-    - The [Source](./source.md) must be either a snapshot or a list of snapshots. If the former, then the type is `TDR Snapshots`. If the latter, it is of type `TDRSnapshotListSource`.
+    - For continuous processing, the [Source](./source.md) request
+      is expected to have name [`Terra DataRepo`](./source.md#terra-datarepo-source)
+      and specify a Terra Data Repository (TDR) dataset to poll and snapshot.
+      In one-off processing or development, we may instead use name
+      [`TDR Snapshots Source`](./source.md#tdr-snapshots-source)
+      to specify a list of existing TDR snapshots.
      
-    - The [Executor](./executor.md) must be of type `TerraExecutor`
-     
-    - The [Sink](./sink.md) must be of type `TerraWorkspaceSink`. 
+    - The [Executor](./executor.md) request is expected to have name
+      [`Terra`](./executor.md#terra-executor) and specify the Terra workspace
+      configuration for executing workflows.
+
+    - The [Sink](./sink.md) request is expected to have name
+      [`Terra Workspace`](./sink.md#terra-workspace-sink)
+      and specify the Terra workspace configuration for saving workflow outputs.
       
-    If everything passes verification, then the caller will receive a response which will contain the `uuid` of the workload.
+    If all stage requests pass verification,
+    then the caller will receive a response containing the workload's `uuid`.
    
-2. Next, the caller needs to "start" the newly created workload, which will begin the analysis. Once started, Workflow Launcher will continue to poll for new inputs to the source until it is stopped (see #3 below).
-   
-3. WFL can, in addition, stop watching a workflow using the `stop` endpoint. This will not cancel analysis, but WFL will stop managing the workload, which means that it will no longer poll for new inputs to that workload.
+2. Next, the caller needs to [start](#start-workload) the newly created workload, which will begin the analysis.
+   Once started, WFL will continue to poll for new inputs to the source until it is stopped.
+
+3. WFL can, in addition, [stop](#stop-workload) watching a workflow.
+   This will not cancel analysis, but WFL will stop polling for new inputs to that workload,
+   and will mark the workload finished once any previously-identified inputs have undergone processing.
+
+    - Example: the caller may wish to stop a continuous workflow
+      if maintenance is required on the underlying method.
+
+The caller can also [retry](#retry-workload) workflows in a workload
+matching a given status (ex. "Failed").
 
 To give more information, here are some example inputs to the above endpoints:
 
-**GET /api/v1/workload**
+### Get Workloads
 
-==="Sample Request"
+!!! warning "Note"
+    A request to the `/api/v1/workload` endpoint without a `uuid`
+    or `project` parameter returns all workloads known to WFL.
+    That response might be large and take awhile to process.
+
+**GET /api/v1/workload?uuid={uuid}**
+
+Query WFL for a workload by its UUID.
+
+Note that a successful response from `/api/v1/workload` will
+always be an array of workload objects, but specifying a `uuid`
+will return a singleton.
+
+=== "Request"
 
     ```
-    curl 'http://localhost:8080/api/v1/workload' \
+    curl -X GET 'http://localhost:3000/api/v1/workload' \
         -H 'Authorization: Bearer '$(gcloud auth print-access-token) \
-        -H 'Accept: application/json'
+        -H 'Accept: application/json' \
+        -d $'{ "uuid": "e66c86b2-120d-4f7f-9c3a-b9eaadeb1919" }'
     ```
+
+=== "Response"
+
+    ```
+    [ {
+    "started" : "2021-07-14T15:36:47Z",
+    "watchers" : [ "okotsopo@broadinstitute.org" ],
+    "labels" : [ "hornet:test", "project:okotsopo testing enhanced source, executor, sink logging" ],
+    "creator" : "okotsopo@broadinstitute.org",
+    "updated" : "2021-08-06T21:41:28Z",
+    "created" : "2021-07-14T15:36:07Z",
+    "source" : {
+    "snapshots" : [ "67a2bfd7-88e4-4adf-9e41-9b0d04fb32ea" ],
+    "name" : "TDR Snapshots"
+    },
+    "finished" : "2021-08-06T21:41:28Z",
+    "commit" : "9719eda7424bf5b0804f5493875681fa014cdb29",
+    "uuid" : "e66c86b2-120d-4f7f-9c3a-b9eaadeb1919",
+    "executor" : {
+    "workspace" : "wfl-dev/CDC_Viral_Sequencing_okotsopo_20210707",
+    "methodConfiguration" : "wfl-dev/sarscov2_illumina_full",
+    "methodConfigurationVersion" : 41,
+    "fromSource" : "importSnapshot",
+    "name" : "Terra"
+    },
+    "version" : "0.8.0",
+    "sink" : {
+    "workspace" : "wfl-dev/CDC_Viral_Sequencing_okotsopo_20210707",
+    "entityType" : "flowcell",
+    "fromOutputs" : {
+    "submission_xml" : "submission_xml",
+    "assembled_ids" : "assembled_ids",
+    ...
+    },
+    "identifier" : "run_id",
+    "name" : "Terra Workspace"
+    }
+    } ]
+    ```
+
+**GET /api/v1/workload?project={project}**
+
+Query WFL for all workloads with a specified `project` label.
+
+The response has the same format as when specifying a UUID,
+except the array may contain multiple workload objects
+that share the same `project` value.
+
+=== "Request"
+
+    ```
+    curl -X GET 'http://localhost:3000/api/v1/workload' \
+        -H 'Authorization: Bearer '$(gcloud auth print-access-token) \
+        -H 'Accept: application/json' \
+        -d $'{ "project": "PO-1234" }'
+    ```
+
+### Get Workflows
 
 **GET /api/v1/workload/{uuid}/workflows**
 
-=== "Sample Request"
+Query WFL for all workflows associated with workload `uuid`.
+
+The response is a list of Firecloud-derived
+[workflows](https://firecloud-orchestration.dsde-prod.broadinstitute.org/#/Submissions/workflowMetadata)
+and their [outputs](https://firecloud-orchestration.dsde-prod.broadinstitute.org/#/Submissions/workflowOutputsInSubmission)
+when available.
+
+=== "Request"
 
     ```
-    curl -X GET 'http://localhost:8080/api/v1/workload/ed6e8637-5bae-4602-8b7f-f5a1bbfd2406/workflows' 
-         -H 'Authorization: Bearer '$(gcloud auth print-access-token)      
+    curl -X GET 'http://localhost:3000/api/v1/workload/e66c86b2-120d-4f7f-9c3a-b9eaadeb1919/workflows' \
+         -H 'Authorization: Bearer '$(gcloud auth print-access-token) \
          -H 'Accept: application/json'
     ```
 
-**POST /api/v1/create**
-
-=== "Sample Request"
+=== "Response"
 
     ```
-    curl -X "POST" "http://localhost:8080/api/v1/create" \
+    [ {
+    "inputs" : {
+    "biosample_to_genbank.docker" : "quay.io/broadinstitute/viral-phylo:2.1.19.1",
+    "instrument_model" : "Illumina NovaSeq 6000",
+    ...
+    },
+    "uuid" : "53f70344-6f0f-47fb-adee-4e780fb3f19a",
+    "status" : "Failed",
+    "outputs" : { },
+    "updated" : "2021-08-06T21:41:28Z"
+    } ]
+    ```
+
+**GET /api/v1/workload/{uuid}/workflows?status={status}**
+
+Query WFL for all workflows with `status` associated with workload `uuid`.
+
+The response has the same format as when querying without the status restriction.
+
+=== "Request"
+
+    ```
+    curl -X GET 'http://localhost:3000/api/v1/workload/e66c86b2-120d-4f7f-9c3a-b9eaadeb1919/workflows' \
+        -H 'Authorization: Bearer '$(gcloud auth print-access-token) \
+        -H 'Accept: application/json' \
+        -d $'{ "status": "Failed" }'
+    ```
+
+### Retry Workload
+
+**POST /api/v1/workload/{uuid}/retry?status={status}**
+
+Resubmit all workflows matching `status` associated with workload `uuid`.
+
+Prerequisites:
+
+- The status is [supported](./usage-retry.md#supported-statuses)
+- Workflows must exist in the workload for the specified status
+- The workload should be started
+
+With all prerequisite fulfilled, WFL will then...
+
+- Submit the retry to the executor
+- (If necessary) remark the workload as active
+  so that it will be visible in the update loop
+- Return the updated workload
+
+Further information found in general
+[retry documentation](./usage-retry.md#retrying-terra-workflows-via-wfl-api).
+
+=== "Request"
+
+    ```
+    curl -X POST "http://localhost:3000/api/v1/workload/e66c86b2-120d-4f7f-9c3a-b9eaadeb1919/retry" \
+        -H 'Authorization: Bearer '$(gcloud auth print-access-token) \
+        -H "Content-Type: application/json" \
+        -d '{ "status": "Aborted" }'
+    ```
+
+=== "Response"
+
+    ```
+    {
+    "started" : "2021-07-14T15:36:47Z",
+    "watchers" : [ "okotsopo@broadinstitute.org" ],
+    "labels" : [ "hornet:test", "project:okotsopo testing enhanced source, executor, sink logging", "project:wfl-dev/CDC_Viral_Sequencing_okotsopo_20210707" ],
+    "creator" : "okotsopo@broadinstitute.org",
+    "updated" : "2021-08-09T21:45:50Z",
+    "created" : "2021-07-14T15:36:07Z",
+    "source" : {
+    "snapshots" : [ "67a2bfd7-88e4-4adf-9e41-9b0d04fb32ea" ],
+    "name" : "TDR Snapshots"
+    },
+    "commit" : "9719eda7424bf5b0804f5493875681fa014cdb29",
+    "uuid" : "e66c86b2-120d-4f7f-9c3a-b9eaadeb1919",
+    "executor" : {
+    "workspace" : "wfl-dev/CDC_Viral_Sequencing_okotsopo_20210707",
+    "methodConfiguration" : "wfl-dev/sarscov2_illumina_full",
+    "methodConfigurationVersion" : 43,
+    "fromSource" : "importSnapshot",
+    "name" : "Terra"
+    },
+    "version" : "0.8.0",
+    "sink" : {
+    "workspace" : "wfl-dev/CDC_Viral_Sequencing_okotsopo_20210707",
+    "entityType" : "flowcell",
+    "fromOutputs" : {
+    "submission_xml" : "submission_xml",
+    "assembled_ids" : "assembled_ids",
+    ...
+    },
+    "identifier" : "run_id",
+    "name" : "Terra Workspace"
+    }
+    }
+    ```
+
+### Create Workload
+
+**POST /api/v1/create**
+
+Create a new workload from a request.
+Expected request format documented within [staged workload](./staged-workload.md)
+navigation.
+
+The response will be the newly created workload object with an assigned `uuid`.
+
+=== "Request"
+
+    ```
+    curl -X "POST" "http://localhost:3000/api/v1/create" \
          -H 'Authorization: Bearer '$(gcloud auth print-access-token) \
-         -H 'Accept: application/json' \
          -H 'Content-Type: application/json' \
          -d '{
                 "watchers": [
@@ -102,26 +313,57 @@ To give more information, here are some example inputs to the above endpoints:
             }'
     ```
 
-**POST /api/v1/start**
-
-=== "Sample Request"
+=== "Response"
 
     ```
-    curl -X POST 'http://localhost:8080/api/v1/start' \
+    TODO!
+    ```
+
+### Start Workload
+
+**POST /api/v1/start?uuid={uuid}**
+
+Start an existing, unstarted workload `uuid`.
+
+The response will be the updated workload object.
+See [create endpoint documentation](#create-workload) for response example.
+
+=== "Request"
+
+    ```
+    curl -X POST 'http://localhost:3000/api/v1/start' \
          -H 'Authorization: Bearer '$(gcloud auth print-access-token) \
-         -H 'Accept: application/json' \
          -H 'Content-Type: application/json' \
          -d $'{ "uuid": "fb06bcf3-bc10-471b-a309-b2f99e4f5a67" }'
     ```
 
-**POST /api/v1/stop**
+### Stop Workload
 
-=== "Sample Request"
+**POST /api/v1/stop?uuid={uuid}**
+
+Stop a running workload `uuid`.
+
+The response will be the updated workload object.
+See [create endpoint documentation](#create-workload) for response example.
+
+=== "Request"
 
     ```
-    curl -X POST 'http://localhost:8080/api/v1/start' \
+    curl -X POST 'http://localhost:3000/api/v1/stop' \
          -H 'Authorization: Bearer '$(gcloud auth print-access-token) \
-         -H 'Accept: application/json' \
          -H 'Content-Type: application/json' \
          -d $'{ "uuid": "fb06bcf3-bc10-471b-a309-b2f99e4f5a67" }'
     ```
+
+### Execute Workload
+
+**POST /api/v1/exec**
+
+Create and start (execute) a workload from a request.
+Expected request format documented within [staged workload](./staged-workload.md)
+navigation.
+
+The response will be the newly created and running workload object with an assigned `uuid`.
+
+See [create endpoint documentation](#create-workload) for request and response examples,
+but with modified endpoint.

--- a/docs/md/staged-workload.md
+++ b/docs/md/staged-workload.md
@@ -1,12 +1,13 @@
-# Workloads
+# Staged Workloads
 
-## What is it?
-Within the context of Workflow Launcher, a workload is a discrete body of work, which takes data from a source, pushes it into a workflow executor for analysis, and then delivers the results of the analysis to an output location (also known as a sink).
+A staged workload is a discrete body of work, which takes data from a source,
+pushes it into a workflow executor for analysis,
+and then delivers the results of the analysis to an output location (also known as a sink).
 
-## Workload Components
+## Staged Workload Components
 ### Source
-The workload [Source](./source.md) models the first stage of a processing pipeline. In a
-typical workload configuration, a `Source` can be used to read workflow inputs
+The workload [Source](./source.md) models the first stage of a processing pipeline.
+In a typical workload configuration, a `Source` can be used to read workflow inputs
 from a specified location or service in the cloud.
 
 ### Executor
@@ -15,12 +16,14 @@ In a typical workload configuration, an `Executor` uses a supported
 service in the cloud to execute workflows.
 
 ### Sink
-The workload [Sink](./sink.md) models the terminal stage of a processing pipeline. In a
-typical workload configuration, a `Sink` can be used to write workflow outputs
+The workload [Sink](./sink.md) models the terminal stage of a processing pipeline.
+In a typical workload configuration, a `Sink` can be used to write workflow outputs
 to a desired location in the cloud.
 
-## Example workload 
-The specific values below are from the COVID-19 Surveillance in Terra project. Workloads for other projects may leverage different implementations for source, executor or sink.
+## Example Staged Workload 
+The specific values below are from the
+[COVID-19 Surveillance in Terra](./modules-covid.md) project.
+Workloads for other projects may leverage different implementations for source, executor or sink.
 
 ```
 {
@@ -60,13 +63,13 @@ The specific values below are from the COVID-19 Surveillance in Terra project. W
 }
 ```
 
-## Workload Anatomy (High Level)
+## Staged Workload Anatomy (High Level)
 
 | Field    | Type | Description                     |
 |----------|------|---------------------------------|
-| watchers | List | A list of emails to notify |
-| labels   | List | A list of user-defined labels. They must be a string of the form `"name":"value”`, where `name` must start with a letter followed by any combination of digits, letters, spaces, underscores and hyphens and `value` is any non-blank string |
+| watchers | List   | A list of emails to notify |
+| labels   | List   | A list of user-defined labels.They must be a string of the form `"name":"value”`, where `name` must start with a letter followed by any combination of digits, letters, spaces, underscores and hyphens and `value` is any non-blank string |
 | project  | String |  The project is a non-null string required in the workload table. It's needed to support querying workloads by project |
 | source   | Object | The data source |
-| executor   | Object | The mechanism executing the analysis. (Most often this is Terra)|
-| sink   | Object | The location where data will be placed after analysis is complete|
+| executor | Object | The mechanism executing the analysis. (Most often this is Terra)|
+| sink     | Object | The location where data will be placed after analysis is complete|

--- a/docs/md/usage-retry.md
+++ b/docs/md/usage-retry.md
@@ -1,14 +1,12 @@
-# Retry Workflows in Terra
+# Retrying Workflows
 
-WFL has a `/retry` endpoint
-that selects workflows
-by their completion status
+## Retrying Terra Workflows via WFL API
+
+WFL has a `/retry` endpoint that selects workflows by their completion status
 and re-submits them.
 
-The following `curl` shell command
-finds the workflows
-with the Cromwell status `"Failed"`
-in the workload with `$UUID`
+The following `curl` shell command finds the workflows
+with the Cromwell status `"Failed"` in workload `$UUID`
 and resubmits them for processing.
 
 ```bash
@@ -18,6 +16,18 @@ UUID=0d307eb3-2b8e-419c-b687-8c08c84e2a0c # workload UUID
 
 curl -X POST -H "$AUTH" $WFL/$UUID/retry --data '{"status":"Failed"}' | jq
 ```
+
+A successful `/retry` request returns the workload specified by `$UUID`.
+A failed `/retry` request will return a description of the failure.
+
+The `/retry` endpoint is not yet implemented for all workloads
+and in such cases returns a `501` HTTP failure status.
+[Staged workloads](./staged-workload.md) with a [Terra executor](./executor.md#terra-executor)
+are likely to implement this endpoint.
+For confirmation, see module-specific documentation.
+For unimplemented cases, see the [runbook](#retrying-failures-via-wfl-runbook) below.
+
+### Supported Statuses
 
 The only
 [Cromwell statuses](https://github.com/broadinstitute/wfl/blob/c87ce58e815c9fe73648471057c8d3cda7bc02e0/api/src/wfl/service/cromwell.clj#L12-L14)
@@ -30,45 +40,42 @@ are the terminal and likely failure workflow statuses:
 
 Attempting to retry workflows of any other status
 will return a `400` HTTP failure status,
-as will specifying a status for which the
-workload has no workflows.
+as will specifying a status for which the workload has no workflows.
 
-!!! warning "Submission of snapshot subsets not yet supported"
-    Note that WFL is limited by Rawls functionality
-    and cannot yet submit a subset of a snapshot.
-    So retrying any workflow from a workload snapshot
-    will resubmit all entities from that snapshot.
+### Warnings and Caveats
 
-    Example - a running submission from a snapshot
-    has 500 workflows:
+#### Submission of snapshot subsets not yet supported
 
-    - 1 failed
+WFL is limited by Rawls functionality
+and cannot yet submit a subset of a snapshot.
+So retrying any workflow from a workload snapshot
+will resubmit all entities from that snapshot.
 
-    - 249 running
+Example - a running submission from a snapshot has 500 workflows:
 
-    - 250 succeeded
+- 1 failed
 
-    Retrying the failed workflow will create a new submission
-    where all 500 original workflows are retried.
+- 249 running
 
-    Consider whether you should wait for all workflows
-    in the submission to complete before initiating a retry
-    to avoid multiple workflows running concurrently
-    in competition for the same output files.
+- 250 succeeded
 
-A successful `/retry` request
-returns the workload
-specified by `$UUID`.
-A failed `/retry` request
-will return a description
-of the failure.
+Retrying the failed workflow will create a new submission
+where all 500 original workflows are retried.
 
-The `/retry` endpoint is not yet implemented for all workflows
-and in such cases returns a `501` HTTP failure status.
-Until it is supported,
-see the method below.
+Consider whether you should wait for all workflows in the submission to complete
+before initiating a retry
+to avoid multiple workflows running concurrently
+in competition for the same output files.
 
-# Retrying Failures via WFL
+#### Race condition when retrying the same workload concurrently
+
+A caller could hit this endpoint for the same workload multiple times in quick succession,
+making possible a race condition where each run retries the same set of workflows.
+
+Future improvements will make this operation threadsafe, but in the interim
+try to wait for a response from your retry request before resubmitting.
+
+## Retrying Failures via WFL Runbook
 
 WFL remembers enough about submissions to let you quickly resubmit failed
 workflows with the same inputs/options as they were originally submitted.
@@ -162,9 +169,9 @@ main() {
 main "$1"
 ```
 
-## Tips
+### Tips
 
-### Customizing Inputs/Options
+#### Customizing Inputs/Options
 
 If you want to inject a new input or option into all of the retried workflows,
 you can do that with a `common` block. For example, replace this:

--- a/docs/md/usage-retry.md
+++ b/docs/md/usage-retry.md
@@ -46,7 +46,7 @@ as will specifying a status for which the workload has no workflows.
 
 #### Submission of snapshot subsets not yet supported
 
-WFL is limited by Rawls functionality
+WFL is limited by [Rawls](https://github.com/broadinstitute/rawls) functionality
 and cannot yet submit a subset of a snapshot.
 So retrying any workflow from a workload snapshot
 will resubmit all entities from that snapshot.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -35,6 +35,11 @@ nav:
     - Release Process: dev-release.md
     - Logging: dev-logging.md
     - Frontend: dev-frontend.md
+  - Staged Workloads:
+    - Overview: staged-workload.md
+    - Source: source.md
+    - Executor: executor.md
+    - Sink: sink.md
   - Module-Specific Usage:
     - Overview: modules-general.md
     - Arrays: modules-aou-arrays.md
@@ -45,7 +50,7 @@ nav:
   - General Usage:
     - Workflow Options: usage-workflow-options.md
     - Usage Across a Directory: usage-across-directory.md
-    - Retrying Failures: usage-retry.md
+    - Retrying Workflows: usage-retry.md
     - Aborting a Workload: usage-abort.md
   - Readings:
     - WorkFlow Launcher's Role in Terra: terra.md

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -43,3 +43,8 @@ INFO    -  Browser Connected: http://localhost:8000/dev-process/
 [Relative links in markup files](https://github.blog/2013-01-31-relative-links-in-markup-files/)
 allow intra-doc links to work within GitHub Pages website as well as the
 repository view.
+
+[Links to headers](https://stackoverflow.com/questions/27981247/github-markdown-same-page-link)
+can be determined by following these conversion rules.
+Or you can get the link directly from your local docsite instance
+by clicking on the anchor icon visible when hovering to the right of the header.


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- [GH-1395](https://broadinstitute.atlassian.net/browse/GH-1395) Document the new WFL retry capability for users.
- [GH-1428](https://broadinstitute.atlassian.net/browse/GH-1428) Staged workflow GitHub pages should be pulled into navigation

Following implementation of Terra executor retry functionality and COVID `/retry` endpoint in https://github.com/broadinstitute/wfl/pull/482, I looked at our public documentation to see what updates were needed.  I also addressed existing omissions and opportunities for better clarity.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

Staged workflows
- Not all workloads are staged workloads, update throughout to reflect this distinction
- Add pages to the site navigation

Executor
- Added new retry method to protocol representation

Retry usage
- Reorganization to allow for anchor links from other pages
- Added warning for possible race condition

COVID (most extensive changes here)
- Added documentation for missing endpoints, including new `/retry`
- Added response examples
- Corrected requests after making sure that they worked when copy-pasted

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

Please spin up a local [docsite](https://github.com/broadinstitute/wfl/blob/develop/docs/readme.md) to view these changes.  Do the nav bar links as well as relative links within pages allow you to navigate intuitively?  Does the newly-added content make behavior and usage clear?

I added a number of relative links throughout and tried to click through all of them successfully.
