### PR TITLE
GH-1452: Bump AoU Arrays.wdl version to 2.4.1 to drop default genotype_concordance_threshold to 0.95.

### DIFF
--- a/api/src/wfl/module/aou.clj
+++ b/api/src/wfl/module/aou.clj
@@ -33,7 +33,7 @@
 
 (def workflow-wdl
   "The top-level WDL file and its version."
-  {:release "Arrays_v2.3.0"
+  {:release "Arrays_v2.4.1"
    :path    "pipelines/broad/arrays/single_sample/Arrays.wdl"})
 
 (def cromwell-label-map

--- a/api/test/wfl/tools/workloads.clj
+++ b/api/test/wfl/tools/workloads.clj
@@ -93,7 +93,7 @@
    :sample_lsid                     "broadinstitute.org:bsp.dev.sample:NOTREAL.03C17319",
    :analysis_version_number         1,
    :call_rate_threshold             0.98,
-   :genotype_concordance_threshold  0.98,
+   :genotype_concordance_threshold  0.95,
    :reported_gender                 "Male",
    :chip_well_barcode               "200598830050_R07C01",
    :green_idat_cloud_path           "gs://broad-gotc-dev-wfl-ptc-test-inputs/arrays/PsychChip_v1-1_15073391_A1/idats/200598830050_R07C01/200598830050_R07C01_Grn.idat",


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1452

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Just did what it says.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
