### PR TITLE
GH-1439 Succeeded workflow status should be permissible to retry

### DIFF
--- a/api/src/wfl/service/cromwell.clj
+++ b/api/src/wfl/service/cromwell.clj
@@ -11,11 +11,11 @@
 
 (def retry-status?
   "Cromwell workflow statuses eligible for retry."
-  #{"Aborted" "Failed"})
+  #{"Aborted" "Failed" "Succeeded"})
 
 (def final?
   "The final statuses a Cromwell workflow can have."
-  (conj retry-status? "Succeeded"))
+  retry-status?)
 
 (def active?
   "The statuses an active Cromwell workflow can have."

--- a/docs/md/index.md
+++ b/docs/md/index.md
@@ -192,8 +192,6 @@ to deploy applicable versions of WFL to various available cloud projects.
 
 ## Implementation
 
-For frontend details, check [Frontend Section](./dev-frontend.md)
-
 ### Top-level files
 
 After cloning a new WFL repo, the top-level files are:

--- a/docs/md/usage-retry.md
+++ b/docs/md/usage-retry.md
@@ -30,13 +30,19 @@ For unimplemented cases, see the [runbook](#retrying-failures-via-wfl-runbook) b
 ### Supported Statuses
 
 The only
-[Cromwell statuses](https://github.com/broadinstitute/wfl/blob/c87ce58e815c9fe73648471057c8d3cda7bc02e0/api/src/wfl/service/cromwell.clj#L12-L14)
+[Cromwell statuses](https://github.com/broadinstitute/wfl/blob/6bcfde01542bfef1601eaaf4bb2657cf1520218f/api/src/wfl/service/cromwell.clj#L12-L14)
 supported with the `/retry` API
-are the terminal and likely failure workflow statuses:
+are the terminal workflow statuses:
 
 - `"Aborted"`
 
 - `"Failed"`
+
+- `"Succeeded"`
+
+???+ info "Why would you retry succeeded workflows?"
+    A workflow may have functionally succeeded, but be scientifically inaccurate
+    and need to be rerun, e.g. if the initial run contained incorrect metadata.
 
 Attempting to retry workflows of any other status
 will return a `400` HTTP failure status,

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -37,7 +37,6 @@ nav:
     - Development Process and Tips: dev-process.md
     - Release Process: dev-release.md
     - Logging: dev-logging.md
-    - Frontend: dev-frontend.md
     - Monitoring: dev-monitoring.md
   - Staged Workloads:
     - Overview: staged-workload.md


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1439

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Succeeded workflows are now permissible to retry
- Updated public-facing documentation to reflect this
- While working on docs, removed references to now-deleted frontend documentation page

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

I ran the retry system tests `wfl.system.v1-endpoint-test/test-retry-*-workload` and they all succeeded.  Example output:

```
$ WFL_WFL_URL=http://localhost:3000 clojure -M:test --focus wfl.system.v1-endpoint-test/test-retry-wgs-workload
--- system (clojure.test) ---------------------------
wfl.system.v1-endpoint-test
  test-retry-wgs-workload
    retry-workflows fails (400) when workflow status unsupported
    retry-workflows fails (400) when no workflows for supported status

1 tests, 14 assertions, 0 failures.
```

I also executed a COVID workload with a failing workflow and then verified that "Succeeded" status was permissible to be passed in (failure expected since the workload had no successful workflows):
```
$ curl -X POST "http://localhost:3000/api/v1/workload/b4644fbe-68b9-4113-bc60-024f8ded6871/retry" \
> -H 'Authorization: Bearer '$(gcloud auth print-access-token) \
> -H 'Content-Type: application/json' \
> -d '{"status": "Succeeded"}'
{
  "message" : "No workflows to retry for requested status.",
  "uri" : "/api/v1/workload/b4644fbe-68b9-4113-bc60-024f8ded6871/retry",
  "details" : {
    "workload" : "b4644fbe-68b9-4113-bc60-024f8ded6871",
    "requested-status" : "Succeeded"
  }
}
```

Expected error for unsupported status:
```
$ curl -X POST "http://localhost:3000/api/v1/workload/b4644fbe-68b9-4113-bc60-024f8ded6871/retry" -H 'Authorization: Bearer '$(gcloud auth print-access-token) -H 'Content-Type: application/json' -d '{"status": "Running"}'
{
  "message" : "Retry unsupported for requested status.",
  "uri" : "/api/v1/workload/b4644fbe-68b9-4113-bc60-024f8ded6871/retry",
  "details" : {
    "workload" : "b4644fbe-68b9-4113-bc60-024f8ded6871",
    "supported-statuses" : [ "Failed", "Succeeded", "Aborted" ],
    "requested-status" : "Running"
  }
}
```

And successful retry when retrying the failed workflow:
```
$ curl -X POST "http://localhost:3000/api/v1/workload/b4644fbe-68b9-4113-bc60-024f8ded6871/retry" -H 'Authorization: Bearer '$(gcloud auth print-access-token) -H 'Content-Type: application/json' -d '{"status": "Failed"}'
{
  "started" : "2021-09-08T18:49:42Z",
  "watchers" : [ [ "slack", "C0268EM3LPL" ] ],
  "labels" : [ "hornet:test", "project:wfl-dev/CDC_Viral_Sequencing_okotsopo_20210707" ],
  "creator" : "wfl-prod@broad-gotc-prod.iam.gserviceaccount.com",
  "updated" : "2021-09-08T18:59:30Z",
  "created" : "2021-09-08T18:48:23Z",
  "source" : {
    "snapshots" : [ "67a2bfd7-88e4-4adf-9e41-9b0d04fb32ea" ],
    "name" : "TDR Snapshots"
  },
  "commit" : "6bcfde01542bfef1601eaaf4bb2657cf1520218f",
  "uuid" : "b4644fbe-68b9-4113-bc60-024f8ded6871",
  "executor" : {
    "workspace" : "wfl-dev/CDC_Viral_Sequencing_okotsopo_20210707",
    "methodConfiguration" : "wfl-dev/sarscov2_illumina_full",
    "methodConfigurationVersion" : 53,
    "fromSource" : "importSnapshot",
    "name" : "Terra"
  },
  "version" : "0.8.0",
  "sink" : {
    "workspace" : "wfl-dev/CDC_Viral_Sequencing_okotsopo_20210707",
    "entityType" : "flowcell",
    "fromOutputs" : {
      "submission_xml" : "submission_xml",
      "assembled_ids" : "assembled_ids",
      …
    },
    "identifier" : "run_id",
    "name" : "Terra Workspace"
  }
}
```

Launched local docsite to click through new link and verify formatting:
<img width="798" alt="Screen Shot 2021-09-08 at 3 04 23 PM" src="https://user-images.githubusercontent.com/79769153/132571153-67f3cdf2-f44e-4469-bdfe-6f000777ee98.png">

