### PR TITLE
GH-1444 TerraDataRepoSource should snapshot less frequently

### DIFF
--- a/api/src/wfl/service/slack.clj
+++ b/api/src/wfl/service/slack.clj
@@ -57,7 +57,8 @@
 (def notifier (agent (PersistentQueue/EMPTY)))
 (add-watch notifier :watcher
            (fn [_key _ref _old-state new-state]
-             (log/debug (format "the current notification queue is: %s" (seq new-state)))))
+             (when (seq new-state)
+               (log/debug (format "the current notification queue is: %s" (seq new-state))))))
 
 (defn add-notification
   "Add notification defined by a map of

--- a/api/src/wfl/source.clj
+++ b/api/src/wfl/source.clj
@@ -310,9 +310,8 @@
   insert resulting job creation ids into database and update the
   timestamp for next time."
   [{:keys [stopped] :as source}]
-  (let [now          (utc-now)
-        should-poll? (tdr-source-should-poll? source now)]
-    (when (and (not stopped) should-poll?)
+  (let [now (utc-now)]
+    (when (and (not stopped) (tdr-source-should-poll? source now))
       (find-and-snapshot-new-rows source now)))
   (update-pending-snapshot-jobs source)
   ;; load and return the source table

--- a/api/src/wfl/source.clj
+++ b/api/src/wfl/source.clj
@@ -158,7 +158,7 @@
   [{:keys [dataset details table column] :as source}
    [begin end                            :as _interval]]
   (log/info (format "%s Looking for rows in %s.%s between [%s, %s]..."
-                     (log-prefix source) (:name dataset) table begin end))
+                    (log-prefix source) (:name dataset) table begin end))
   (let [wfl   (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
                 (postgres/get-table tx details))
         old   (when (seq wfl) (reduce combine-tdr-source-details wfl))

--- a/api/src/wfl/source.clj
+++ b/api/src/wfl/source.clj
@@ -293,7 +293,6 @@
 ;; - locking the dataset / running into dataset locks
 (def ^:private tdr-source-polling-interval-minutes 20)
 
-;; TODO: add unit tests
 (defn ^:private tdr-source-should-poll?
   "Return true if it's been at least `tdr-source-polling-interval-minutes`
    since `last_checked` -- when we last checked for new rows in the TDR."

--- a/api/src/wfl/util.clj
+++ b/api/src/wfl/util.clj
@@ -168,22 +168,6 @@
   [f m]
   (zipmap (keys m) (map f (vals m))))
 
-(defn minutes-between
-  "The number of minutes from START to END."
-  [start end]
-  (.between
-   ChronoUnit/SECONDS
-   (OffsetDateTime/parse start)
-   (OffsetDateTime/parse end)))
-
-(defn seconds-between
-  "The number of seconds from START to END."
-  [start end]
-  (.between
-   ChronoUnit/SECONDS
-   (OffsetDateTime/parse start)
-   (OffsetDateTime/parse end)))
-
 (defn summarize
   "Summarize COMMANDS in a string vector."
   [commands]

--- a/api/src/wfl/util.clj
+++ b/api/src/wfl/util.clj
@@ -12,7 +12,6 @@
            [java.nio.file Files]
            [java.nio.file.attribute FileAttribute]
            [java.time OffsetDateTime ZoneId]
-           [java.time.temporal ChronoUnit]
            [java.util ArrayList Collections Random UUID]
            [java.util.concurrent TimeUnit TimeoutException]
            [javax.mail.internet InternetAddress]

--- a/api/test/wfl/integration/source_test.clj
+++ b/api/test/wfl/integration/source_test.clj
@@ -210,8 +210,7 @@
                                                      {:called-with args})))]
     (with-redefs-fn
       {#'source/tdr-source-should-poll?    (constantly false)
-       #'source/find-and-snapshot-new-rows throw-if-called
-       #'source/check-tdr-job              mock-check-tdr-job}
+       #'source/find-and-snapshot-new-rows throw-if-called}
       (fn []
         (source/update-source!
          (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]

--- a/api/test/wfl/integration/source_test.clj
+++ b/api/test/wfl/integration/source_test.clj
@@ -216,7 +216,7 @@
          (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
            (source/start-source! tx source)
            (reload-source tx source)))
-        (is (== 0 (stage/queue-length source)) "No snapshots should be enqueued")
+        (is (zero? (stage/queue-length source)) "No snapshots should be enqueued")
         (let [stopped-source (source/update-source!
                               (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
                                 (source/stop-source! tx source)

--- a/api/test/wfl/unit/source_test.clj
+++ b/api/test/wfl/unit/source_test.clj
@@ -6,8 +6,8 @@
            [java.time.temporal ChronoUnit]))
 
 (deftest test-tdr-source-should-poll?
-  (let [now              (utc-now)
-        source           {:last_checked (Timestamp/from (.toInstant now))}]
+  (let [now    (utc-now)
+        source {:last_checked (Timestamp/from (.toInstant now))}]
     (letfn [(end-of-interval [min-from-interval]
               (->> #'source/tdr-source-polling-interval-minutes
                    var-get

--- a/api/test/wfl/unit/source_test.clj
+++ b/api/test/wfl/unit/source_test.clj
@@ -1,0 +1,18 @@
+(ns wfl.unit.source-test
+  (:require [clojure.test :refer [deftest is]]
+            [wfl.source   :as source]
+            [wfl.util     :refer [utc-now]])
+  (:import [java.sql Timestamp]
+           [java.time.temporal ChronoUnit]))
+
+(deftest test-tdr-source-should-poll?
+  (let [now              (utc-now)
+        source           {:last_checked (Timestamp/from (.toInstant now))}]
+    (letfn [(end-of-interval [min-from-interval]
+              (->> #'source/tdr-source-polling-interval-minutes
+                   var-get
+                   (+ min-from-interval)
+                   (.addTo ChronoUnit/MINUTES now)))]
+      (is (false? (#'source/tdr-source-should-poll? source (end-of-interval -1))))
+      (is (true? (#'source/tdr-source-should-poll? source (end-of-interval 0))))
+      (is (true? (#'source/tdr-source-should-poll? source (end-of-interval 1)))))))

--- a/docs/md/source.md
+++ b/docs/md/source.md
@@ -22,6 +22,14 @@ from a single table.
 When you `start` the workload, the `Terra DataRepo` source will start looking
 for new/updated rows from that instant.
 
+!!! note
+    `Terra DataRepo` source only polls for new rows every 20 minutes
+    to reduce the chances of dataset lock collision and creating
+    many low-cardinality snapshots.
+
+    This is a longer cadence than the parent workload update loop,
+    which runs every 20 seconds.
+
 When you `stop` the workload, the `Terra DataRepo` source will stop looking
 for new/updated rows from that instant. All pending snapshots may continue
 to be processed by a later workload stage.


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1444

Workloads are universally updated every 20 seconds at present, but polling the TDR that frequently for rows to snapshot can lead to problems, as we've found now that the COVID workload has been running in real life for a week:

- More likely that we create many single-row / low-cardinality snapshots, which then spawn multiple submissions.  Harder for stakeholders to keep track (not to mention, smells funny).
- A snapshot creation job carries with it an exclusive lock on the entire dataset.  More snapshotting = more locks = more possibilities of collision (WFL vs. WFL or WFL vs. externally-managed ingests).

Feedback from COVID and eMerge stakeholders has been to suggest polling every 20 minutes for new rows instead of every 20 seconds, or even longer.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Now only poll TDR for new rows if the workload has not been stopped *and* it's been at least 20 minutes since the last check.
- Following engineering discussion, we now update `last_checked` any time we poll TDR, even if it did not find new rows.
- Fixed a missed reference to old log module.
- Added unit and integration testing

### Manual Testing

With the following local changes, a local WFL and local Postgres:
- Additional debug logging
- Overwrote 20 minute TDR polling interval to 1 minute (still less frequent than 20 second workload update loop)
- Debug logging enabled via `curl -X POST http://localhost:3000/api/v1/logging_level?level=DEBUG`
I executed a COVID workload with TDR polling.

I observed in WFL logs that in the update loop runs when it hadn't yet been 1 minute since our last TDR poll, we did not poll.  And did poll once we exceeded this interval, as well as at that time update `last_checked` even though no new rows were found.

```
{"severity":"DEBUG","logging.googleapis.com/sourceLocation":{"file":"wfl/source.clj","line":304},"timestamp":"2021-09-24T19:41:46.652550Z","message":"last_checked 2021-09-24T19:41:04.729397Z vs. now 2021-09-24T19:41:46.652492Z"}
{"severity":"DEBUG","logging.googleapis.com/sourceLocation":{"file":"wfl/source.clj","line":316},"timestamp":"2021-09-24T19:41:46.652662Z","message":"NO POLL YET... :("}
{"severity":"DEBUG","logging.googleapis.com/sourceLocation":{"file":"wfl/source.clj","line":282},"timestamp":"2021-09-24T19:41:46.652777Z","message":"[TerraDataRepoSource id=2] Looking for running snapshot jobs..."}
…
{"severity":"DEBUG","logging.googleapis.com/sourceLocation":{"file":"wfl/source.clj","line":304},"timestamp":"2021-09-24T19:42:06.720508Z","message":"last_checked 2021-09-24T19:41:04.729397Z vs. now 2021-09-24T19:42:06.720465Z"}
{"severity":"DEBUG","logging.googleapis.com/sourceLocation":{"file":"wfl/source.clj","line":265},"timestamp":"2021-09-24T19:42:06.720688Z","message":"YEP WE SHOULD POLL :)"}
{"severity":"DEBUG","logging.googleapis.com/sourceLocation":{"file":"wfl/source.clj","line":160},"timestamp":"2021-09-24T19:42:06.721083Z","message":"[TerraDataRepoSource id=2] Looking for rows in CDC_COVID19_Surveillance_v1.flowcells between [2021-09-24T17:42:06, 2021-09-24T19:42:06]..."}
…
<no new rows found>
…
{"severity":"DEBUG","logging.googleapis.com/sourceLocation":{"file":"wfl/source.clj","line":304},"timestamp":"2021-09-24T19:42:27.526339Z","message":"last_checked 2021-09-24T19:42:06.720465Z vs. now 2021-09-24T19:42:27.526291Z"}
{"severity":"DEBUG","logging.googleapis.com/sourceLocation":{"file":"wfl/source.clj","line":316},"timestamp":"2021-09-24T19:42:27.526438Z","message":"NO POLL YET... :("}
{"severity":"DEBUG","logging.googleapis.com/sourceLocation":{"file":"wfl/source.clj","line":282},"timestamp":"2021-09-24T19:42:27.526547Z","message":"[TerraDataRepoSource id=2] Looking for running snapshot jobs..."}
```

I separately observed in Postgres that `terradatareposource.last_checked` was updated every minute upon a TDR polling attempt.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- See above manual testing, but I'd like feedback on whether the automated testing gives you confidence that this changeset works as expected.

### TODO

- Future work to allow this to be set at the workload level: https://broadinstitute.atlassian.net/browse/GH-1465