### PR TITLE
GH-1454 Update integration tests to reflect updated COVID method config

### DIFF
--- a/api/test/wfl/integration/executor_test.clj
+++ b/api/test/wfl/integration/executor_test.clj
@@ -16,7 +16,7 @@
 (def ^:private testing-workspace (str testing-namespace "/" "CDC_Viral_Sequencing"))
 (def ^:private testing-method-name "sarscov2_illumina_full")
 (def ^:private testing-method-configuration (str testing-namespace "/" testing-method-name))
-(def ^:private testing-method-configuration-version 1)
+(def ^:private testing-method-configuration-version 2)
 
 (let [new-env {"WFL_FIRECLOUD_URL" "https://api.firecloud.org"
                "WFL_RAWLS_URL"     "https://rawls.dsde-prod.broadinstitute.org"}]

--- a/api/test/wfl/integration/modules/covid_test.clj
+++ b/api/test/wfl/integration/modules/covid_test.clj
@@ -40,7 +40,7 @@
 (def ^:private testing-workspace (str testing-namespace "/" "CDC_Viral_Sequencing"))
 (def ^:private testing-method-name "sarscov2_illumina_full")
 (def ^:private testing-method-configuration (str testing-namespace "/" testing-method-name))
-(def ^:private testing-method-configuration-version 1)
+(def ^:private testing-method-configuration-version 2)
 (def ^:private testing-table-name "flowcells")
 (def ^:private testing-column-name "run_date")
 


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1454

Description of the cause in the ticket.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Bump method configuration 1->2 in automated tests where [this](https://app.terra.bio/#workspaces/wfl-dev/CDC_Viral_Sequencing/workflows/wfl-dev/sarscov2_illumina_full) method configuration is accessed

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

I reran the automated tests locally, those which failed now succeed.
