### PR TITLE
[GH-1430] Remove `stage/validate-or-throw` and inline their implementations into `create-X`.

### DIFF
--- a/api/src/wfl/executor.clj
+++ b/api/src/wfl/executor.clj
@@ -54,6 +54,15 @@
    association in the `workload`."
   (fn [_transaction workload] (:executor_type workload)))
 
+(defmethod create-executor! :default
+  [_ _ {:keys [name] :as request}]
+  (throw (UserException.
+          "Invalid executor name"
+          {:name      name
+           :request   request
+           :status    400
+           :executors (-> create-executor! methods (dissoc :default) keys)})))
+
 ;; Terra Executor
 (def ^:private terra-executor-name  "Terra")
 (def ^:private terra-executor-type  "TerraExecutor")

--- a/api/src/wfl/executor.clj
+++ b/api/src/wfl/executor.clj
@@ -109,7 +109,7 @@
     (throw (UserException. "Only Dockstore methods are supported."
                            {:status 400 :methodRepoMethod methodRepoMethod}))))
 
-(defn validate-terra-executor-request
+(defn terra-executor-validate-request-or-throw
   "Verify the method-configuration exists."
   [{:keys [skipValidation
            workspace
@@ -444,7 +444,7 @@
 
 (defmethod create-executor! terra-executor-name
   [tx id request]
-  (write-terra-executor tx id (validate-terra-executor-request request)))
+  (write-terra-executor tx id (terra-executor-validate-request-or-throw request)))
 
 (defoverload load-executor!               terra-executor-type load-terra-executor)
 (defoverload update-executor!             terra-executor-type update-terra-executor)

--- a/api/src/wfl/executor.clj
+++ b/api/src/wfl/executor.clj
@@ -14,6 +14,16 @@
   (:import [wfl.util UserException]))
 
 ;; executor operations
+(defmulti validate-or-throw
+  "Return a validated executor request (i.e. resources exist and wfl can access
+   them) or throw."
+  :name)
+
+(defmethod validate-or-throw :default
+  [{:keys [name] :as request}]
+  (throw (UserException. "No such executor"
+                         (util/make-map name request))))
+
 (defmulti update-executor!
   "Consume items from the `upstream-queue` and enqueue to the `executor` queue
    for consumption by a later processing stage, performing any external effects
@@ -433,6 +443,7 @@
       (util/select-non-nil-keys (keys terra-executor-serialized-fields))
       (assoc :name terra-executor-name)))
 
+(defoverload validate-or-throw terra-executor-name verify-terra-executor)
 (defoverload create-executor! terra-executor-name create-terra-executor)
 (defoverload load-executor!   terra-executor-type load-terra-executor)
 
@@ -440,11 +451,9 @@
 (defoverload executor-workflows           terra-executor-type terra-executor-workflows)
 (defoverload executor-workflows-by-status terra-executor-type terra-executor-workflows-by-status)
 
-(defoverload stage/validate-or-throw terra-executor-name verify-terra-executor)
-(defoverload stage/done?             terra-executor-type terra-executor-done?)
-
 (defoverload stage/peek-queue   terra-executor-type peek-terra-executor-queue)
 (defoverload stage/pop-queue!   terra-executor-type pop-terra-executor-queue)
 (defoverload stage/queue-length terra-executor-type terra-executor-queue-length)
+(defoverload stage/done?        terra-executor-type terra-executor-done?)
 
 (defoverload util/to-edn terra-executor-type terra-executor-to-edn)

--- a/api/src/wfl/module/covid.clj
+++ b/api/src/wfl/module/covid.clj
@@ -95,14 +95,16 @@
 
 (defn ^:private create-covid-workload
   [tx {:keys [source executor sink] :as request}]
-  (let [[source executor sink] (mapv stage/validate-or-throw [source executor sink])
-        id                     (add-workload-metadata tx request)]
+  (let [source'   (source/validate-or-throw source)
+        executor' (executor/validate-or-throw executor)
+        sink'     (sink/validate-or-throw sink)
+        id        (add-workload-metadata tx request)]
     (jdbc/execute!
      tx
      (concat [update-workload-query]
-             (source/create-source! tx id source)
-             (executor/create-executor! tx id executor)
-             (sink/create-sink! tx id sink)
+             (source/create-source! tx id source')
+             (executor/create-executor! tx id executor')
+             (sink/create-sink! tx id sink')
              [id]))
     (workloads/load-workload-for-id tx id)))
 

--- a/api/src/wfl/module/covid.clj
+++ b/api/src/wfl/module/covid.clj
@@ -95,14 +95,13 @@
 
 (defn ^:private create-covid-workload
   [tx {:keys [source executor sink] :as request}]
-  (let [sink'     (sink/validate-or-throw sink)
-        id        (add-workload-metadata tx request)]
+  (let [id (add-workload-metadata tx request)]
     (jdbc/execute!
      tx
      (concat [update-workload-query]
              (source/create-source! tx id source)
              (executor/create-executor! tx id executor)
-             (sink/create-sink! tx id sink')
+             (sink/create-sink! tx id sink)
              [id]))
     (workloads/load-workload-for-id tx id)))
 

--- a/api/src/wfl/module/covid.clj
+++ b/api/src/wfl/module/covid.clj
@@ -95,14 +95,13 @@
 
 (defn ^:private create-covid-workload
   [tx {:keys [source executor sink] :as request}]
-  (let [executor' (executor/validate-or-throw executor)
-        sink'     (sink/validate-or-throw sink)
+  (let [sink'     (sink/validate-or-throw sink)
         id        (add-workload-metadata tx request)]
     (jdbc/execute!
      tx
      (concat [update-workload-query]
              (source/create-source! tx id source)
-             (executor/create-executor! tx id executor')
+             (executor/create-executor! tx id executor)
              (sink/create-sink! tx id sink')
              [id]))
     (workloads/load-workload-for-id tx id)))

--- a/api/src/wfl/module/covid.clj
+++ b/api/src/wfl/module/covid.clj
@@ -95,14 +95,13 @@
 
 (defn ^:private create-covid-workload
   [tx {:keys [source executor sink] :as request}]
-  (let [source'   (source/validate-or-throw source)
-        executor' (executor/validate-or-throw executor)
+  (let [executor' (executor/validate-or-throw executor)
         sink'     (sink/validate-or-throw sink)
         id        (add-workload-metadata tx request)]
     (jdbc/execute!
      tx
      (concat [update-workload-query]
-             (source/create-source! tx id source')
+             (source/create-source! tx id source)
              (executor/create-executor! tx id executor')
              (sink/create-sink! tx id sink')
              [id]))

--- a/api/src/wfl/sink.clj
+++ b/api/src/wfl/sink.clj
@@ -111,7 +111,7 @@
   (str/join " " ["Found additional attributes in fromOutputs that are not"
                  "present in the entityType."]))
 
-(defn terra-workspace-validate-request-or-throw
+(defn terra-workspace-sink-validate-request-or-throw
   "Verify that the WFL has access the `workspace`."
   [{:keys [entityType fromOutputs skipValidation workspace] :as sink}]
   (when-not skipValidation
@@ -199,7 +199,7 @@
 (defmethod create-sink! terra-workspace-sink-name
   [tx id request]
   (write-terra-workspace-sink
-   tx id (terra-workspace-validate-request-or-throw request)))
+   tx id (terra-workspace-sink-validate-request-or-throw request)))
 
 (defoverload load-sink!   terra-workspace-sink-type load-terra-workspace-sink)
 (defoverload update-sink! terra-workspace-sink-type update-terra-workspace-sink)

--- a/api/src/wfl/sink.clj
+++ b/api/src/wfl/sink.clj
@@ -21,6 +21,16 @@
            [wfl.util UserException]))
 
 ;; Interface
+(defmulti validate-or-throw
+  "Return a validated sink request (i.e. resources exist and wfl can access
+   them) or throw."
+  :name)
+
+(defmethod validate-or-throw :default
+  [{:keys [name] :as request}]
+  (throw (UserException. "No such sink"
+                         (util/make-map name request))))
+
 (defmulti create-sink!
   "Create a `Sink` instance using the database `transaction` and configuration
    in the sink `request` and return a `[type items]` pair to be written to a
@@ -187,8 +197,8 @@
       (util/select-non-nil-keys (keys terra-workspace-sink-serialized-fields))
       (assoc :name terra-workspace-sink-name)))
 
-(defoverload stage/validate-or-throw terra-workspace-sink-name terra-workspace-validate-request-or-throw)
-(defoverload create-sink!            terra-workspace-sink-name create-terra-workspace-sink)
+(defoverload validate-or-throw terra-workspace-sink-name terra-workspace-validate-request-or-throw)
+(defoverload create-sink!      terra-workspace-sink-name create-terra-workspace-sink)
 
 (defoverload load-sink!    terra-workspace-sink-type load-terra-workspace-sink)
 (defoverload update-sink!  terra-workspace-sink-type update-terra-workspace-sink)
@@ -364,8 +374,8 @@
       (update :dataset :id)
       (assoc :name datarepo-sink-name)))
 
-(defoverload stage/validate-or-throw datarepo-sink-name datarepo-sink-validate-request-or-throw)
-(defoverload create-sink!            datarepo-sink-name create-datarepo-sink)
+(defoverload validate-or-throw datarepo-sink-name datarepo-sink-validate-request-or-throw)
+(defoverload create-sink!      datarepo-sink-name create-datarepo-sink)
 
 (defoverload load-sink!   datarepo-sink-type load-datarepo-sink)
 (defoverload update-sink! datarepo-sink-type update-datarepo-sink)

--- a/api/src/wfl/sink.clj
+++ b/api/src/wfl/sink.clj
@@ -50,6 +50,15 @@
    and the `Queue`'s parameterisation must be convertible to the `Sink`s."
   (fn [_upstream-queue sink] (:type sink)))
 
+(defmethod create-sink! :default
+  [_ _ {:keys [name] :as request}]
+  (throw (UserException.
+          "Invalid sink name"
+          {:name    name
+           :request request
+           :status  400
+           :sources (-> create-sink! methods (dissoc :default) keys)})))
+
 ;; Terra Workspace Sink
 (def ^:private ^:const terra-workspace-sink-name  "Terra Workspace")
 (def ^:private ^:const terra-workspace-sink-type  "TerraWorkspaceSink")

--- a/api/src/wfl/sink.clj
+++ b/api/src/wfl/sink.clj
@@ -199,7 +199,7 @@
 (defoverload util/to-edn terra-workspace-sink-type terra-workspace-sink-to-edn)
 
 ;; TerraDataRepo Sink
-(def ^:private ^:const datarepo-sink-name  "Terra DataRepo Sink")
+(def ^:private ^:const datarepo-sink-name  "Terra DataRepo")
 (def ^:private ^:const datarepo-sink-type  "TerraDataRepoSink")
 (def ^:private ^:const datarepo-sink-table "TerraDataRepoSink")
 (def ^:private ^:const datarepo-sink-serialized-fields

--- a/api/src/wfl/source.clj
+++ b/api/src/wfl/source.clj
@@ -80,6 +80,15 @@
    `workload`."
   (fn [_transaction workload] (:source_type workload)))
 
+(defmethod create-source! :default
+  [_ _ {:keys [name] :as request}]
+  (throw (UserException.
+          "Invalid source name"
+          {:name    name
+           :request request
+           :status  400
+           :sources (-> create-source! methods (dissoc :default) keys)})))
+
 ;; Terra Data Repository Source
 (def ^:private tdr-source-name  "Terra DataRepo")
 (def ^:private tdr-source-type  "TerraDataRepoSource")

--- a/api/src/wfl/source.clj
+++ b/api/src/wfl/source.clj
@@ -119,7 +119,7 @@
         (update :dataset edn/read-string))
     (throw (ex-info "source_items is not an integer" {:workload workload}))))
 
-(defn validate-datarepo-source!
+(defn datarepo-source-validate-request-or-throw
   "Verify that the `dataset` exists and that WFL has the necessary permissions
    to read it."
   [{:keys [dataset table column skipValidation] :as source}]
@@ -317,7 +317,7 @@
 
 (defmethod create-source! tdr-source-name
   [tx id request]
-  (write-tdr-source tx id (validate-datarepo-source! request)))
+  (write-tdr-source tx id (datarepo-source-validate-request-or-throw request)))
 
 (defoverload load-source!   tdr-source-type load-tdr-source)
 (defoverload start-source!  tdr-source-type start-tdr-source)
@@ -335,7 +335,7 @@
 (def ^:private tdr-snapshot-list-name "TDR Snapshots")
 (def ^:private tdr-snapshot-list-type "TDRSnapshotListSource")
 
-(defn validate-tdr-snapshot-list
+(defn tdr-snappshot-list-validate-request-or-throw
   [{:keys [skipValidation] :as source}]
   (letfn [(snapshot-or-throw [snapshot-id]
             (try
@@ -406,7 +406,8 @@
 
 (defmethod create-source! tdr-snapshot-list-name
   [tx id request]
-  (write-tdr-snapshot-list tx id (validate-tdr-snapshot-list request)))
+  (write-tdr-snapshot-list
+   tx id (tdr-snappshot-list-validate-request-or-throw request)))
 
 (defoverload load-source!   tdr-snapshot-list-type  load-tdr-snapshot-list)
 (defoverload start-source!  tdr-snapshot-list-type  start-tdr-snapshot-list)

--- a/api/src/wfl/source.clj
+++ b/api/src/wfl/source.clj
@@ -61,6 +61,16 @@
   :type)
 
 ;; source load/save operations
+(defmulti validate-or-throw
+  "Return a validated source request (i.e. resources exist and wfl can access
+   them) or throw."
+  :name)
+
+(defmethod validate-or-throw :default
+  [{:keys [name] :as request}]
+  (throw (UserException. "No such source"
+                         (util/make-map name request))))
+
 (defmulti create-source!
   "Create a `Source` instance using the database `transaction` and configuration
    in the source `request` and return a `[type items]` pair to be written to a
@@ -306,7 +316,7 @@
       (update :dataset :id)
       (assoc :name tdr-source-name)))
 
-(defoverload stage/validate-or-throw tdr-source-name verify-data-repo-source!)
+(defoverload validate-or-throw tdr-source-name verify-data-repo-source!)
 
 (defoverload create-source! tdr-source-name create-tdr-source)
 (defoverload start-source!  tdr-source-type start-tdr-source)
@@ -399,14 +409,13 @@
 (defoverload stop-source!   tdr-snapshot-list-type  stop-tdr-snapshot-list)
 (defoverload update-source! tdr-snapshot-list-type  update-tdr-snapshot-list)
 
-(defoverload create-source! tdr-snapshot-list-name  create-tdr-snapshot-list)
-(defoverload load-source!   tdr-snapshot-list-type  load-tdr-snapshot-list)
+(defoverload validate-or-throw tdr-snapshot-list-name  validate-tdr-snapshot-list)
+(defoverload create-source!    tdr-snapshot-list-name  create-tdr-snapshot-list)
+(defoverload load-source!      tdr-snapshot-list-type  load-tdr-snapshot-list)
 
 (defoverload stage/peek-queue tdr-snapshot-list-type peek-tdr-snapshot-list)
 (defoverload stage/pop-queue! tdr-snapshot-list-type pop-tdr-snapshot-list)
 (defoverload stage/queue-length tdr-snapshot-list-type  tdr-snapshot-list-queue-length)
-
-(defoverload stage/validate-or-throw tdr-snapshot-list-name  validate-tdr-snapshot-list)
 (defoverload stage/done? tdr-snapshot-list-type  tdr-snapshot-list-done?)
 
 (defoverload util/to-edn tdr-snapshot-list-type tdr-snapshot-list-to-edn)

--- a/api/src/wfl/source.clj
+++ b/api/src/wfl/source.clj
@@ -90,7 +90,7 @@
    :column          :table_column_name
    :snapshotReaders :snapshot_readers})
 
-(defn ^:private create-tdr-source [tx id source]
+(defn ^:private write-tdr-source [tx id source]
   (let [create  "CREATE TABLE %s OF TerraDataRepoSourceDetails (PRIMARY KEY (id))"
         alter   "ALTER TABLE %s ALTER COLUMN id ADD GENERATED ALWAYS AS IDENTITY"
         details (format "%s_%09d" tdr-source-type id)]
@@ -308,7 +308,7 @@
 
 (defmethod create-source! tdr-source-name
   [tx id request]
-  (create-tdr-source tx id (validate-datarepo-source! request)))
+  (write-tdr-source tx id (validate-datarepo-source! request)))
 
 (defoverload load-source!   tdr-source-type load-tdr-source)
 (defoverload start-source!  tdr-source-type start-tdr-source)
@@ -340,7 +340,7 @@
       source
       (update source :snapshots #(mapv snapshot-or-throw %)))))
 
-(defn ^:private create-tdr-snapshot-list [tx id {:keys [snapshots] :as _request}]
+(defn ^:private write-tdr-snapshot-list [tx id {:keys [snapshots] :as _request}]
   (let [create  "CREATE TABLE %s OF ListSource (PRIMARY KEY (id))"
         alter   "ALTER TABLE %s ALTER COLUMN id ADD GENERATED ALWAYS AS IDENTITY"
         details (format "%s_%09d" tdr-snapshot-list-type id)]
@@ -397,7 +397,7 @@
 
 (defmethod create-source! tdr-snapshot-list-name
   [tx id request]
-  (create-tdr-snapshot-list tx id (validate-tdr-snapshot-list request)))
+  (write-tdr-snapshot-list tx id (validate-tdr-snapshot-list request)))
 
 (defoverload load-source!   tdr-snapshot-list-type  load-tdr-snapshot-list)
 (defoverload start-source!  tdr-snapshot-list-type  start-tdr-snapshot-list)

--- a/api/src/wfl/stage.clj
+++ b/api/src/wfl/stage.clj
@@ -1,17 +1,6 @@
 (ns wfl.stage
   "An interface for operations on a queue-based pipeline processing stage,
-  e.g. source, executor, or sink."
-  (:require [wfl.util :as util])
-  (:import [wfl.util UserException]))
-
-(defmulti validate-or-throw
-  "Validate the `request` request."
-  :name)
-
-(defmethod validate-or-throw :default
-  [{:keys [name] :as request}]
-  (throw (UserException. "Invalid request - unknown name"
-                         (util/make-map name request))))
+  e.g. source, executor, or sink.")
 
 (defmulti peek-queue
   "Peek the first object from the `queue`, if one exists."

--- a/api/test/wfl/integration/executor_test.clj
+++ b/api/test/wfl/integration/executor_test.clj
@@ -26,7 +26,7 @@
     fixtures/temporary-postgresql-database))
 
 (deftest test-validate-terra-executor-with-valid-executor-request
-  (is (executor/validate-or-throw
+  (is (executor/validate-terra-executor-request
        {:name                       "Terra"
         :workspace                  testing-workspace
         :methodConfiguration        testing-method-configuration
@@ -36,13 +36,13 @@
 (deftest test-validate-terra-executor-with-misnamed-executor
   (is (thrown-with-msg?
        UserException #"Invalid request"
-       (executor/validate-or-throw
+       (executor/validate-terra-executor-request
         {:name "bad name"}))))
 
 (deftest test-validate-terra-executor-with-invalid-executor-request
   (is (thrown-with-msg?
        UserException #"Unsupported coercion"
-       (executor/validate-or-throw
+       (executor/validate-terra-executor-request
         {:name                       "Terra"
          :workspace                  testing-workspace
          :methodConfiguration        testing-method-configuration
@@ -52,7 +52,7 @@
 (deftest test-validate-terra-executor-with-wrong-method-configuration-version
   (is (thrown-with-msg?
        UserException #"Unexpected method configuration version"
-       (executor/validate-or-throw
+       (executor/validate-terra-executor-request
         {:name                       "Terra"
          :workspace                  testing-workspace
          :methodConfiguration        testing-method-configuration
@@ -62,7 +62,7 @@
 (deftest test-validate-terra-executor-with-wrong-method-configuration
   (is (thrown-with-msg?
        UserException #"Cannot access method configuration"
-       (executor/validate-or-throw
+       (executor/validate-terra-executor-request
         {:name                "Terra"
          :workspace           testing-workspace
          :methodConfiguration "no_such/method_configuration"

--- a/api/test/wfl/integration/executor_test.clj
+++ b/api/test/wfl/integration/executor_test.clj
@@ -33,12 +33,6 @@
         :methodConfigurationVersion testing-method-configuration-version
         :fromSource                 "importSnapshot"})))
 
-(deftest test-validate-terra-executor-with-misnamed-executor
-  (is (thrown-with-msg?
-       UserException #"Invalid request"
-       (executor/validate-terra-executor-request
-        {:name "bad name"}))))
-
 (deftest test-validate-terra-executor-with-invalid-executor-request
   (is (thrown-with-msg?
        UserException #"Unsupported coercion"

--- a/api/test/wfl/integration/executor_test.clj
+++ b/api/test/wfl/integration/executor_test.clj
@@ -26,7 +26,7 @@
     fixtures/temporary-postgresql-database))
 
 (deftest test-validate-terra-executor-with-valid-executor-request
-  (is (executor/validate-terra-executor-request
+  (is (executor/terra-executor-validate-request-or-throw
        {:name                       "Terra"
         :workspace                  testing-workspace
         :methodConfiguration        testing-method-configuration
@@ -36,7 +36,7 @@
 (deftest test-validate-terra-executor-with-invalid-executor-request
   (is (thrown-with-msg?
        UserException #"Unsupported coercion"
-       (executor/validate-terra-executor-request
+       (executor/terra-executor-validate-request-or-throw
         {:name                       "Terra"
          :workspace                  testing-workspace
          :methodConfiguration        testing-method-configuration
@@ -46,7 +46,7 @@
 (deftest test-validate-terra-executor-with-wrong-method-configuration-version
   (is (thrown-with-msg?
        UserException #"Unexpected method configuration version"
-       (executor/validate-terra-executor-request
+       (executor/terra-executor-validate-request-or-throw
         {:name                       "Terra"
          :workspace                  testing-workspace
          :methodConfiguration        testing-method-configuration
@@ -56,7 +56,7 @@
 (deftest test-validate-terra-executor-with-wrong-method-configuration
   (is (thrown-with-msg?
        UserException #"Cannot access method configuration"
-       (executor/validate-terra-executor-request
+       (executor/terra-executor-validate-request-or-throw
         {:name                "Terra"
          :workspace           testing-workspace
          :methodConfiguration "no_such/method_configuration"

--- a/api/test/wfl/integration/executor_test.clj
+++ b/api/test/wfl/integration/executor_test.clj
@@ -26,7 +26,7 @@
     fixtures/temporary-postgresql-database))
 
 (deftest test-validate-terra-executor-with-valid-executor-request
-  (is (stage/validate-or-throw
+  (is (executor/validate-or-throw
        {:name                       "Terra"
         :workspace                  testing-workspace
         :methodConfiguration        testing-method-configuration
@@ -36,13 +36,13 @@
 (deftest test-validate-terra-executor-with-misnamed-executor
   (is (thrown-with-msg?
        UserException #"Invalid request"
-       (stage/validate-or-throw
+       (executor/validate-or-throw
         {:name "bad name"}))))
 
 (deftest test-validate-terra-executor-with-invalid-executor-request
   (is (thrown-with-msg?
        UserException #"Unsupported coercion"
-       (stage/validate-or-throw
+       (executor/validate-or-throw
         {:name                       "Terra"
          :workspace                  testing-workspace
          :methodConfiguration        testing-method-configuration
@@ -52,7 +52,7 @@
 (deftest test-validate-terra-executor-with-wrong-method-configuration-version
   (is (thrown-with-msg?
        UserException #"Unexpected method configuration version"
-       (stage/validate-or-throw
+       (executor/validate-or-throw
         {:name                       "Terra"
          :workspace                  testing-workspace
          :methodConfiguration        testing-method-configuration
@@ -62,7 +62,7 @@
 (deftest test-validate-terra-executor-with-wrong-method-configuration
   (is (thrown-with-msg?
        UserException #"Cannot access method configuration"
-       (stage/validate-or-throw
+       (executor/validate-or-throw
         {:name                "Terra"
          :workspace           testing-workspace
          :methodConfiguration "no_such/method_configuration"

--- a/api/test/wfl/integration/modules/covid_test.clj
+++ b/api/test/wfl/integration/modules/covid_test.clj
@@ -103,12 +103,30 @@
 
 (deftest test-create-covid-workload-with-misnamed-source
   (is (thrown-with-msg?
-       UserException #"Invalid request"
+       UserException #"Invalid source"
        (workloads/create-workload!
         (workloads/covid-workload-request
          {:name "bad name"}
          {:skipValidation true}
          {:skipValidation true})))))
+
+(deftest test-create-covid-workload-with-misnamed-executor
+  (is (thrown-with-msg?
+       UserException #"Invalid executor"
+       (workloads/create-workload!
+        (workloads/covid-workload-request
+         {:skipValidation true}
+         {:name "bad name"}
+         {:skipValidation true})))))
+
+(deftest test-create-covid-workload-with-misnamed-sink
+  (is (thrown-with-msg?
+       UserException #"Invalid sink"
+       (workloads/create-workload!
+        (workloads/covid-workload-request
+         {:skipValidation true}
+         {:skipValidation true}
+         {:name "bad name"})))))
 
 (deftest test-create-covid-workload-with-valid-executor-request
   (is (workloads/create-workload!
@@ -119,15 +137,6 @@
          :methodConfigurationVersion testing-method-configuration-version
          :fromSource                 "importSnapshot"}
         {:skipValidation true}))))
-
-(deftest test-create-covid-workload-with-misnamed-executor
-  (is (thrown-with-msg?
-       UserException #"Invalid request"
-       (workloads/create-workload!
-        (workloads/covid-workload-request
-         {:skipValidation true}
-         {:name "bad name"}
-         {:skipValidation true})))))
 
 (deftest test-start-workload
   (let [workload (workloads/create-workload!

--- a/api/test/wfl/integration/sinks/datarepo_sink_test.clj
+++ b/api/test/wfl/integration/sinks/datarepo_sink_test.clj
@@ -83,11 +83,8 @@
 ;; Operation tests
 (def ^:private random (partial rand-int 1000000))
 
-(def ^:private datarepo-sink-config
-  (comp sink/datarepo-sink-validate-request-or-throw datarepo-sink-request))
-
 (deftest test-create-datarepo-sink
-  (let [[type items] (evalT sink/create-sink! (random) (datarepo-sink-config))]
+  (let [[type items] (evalT sink/create-sink! (random) (datarepo-sink-request))]
     (is (= @#'sink/datarepo-sink-type type))
     (is (-> items Integer/parseInt pos?))
     (let [sink (evalT sink/load-sink! {:sink_type type :sink_items items})]
@@ -97,7 +94,7 @@
       (is (evalT postgres/table-exists? (:details sink))))))
 
 (defn ^:private create-and-load-datarepo-sink []
-  (let [[type items] (evalT sink/create-sink! (random) (datarepo-sink-config))]
+  (let [[type items] (evalT sink/create-sink! (random) (datarepo-sink-request))]
     (evalT sink/load-sink! {:sink_type type :sink_items items})))
 
 (deftest test-datarepo-sink-initially-done

--- a/api/test/wfl/integration/sinks/datarepo_sink_test.clj
+++ b/api/test/wfl/integration/sinks/datarepo_sink_test.clj
@@ -42,12 +42,12 @@
    :fromOutputs {:fileref "outfile"}})
 
 (deftest test-validate-datarepo-sink-with-valid-sink-request
-  (is (stage/validate-or-throw (datarepo-sink-request))))
+  (is (sink/validate-or-throw (datarepo-sink-request))))
 
 (deftest test-validate-datarepo-sink-throws-on-invalid-dataset
   (is (thrown-with-msg?
        UserException #"Cannot access dataset"
-       (stage/validate-or-throw
+       (sink/validate-or-throw
         {:name        @#'sink/datarepo-sink-name
          :dataset     util/uuid-nil
          :table       "parameters"
@@ -56,7 +56,7 @@
 (deftest test-validate-datarepo-sink-throws-on-invalid-table
   (is (thrown-with-msg?
        UserException #"Table not found"
-       (stage/validate-or-throw
+       (sink/validate-or-throw
         {:name        @#'sink/datarepo-sink-name
          :dataset     *dataset*
          :table       "not-a-table"
@@ -65,7 +65,7 @@
 (deftest test-validate-datarepo-sink-throws-on-malformed-fromOutputs
   (is (thrown-with-msg?
        UserException (re-pattern sink/datarepo-malformed-from-outputs-message)
-       (stage/validate-or-throw
+       (sink/validate-or-throw
         {:name        @#'sink/datarepo-sink-name
          :dataset     *dataset*
          :table       "parameters"
@@ -74,7 +74,7 @@
 (deftest test-validate-datarepo-sink-throws-on-unknown-column-name
   (is (thrown-with-msg?
        UserException (re-pattern sink/unknown-columns-error-message)
-       (stage/validate-or-throw
+       (sink/validate-or-throw
         {:name        @#'sink/datarepo-sink-name
          :dataset     *dataset*
          :table       "parameters"
@@ -84,7 +84,7 @@
 (def ^:private random (partial rand-int 1000000))
 
 (def ^:private datarepo-sink-config
-  (comp stage/validate-or-throw datarepo-sink-request))
+  (comp sink/validate-or-throw datarepo-sink-request))
 
 (deftest test-create-datarepo-sink
   (let [[type items] (evalT sink/create-sink! (random) (datarepo-sink-config))]

--- a/api/test/wfl/integration/sinks/datarepo_sink_test.clj
+++ b/api/test/wfl/integration/sinks/datarepo_sink_test.clj
@@ -42,12 +42,12 @@
    :fromOutputs {:fileref "outfile"}})
 
 (deftest test-validate-datarepo-sink-with-valid-sink-request
-  (is (sink/validate-or-throw (datarepo-sink-request))))
+  (is (sink/datarepo-sink-validate-request-or-throw (datarepo-sink-request))))
 
 (deftest test-validate-datarepo-sink-throws-on-invalid-dataset
   (is (thrown-with-msg?
        UserException #"Cannot access dataset"
-       (sink/validate-or-throw
+       (sink/datarepo-sink-validate-request-or-throw
         {:name        @#'sink/datarepo-sink-name
          :dataset     util/uuid-nil
          :table       "parameters"
@@ -56,7 +56,7 @@
 (deftest test-validate-datarepo-sink-throws-on-invalid-table
   (is (thrown-with-msg?
        UserException #"Table not found"
-       (sink/validate-or-throw
+       (sink/datarepo-sink-validate-request-or-throw
         {:name        @#'sink/datarepo-sink-name
          :dataset     *dataset*
          :table       "not-a-table"
@@ -65,7 +65,7 @@
 (deftest test-validate-datarepo-sink-throws-on-malformed-fromOutputs
   (is (thrown-with-msg?
        UserException (re-pattern sink/datarepo-malformed-from-outputs-message)
-       (sink/validate-or-throw
+       (sink/datarepo-sink-validate-request-or-throw
         {:name        @#'sink/datarepo-sink-name
          :dataset     *dataset*
          :table       "parameters"
@@ -74,7 +74,7 @@
 (deftest test-validate-datarepo-sink-throws-on-unknown-column-name
   (is (thrown-with-msg?
        UserException (re-pattern sink/unknown-columns-error-message)
-       (sink/validate-or-throw
+       (sink/datarepo-sink-validate-request-or-throw
         {:name        @#'sink/datarepo-sink-name
          :dataset     *dataset*
          :table       "parameters"
@@ -84,7 +84,7 @@
 (def ^:private random (partial rand-int 1000000))
 
 (def ^:private datarepo-sink-config
-  (comp sink/validate-or-throw datarepo-sink-request))
+  (comp sink/datarepo-sink-validate-request-or-throw datarepo-sink-request))
 
 (deftest test-create-datarepo-sink
   (let [[type items] (evalT sink/create-sink! (random) (datarepo-sink-config))]

--- a/api/test/wfl/integration/sinks/workspace_sink_test.clj
+++ b/api/test/wfl/integration/sinks/workspace_sink_test.clj
@@ -29,7 +29,7 @@
 ;; Validation tests
 
 (deftest test-validate-terra-workspace-sink-with-valid-sink-request
-  (is (stage/validate-or-throw
+  (is (sink/validate-or-throw
        {:name        @#'sink/terra-workspace-sink-name
         :workspace   testing-workspace
         :entityType  "assemblies"
@@ -39,7 +39,7 @@
 (deftest test-validate-terra-workspace-sink-throws-on-invalid-sink-entity-type
   (is (thrown-with-msg?
        UserException (re-pattern sink/unknown-entity-type-error-message)
-       (stage/validate-or-throw
+       (sink/validate-or-throw
         {:name        @#'sink/terra-workspace-sink-name
          :workspace   testing-workspace
          :entityType  "does_not_exist"
@@ -49,7 +49,7 @@
 (deftest test-validate-terra-workspace-sink-throws-on-malformed-fromOutputs
   (is (thrown-with-msg?
        UserException (re-pattern sink/terra-workspace-malformed-from-outputs-message)
-       (stage/validate-or-throw
+       (sink/validate-or-throw
         {:name        @#'sink/terra-workspace-sink-name
          :workspace   testing-workspace
          :entityType  "assemblies"
@@ -59,7 +59,7 @@
 (deftest test-validate-terra-workspace-sink-throws-on-unknown-fromOutputs-attributes
   (is (thrown-with-msg?
        UserException (re-pattern sink/unknown-attributes-error-message)
-       (stage/validate-or-throw
+       (sink/validate-or-throw
         {:name        @#'sink/terra-workspace-sink-name
          :workspace   testing-workspace
          :entityType  "assemblies"
@@ -69,7 +69,7 @@
 (deftest test-validate-terra-workspace-sink-throws-on-invalid-sink-workspace
   (is (thrown-with-msg?
        UserException #"Cannot access workspace"
-       (stage/validate-or-throw
+       (sink/validate-or-throw
         {:name        @#'sink/terra-workspace-sink-name
          :workspace   "moo/moo"
          :entityType  "moo"

--- a/api/test/wfl/integration/sinks/workspace_sink_test.clj
+++ b/api/test/wfl/integration/sinks/workspace_sink_test.clj
@@ -29,7 +29,7 @@
 ;; Validation tests
 
 (deftest test-validate-terra-workspace-sink-with-valid-sink-request
-  (is (sink/terra-workspace-validate-request-or-throw
+  (is (sink/terra-workspace-sink-validate-request-or-throw
        {:name        @#'sink/terra-workspace-sink-name
         :workspace   testing-workspace
         :entityType  "assemblies"
@@ -39,7 +39,7 @@
 (deftest test-validate-terra-workspace-sink-throws-on-invalid-sink-entity-type
   (is (thrown-with-msg?
        UserException (re-pattern sink/unknown-entity-type-error-message)
-       (sink/terra-workspace-validate-request-or-throw
+       (sink/terra-workspace-sink-validate-request-or-throw
         {:name        @#'sink/terra-workspace-sink-name
          :workspace   testing-workspace
          :entityType  "does_not_exist"
@@ -49,7 +49,7 @@
 (deftest test-validate-terra-workspace-sink-throws-on-malformed-fromOutputs
   (is (thrown-with-msg?
        UserException (re-pattern sink/terra-workspace-malformed-from-outputs-message)
-       (sink/terra-workspace-validate-request-or-throw
+       (sink/terra-workspace-sink-validate-request-or-throw
         {:name        @#'sink/terra-workspace-sink-name
          :workspace   testing-workspace
          :entityType  "assemblies"
@@ -59,7 +59,7 @@
 (deftest test-validate-terra-workspace-sink-throws-on-unknown-fromOutputs-attributes
   (is (thrown-with-msg?
        UserException (re-pattern sink/unknown-attributes-error-message)
-       (sink/terra-workspace-validate-request-or-throw
+       (sink/terra-workspace-sink-validate-request-or-throw
         {:name        @#'sink/terra-workspace-sink-name
          :workspace   testing-workspace
          :entityType  "assemblies"
@@ -69,7 +69,7 @@
 (deftest test-validate-terra-workspace-sink-throws-on-invalid-sink-workspace
   (is (thrown-with-msg?
        UserException #"Cannot access workspace"
-       (sink/terra-workspace-validate-request-or-throw
+       (sink/terra-workspace-sink-validate-request-or-throw
         {:name        @#'sink/terra-workspace-sink-name
          :workspace   "moo/moo"
          :entityType  "moo"

--- a/api/test/wfl/integration/sinks/workspace_sink_test.clj
+++ b/api/test/wfl/integration/sinks/workspace_sink_test.clj
@@ -29,7 +29,7 @@
 ;; Validation tests
 
 (deftest test-validate-terra-workspace-sink-with-valid-sink-request
-  (is (sink/validate-or-throw
+  (is (sink/terra-workspace-validate-request-or-throw
        {:name        @#'sink/terra-workspace-sink-name
         :workspace   testing-workspace
         :entityType  "assemblies"
@@ -39,7 +39,7 @@
 (deftest test-validate-terra-workspace-sink-throws-on-invalid-sink-entity-type
   (is (thrown-with-msg?
        UserException (re-pattern sink/unknown-entity-type-error-message)
-       (sink/validate-or-throw
+       (sink/terra-workspace-validate-request-or-throw
         {:name        @#'sink/terra-workspace-sink-name
          :workspace   testing-workspace
          :entityType  "does_not_exist"
@@ -49,7 +49,7 @@
 (deftest test-validate-terra-workspace-sink-throws-on-malformed-fromOutputs
   (is (thrown-with-msg?
        UserException (re-pattern sink/terra-workspace-malformed-from-outputs-message)
-       (sink/validate-or-throw
+       (sink/terra-workspace-validate-request-or-throw
         {:name        @#'sink/terra-workspace-sink-name
          :workspace   testing-workspace
          :entityType  "assemblies"
@@ -59,7 +59,7 @@
 (deftest test-validate-terra-workspace-sink-throws-on-unknown-fromOutputs-attributes
   (is (thrown-with-msg?
        UserException (re-pattern sink/unknown-attributes-error-message)
-       (sink/validate-or-throw
+       (sink/terra-workspace-validate-request-or-throw
         {:name        @#'sink/terra-workspace-sink-name
          :workspace   testing-workspace
          :entityType  "assemblies"
@@ -69,7 +69,7 @@
 (deftest test-validate-terra-workspace-sink-throws-on-invalid-sink-workspace
   (is (thrown-with-msg?
        UserException #"Cannot access workspace"
-       (sink/validate-or-throw
+       (sink/terra-workspace-validate-request-or-throw
         {:name        @#'sink/terra-workspace-sink-name
          :workspace   "moo/moo"
          :entityType  "moo"

--- a/api/test/wfl/integration/source_test.clj
+++ b/api/test/wfl/integration/source_test.clj
@@ -50,7 +50,7 @@
   (source/load-source! tx {:source_type type :source_items (str id)}))
 
 (deftest test-create-tdr-source-from-valid-request
-  (is (source/validate-or-throw
+  (is (source/validate-datarepo-source!
        {:name    "Terra DataRepo"
         :dataset testing-dataset
         :table   testing-table-name
@@ -59,14 +59,14 @@
 (deftest test-create-tdr-source-with-non-existent-dataset
   (is (thrown-with-msg?
        UserException #"Cannot access dataset"
-       (source/validate-or-throw
+       (source/validate-datarepo-source!
         {:name    "Terra DataRepo"
          :dataset util/uuid-nil}))))
 
 (deftest test-create-tdr-source-with-invalid-dataset-table
   (is (thrown-with-msg?
        UserException #"Table not found"
-       (source/validate-or-throw
+       (source/validate-datarepo-source!
         {:name    "Terra DataRepo"
          :dataset testing-dataset
          :table   "no_such_table"}))))
@@ -74,7 +74,7 @@
 (deftest test-create-tdr-source-with-invalid-dataset-column
   (is (thrown-with-msg?
        UserException #"Column not found"
-       (source/validate-or-throw
+       (source/validate-datarepo-source!
         {:name    "Terra DataRepo"
          :dataset testing-dataset
          :table   testing-table-name
@@ -145,13 +145,13 @@
     (is (s/valid? ::source/snapshot-list-source source))))
 
 (deftest test-create-covid-workload-with-empty-snapshot-list
-  (is (source/validate-or-throw
+  (is (source/validate-tdr-snapshot-list
        {:name      "TDR Snapshots"
         :snapshots [testing-snapshot]})))
 
 (deftest test-create-covid-workload-with-invalid-snapshot
   (is (thrown-with-msg?
        UserException #"Cannot access snapshot"
-       (source/validate-or-throw
+       (source/validate-tdr-snapshot-list
         {:name     "TDR Snapshots"
          :snapshots [util/uuid-nil]}))))

--- a/api/test/wfl/integration/source_test.clj
+++ b/api/test/wfl/integration/source_test.clj
@@ -50,7 +50,7 @@
   (source/load-source! tx {:source_type type :source_items (str id)}))
 
 (deftest test-create-tdr-source-from-valid-request
-  (is (source/validate-datarepo-source!
+  (is (source/datarepo-source-validate-request-or-throw
        {:name    "Terra DataRepo"
         :dataset testing-dataset
         :table   testing-table-name
@@ -59,14 +59,14 @@
 (deftest test-create-tdr-source-with-non-existent-dataset
   (is (thrown-with-msg?
        UserException #"Cannot access dataset"
-       (source/validate-datarepo-source!
+       (source/datarepo-source-validate-request-or-throw
         {:name    "Terra DataRepo"
          :dataset util/uuid-nil}))))
 
 (deftest test-create-tdr-source-with-invalid-dataset-table
   (is (thrown-with-msg?
        UserException #"Table not found"
-       (source/validate-datarepo-source!
+       (source/datarepo-source-validate-request-or-throw
         {:name    "Terra DataRepo"
          :dataset testing-dataset
          :table   "no_such_table"}))))
@@ -74,7 +74,7 @@
 (deftest test-create-tdr-source-with-invalid-dataset-column
   (is (thrown-with-msg?
        UserException #"Column not found"
-       (source/validate-datarepo-source!
+       (source/datarepo-source-validate-request-or-throw
         {:name    "Terra DataRepo"
          :dataset testing-dataset
          :table   testing-table-name
@@ -145,13 +145,13 @@
     (is (s/valid? ::source/snapshot-list-source source))))
 
 (deftest test-create-covid-workload-with-empty-snapshot-list
-  (is (source/validate-tdr-snapshot-list
+  (is (source/tdr-snappshot-list-validate-request-or-throw
        {:name      "TDR Snapshots"
         :snapshots [testing-snapshot]})))
 
 (deftest test-create-covid-workload-with-invalid-snapshot
   (is (thrown-with-msg?
        UserException #"Cannot access snapshot"
-       (source/validate-tdr-snapshot-list
+       (source/tdr-snappshot-list-validate-request-or-throw
         {:name     "TDR Snapshots"
          :snapshots [util/uuid-nil]}))))

--- a/api/test/wfl/integration/source_test.clj
+++ b/api/test/wfl/integration/source_test.clj
@@ -50,7 +50,7 @@
   (source/load-source! tx {:source_type type :source_items (str id)}))
 
 (deftest test-create-tdr-source-from-valid-request
-  (is (stage/validate-or-throw
+  (is (source/validate-or-throw
        {:name    "Terra DataRepo"
         :dataset testing-dataset
         :table   testing-table-name
@@ -59,14 +59,14 @@
 (deftest test-create-tdr-source-with-non-existent-dataset
   (is (thrown-with-msg?
        UserException #"Cannot access dataset"
-       (stage/validate-or-throw
+       (source/validate-or-throw
         {:name    "Terra DataRepo"
          :dataset util/uuid-nil}))))
 
 (deftest test-create-tdr-source-with-invalid-dataset-table
   (is (thrown-with-msg?
        UserException #"Table not found"
-       (stage/validate-or-throw
+       (source/validate-or-throw
         {:name    "Terra DataRepo"
          :dataset testing-dataset
          :table   "no_such_table"}))))
@@ -74,7 +74,7 @@
 (deftest test-create-tdr-source-with-invalid-dataset-column
   (is (thrown-with-msg?
        UserException #"Column not found"
-       (stage/validate-or-throw
+       (source/validate-or-throw
         {:name    "Terra DataRepo"
          :dataset testing-dataset
          :table   testing-table-name
@@ -145,13 +145,13 @@
     (is (s/valid? ::source/snapshot-list-source source))))
 
 (deftest test-create-covid-workload-with-empty-snapshot-list
-  (is (stage/validate-or-throw
+  (is (source/validate-or-throw
        {:name      "TDR Snapshots"
         :snapshots [testing-snapshot]})))
 
 (deftest test-create-covid-workload-with-invalid-snapshot
   (is (thrown-with-msg?
        UserException #"Cannot access snapshot"
-       (stage/validate-or-throw
+       (source/validate-or-throw
         {:name     "TDR Snapshots"
          :snapshots [util/uuid-nil]}))))

--- a/api/test/wfl/system/v1_endpoint_test.clj
+++ b/api/test/wfl/system/v1_endpoint_test.clj
@@ -348,7 +348,7 @@
                       :methodConfiguration        "warp-pipelines/IlluminaGenotypingArray"
                       :methodConfigurationVersion 1
                       :fromSource                 "importSnapshot"}
-            sink     {:name        "Terra DataRepo Sink"
+            sink     {:name        "Terra DataRepo"
                       :dataset     dataset
                       :table       "outputs"
                       :fromOutputs (resources/read-resource

--- a/api/test/wfl/tools/workloads.clj
+++ b/api/test/wfl/tools/workloads.clj
@@ -1,6 +1,5 @@
 (ns wfl.tools.workloads
   (:require [clojure.string                 :as str]
-            [clojure.tools.logging.readable :as log]
             [wfl.api.workloads]
             [wfl.auth                       :as auth]
             [wfl.environment                :as env]


### PR DESCRIPTION
RR: https://broadinstitute.atlassian.net/browse/GH-1430
Remove `stage/validate-or-throw` and inline their implementations in their respective `create-X` functions.

This is done because
- we were losing context (ie. was this a source/sink/executor) and had a collision in the tdr sink and source impls
- these multimethods didn't really make sense and require some redesign work
