### PR TITLE
GH-1450 Add retry attribute to TerraDataRepoSource type and instances

### DIFF
--- a/database/changelog.xml
+++ b/database/changelog.xml
@@ -43,4 +43,5 @@
     <include file="changesets/20210709_TerraDataRepoSink.xml"                         relativeToChangelogFile="true"/>
     <include file="changesets/20210720_AddConfigurationTable.xml"                     relativeToChangelogFile="true"/>
     <include file="changesets/20210823_ConvertWatchersArrayToText.xml"                relativeToChangelogFile="true"/>
+    <include file="changesets/20210910_AddRetryToTerraDataRepoSourceDetails.xml"      relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/database/changesets/20210910_AddRetryToTerraDataRepoSourceDetails.xml
+++ b/database/changesets/20210910_AddRetryToTerraDataRepoSourceDetails.xml
@@ -1,0 +1,30 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext
+                        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
+                        http://www.liquibase.org/xml/ns/dbchangelog
+                        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+    <changeSet author="hornet@broadinstitute.org"
+               dbms="postgresql"
+               id="20210910"
+               logicalFilePath="20210910_AddRetryToTerraDataRepoSourceDetails.xml"
+               runInTransaction="false">
+        <comment>
+            Add a `retry` attribute to the `TerraDataRepoSourceDetails` type
+            and all instantiations thereof to support automatic retry of
+            failed snapshot creation jobs.
+            When a snapshot creation job is retried, this column is set to
+            the row id of the new record corresponding to its retry.
+            From this, one can construct a singly linked list
+            tracing the retry history of a set of snapshot creation jobs.
+        </comment>
+        <sql>
+            ALTER TYPE TerraDataRepoSourceDetails
+            ADD ATTRIBUTE retry BIGINT
+            CASCADE;
+        </sql>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1450

In preparation for automatic retries of failed snapshot creation jobs within `TerraDataRepoSource`'s update loop, added a retry column to the `TerraDataRepoSource` type and its instances.

I looked at all existing queries of this source details table (details table peek and queue length).  I found nowhere that needed an additional filter to exclude retried snapshot creation jobs, since we will only be automating retries for failed (and as such, never-to-be-consumed) jobs.

*However*, it might be worth codifying this filter if we think we might ever support API-driven retry of snapshot creation jobs, specifically successful ones.  LMK if you'd like me to make this change.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

Prior to this change, I executed a COVID workload with a `TerraDataRepoSource`.
After making the change and running the Liquibase update, I confirmed in my local Postgres that the existing source details table had been updated with a retry column.

```
api $ clojure -M:liquibase
```

<img width="1740" alt="Screen Shot 2021-09-10 at 3 48 43 PM" src="https://user-images.githubusercontent.com/79769153/132917351-bc1c2ed3-e5bd-4ea6-9550-cfa20b538f1b.png">
