### PR TITLE
GH-1373 rename removeSucceeded in retry runbook

### DIFF
--- a/docs/md/usage-retry.md
+++ b/docs/md/usage-retry.md
@@ -107,7 +107,7 @@ Ex: `bash retry.sh project=PO-29619`
 ```bash
 # Usage: bash abort.sh QUERY [WFL_URL]
 #   QUERY is either like `project=PO-123` or `uuid=1a2b3c4d`
-#   WFL_URL is the WFL instance to abort workflows from [default: gotc-prod]
+#   WFL_URL is the WFL instance to retry workflows from [default: gotc-prod]
 
 WFL_URL="${2:-https://gotc-prod-wfl.gotc-prod.broadinstitute.org}"
 AUTH_HEADER="Authorization: Bearer $(gcloud auth print-access-token)"
@@ -127,7 +127,7 @@ getWorkflows() {
          | jq
 }
 
-removeSucceeded() {
+failedWorkflowsToSubmit() {
     # [[Workflow]] -> [Workflow]
     jq 'flatten
         | map ( select ( .status=="Failed" )
@@ -161,7 +161,7 @@ main() {
     # Query -> ()
     workloads=$(getWorkloads "${1}")
     workflows=$(mapjq getWorkflows "${workloads}")
-    toSubmit=$(removeSucceeded "${workflows}")
+    toSubmit=$(failedWorkflowsToSubmit "${workflows}")
     makeRetryRequest "${workloads[0]}" "${toSubmit}" > /tmp/retry.json
 
     curl -X POST "${WFL_URL}/api/v1/exec" \


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1373

As the retry runbook no longer removes successful workflows, but keeps the failed ones, renamed the function accordingly. 

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

I spun up a local docsite and followed the instructions in my [QA comment](https://broadinstitute.atlassian.net/browse/GH-1373?focusedCommentId=1262242).
