### PR TITLE
GH-1373: Keep non-null inputs and options from "Failed" workflows.

### DIFF
--- a/docs/md/usage-retry.md
+++ b/docs/md/usage-retry.md
@@ -130,11 +130,9 @@ getWorkflows() {
 removeSucceeded() {
     # [[Workflow]] -> [Workflow]
     jq 'flatten
-        | group_by( {inputs: .inputs, options: .options} )
-        | map( select( all(.status=="Succeeded") )
-             | .[0]
-             | {inputs: .inputs, options: .options} )
-        | del(.[][] | nulls)
+        | map ( select ( .status=="Failed" )
+                | {inputs: .inputs, options: .options}
+                | del ( .[] | nulls ) )
         ' <<< "$1"
 }
 


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1373

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Fixed `removeSucceeded()` to do the right thing.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- Maybe extract the documented code to a shell script file, replace the `curl` with a `cat`, then run it like this?

`script uuid=1ea3b3a4-e5b3-4911-a52b-11470105a0c3 https://dev-wfl.gotc-dev.broadinstitute.org/`

Verify you see a valid workload request for any `"Failed"` workflows … or something.