### PR TITLE
Github actions should build docs on develop.

### DIFF
--- a/.github/workflows/doc-site.yml
+++ b/.github/workflows/doc-site.yml
@@ -3,7 +3,7 @@ name: Publish docs via GitHub Pages
 on:
   push:
     branches:
-      - main
+      - develop
     paths:
       - docs/md/**
 


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- No ticket is linked to this PR.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Github actions should build docs on develop.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- I looked into [how `mkdocs` uses `mike` as a versioning manager](https://squidfunk.github.io/mkdocs-material/setup/setting-up-versioning/?h=version), but it introduces too much complication into our build workflow, so maybe we should just deploy docsite on pushing to `develop`.
