### PR TITLE
GH-1522 TerraWorkspaceSink: identifier can be a workflow input

### DIFF
--- a/api/test/wfl/unit/logging_test.clj
+++ b/api/test/wfl/unit/logging_test.clj
@@ -1,10 +1,9 @@
 (ns wfl.unit.logging-test
   "Test that logging is functional (since there's several layers of delegation)"
-  (:require
-   [wfl.log :as log]
-   [clojure.data.json :refer [read-str]]
-   [clojure.test :refer [is deftest testing]]
-   [clojure.string :refer [upper-case blank?]])
+  (:require [clojure.test      :refer [is deftest testing]]
+            [clojure.data.json :as json]
+            [clojure.string    :as str]
+            [wfl.log           :as log])
   (:import java.util.regex.Pattern))
 
 (defmulti check-message?
@@ -21,8 +20,8 @@
 (defn logged?
   "Test that the logs worked"
   [result severity test]
-  (let [json (read-str result)]
-    (and (= (get-in json ["severity"]) (-> severity name upper-case))
+  (let [json (json/read-str result)]
+    (and (= (get-in json ["severity"]) (-> severity name str/upper-case))
          (boolean (check-message? test (get-in json ["message"]))))))
 
 ;; Useful information on this file is in docs/logging.md#Testing
@@ -38,5 +37,19 @@
 (deftest severity-level-filtering-test
   (testing "test current logging level correctly ignores lesser levels"
     (with-redefs [log/logging-level (atom :info)]
-      (is (blank? (with-out-str (log/debug "Debug Message"))))
+      (is (str/blank? (with-out-str (log/debug "Debug Message"))))
       (is (logged? (with-out-str (log/info "Info Message")) :info "Info Message")))))
+
+(deftest exception-test
+  (testing "exceptions can be serialized as JSON"
+    (let [x   (ex-info "Oops!" {:why "I did it again."}
+                       (ex-info "I played with your heart."
+                                {:why "Got lost in the game."}
+                                (ex-info "Oh baby, baby."
+                                         {:oops "You think I'm in love."
+                                          :that "I'm sent from above."})))
+          log (json/read-str (with-out-str (log/info x)) :key-fn keyword)]
+      (is (= "INFO"                  (get-in log [:severity])))
+      (is (= "I did it again."       (get-in log [:message :via 0 :data :why])))
+      (is (= "Oh baby, baby."        (get-in log [:message :cause])))
+      (is (= "I'm sent from above."  (get-in log [:message :data :that]))))))

--- a/api/test/wfl/unit/sink_test.clj
+++ b/api/test/wfl/unit/sink_test.clj
@@ -39,3 +39,22 @@
 (deftest test-datarepo-sink-request-coercion
   (let [test! (coercion-tester ::sink/sink)]
     (test! datarepo-sink-request)))
+
+(deftest test-entity-name-from-workspace
+  (let [inputs   {:a "aInput" :b "bInput"}
+        outputs  {:b "bOutput" :c "cOutput"}
+        workflow {:inputs inputs :outputs outputs}]
+    (is (nil? (#'sink/entity-name-from-workflow nil "a"))
+        "When nil workflow, should return nil")
+    (is (nil? (#'sink/entity-name-from-workflow (select-keys workflow [:inputs]) "c"))
+        "When no outputs, should only check inputs")
+    (is (nil? (#'sink/entity-name-from-workflow (select-keys workflow [:outputs]) "a"))
+        "When no inputs, should only check outputs")
+    (is (= "aInput" (#'sink/entity-name-from-workflow workflow "a"))
+        "Key a only present in inputs map")
+    (is (= "bOutput" (#'sink/entity-name-from-workflow workflow "b"))
+        "Key b present in both inputs and outputs maps should pull from outputs map")
+    (is (= "cOutput" (#'sink/entity-name-from-workflow workflow "c"))
+        "Key c only present in outputs map")
+    (is (nil? (#'sink/entity-name-from-workflow workflow "d"))
+        "Key d not found in inputs or outputs maps should return nil")))

--- a/docs/md/dev-process.md
+++ b/docs/md/dev-process.md
@@ -6,16 +6,12 @@ encourage ourselves to follow in most cases.
 ## The Swagger page
 
 WFL ships with a Swagger UI that documents all available endpoints. It's
-available at path `/swagger`.  At present, we cannot hit it directly
-without logging in first because it is bundled with the UI and not the API.
+available at path `<host>/swagger`.
 
-- Log into WFL UI, e.g. https://dev-wfl.gotc-dev.broadinstitute.org/login
-- Navigate to `/swagger` via Swagger API button in top right
+- [Dev WFL Swagger](https://dev-wfl.gotc-dev.broadinstitute.org/swagger)
+- [Prod WFL Swagger](https://gotc-prod-wfl.gotc-prod.broadinstitute.org/swagger)
 
-!!! tip
-    To access the swagger page locally, you'll need to start a development
-    server and access via the UI. See the development tips below for more
-    information.
+For local access, see [accessing Swagger Locally](#accessing-swagger-locally).
 
 ## Development Setup
 
@@ -27,7 +23,7 @@ Get a demonstration from someone familiar with Clojure development before you
 spend too much time trying to figure things out on your own.
 
 Find a local Cursive user for guidance if you like IntelliJ.
-[Rex Wang](mailto:chengche@broadinstitute.org) knows how to use it.
+[Olivia Kotsopoulos](mailto:okotsopo@broadinstitute.org) knows how to use it.
 
 Cursive licences are available
 [here](https://broadinstitute.atlassian.net/wiki/spaces/DSDE/pages/48234557/Software%2BLicenses%2B-%2BCursive).
@@ -54,7 +50,7 @@ There is also a
 [Calva](https://marketplace.visualstudio.com/items?itemName=betterthantomorrow.calva)
 plugin for [Visual Studio Code](https://code.visualstudio.com/).
 
-I hack Clojure in Emacs using
+[Tom Lyons](mailto:tbl@broadinstitute.org) hacks Clojure in Emacs using
 [CIDER](https://cider.readthedocs.io/) and
 [nREPL](https://github.com/clojure/tools.nrepl). CIDER is not
 trivial to set up, but not *especially* difficult if you are
@@ -224,43 +220,18 @@ silently fail or the Swagger page will fail to render. Check the
 `clojure.spec.alpha/def`s in `wfl.api.routes` for typos before tearing your
 hair out.
 
-You can quickly check that the Swagger page renders
-by first starting a local WFL server.
+### accessing Swagger locally
+
+First, start a local WFL server.
 
 ``` shell
 ./ops/server.sh
 ```
 
-Then open this URL in a browser.
-
+To view the rendered Swagger page:
 ``` shell
-open http://localhost:3000/swagger/swagger.json
+open http://localhost:3000/swagger
 ```
-
-You should see a page of valid Swagger JSON
-describing the API.
-
-You need to start the UI server too
-if you want to see the swagger page rendered.
-With the local WFL server running on port 3000 as above,
-start the UI this way.
-
-``` shell
-cd ./ui
-npm run serve
-```
-
-With the UI running,
-open this URL in the browser.
-
-``` shell
-open http://localhost:8080/
-```
-
-Click the `LOGIN WITH GOOGLE` button if necessary,
-Then the `SWAGGER API` button at the upper right.
-You should see an interactive Swagger API page.
-
 
 ### debugging Liquibase locally
 


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1522

The TerraWorkspaceSink requires that an identifier be specified.  Previously, it had to be "the name of a pipeline output that should be used as the name of each newly created entity."

For eMerge arrays and imputation workflows, we've found that the most sensible identifiers are actually pipeline inputs.  In such cases, Lantern had to redundantly thread pipeline inputs through as outputs.  This is a common-enough use case that it was worth fixing WFL-side.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

Where can identifiers come from?
- Old behavior: workflow outputs only.
- New behavior: workflow outputs, but if no match fall back to workflow inputs.

What happens if there's no match for an identifier in a workflow and `entityName = nil`?
- Old behavior: try to sink the workflow outputs but fail with `400 Bad Request` from Rawls/Firecloud.
- New behavior: throw a descriptive exception, do not try to sink the workflow outputs.

I also added new unit tests and supplemented an existing integration test.

### Manual Testing

For an eMerge Imputation workload with a bad `sink.identifier`, here's what's thrown when `sink/update-terra-workspace-sink` runs:

```
{"severity":"ERROR","logging.googleapis.com/sourceLocation":{"file":"wfl/server.clj","line":103},"timestamp":"2021-11-05T16:26:49.619452Z","message":"clojure.lang.ExceptionInfo: Entity name not found: sink.identifer not present in workflow outputs or inputs {:sink {:id 19, :details \"TerraWorkspaceSink_000000231\", :workspace \"emerge_prod/Imputation_test\", :entityType \"Imputation_Outputs_Table\", :fromOutputs {:imputed_multisample_vcf \"imputed_multisample_vcf\", :failed_chunks \"failed_chunks\", :imputed_single_sample_vcfs \"imputed_single_sample_vcfs\", :aggregated_imputation_metrics \"aggregated_imputation_metrics\", :imputed_single_sample_vcf_indices \"imputed_single_sample_vcf_indices\", :n_failed_chunks \"n_failed_chunks\", :chunks_info \"chunks_info\", :imputed_multisample_vcf_index \"imputed_multisample_vcf_index\"}, :identifier \"output_callset_name_bad\", :type \"TerraWorkspaceSink\"}, :workflow {:inputs {:haplotype_database \"gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.haplotype_database.txt\", :AggregateImputationQCMetrics.cpu 1, :FindSitesUniqueToFileTwoOnly.memory_mb 4000, :SetIdsVcfToImpute.cpu 1, :SetIdsVcfToImpute.memory_mb 4000, :Minimac4.memory_mb 4000, :SetIdsVcfToImpute.bcftools_docker \"us.gcr.io/broad-dsde-methods/imputation_bcftools_vcftools_docker:v1.0.0\", :merge_ssvcf_mem_mb 3000, :reference_panel_path \"gs://gcp-public-data--broad-references/hg19/v0/1000G_reference_panel/\", :RemoveAnnotations.disk_size_gb nil, :ref_dict \"gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.dict\", :MergeImputationQCMetrics.rtidyverse_docker \"rocker/tidyverse:4.1.0\", :MergeSingleSampleVcfs.cpu 1, :SplitMultiSampleVcf.bcftools_docker \"us.gcr.io/broad-dsde-methods/imputation_bcftools_vcftools_docker:v1.0.0\", :CountSamples.memory_mb 3000, :OptionalQCSites.cpu 1, :MergeImputationQCMetrics.memory_mb 2000, :MergeSingleSampleVcfs.bcftools_docker \"us.gcr.io/broad-dsde-methods/imputation_bcftools_vcftools_docker:v1.0.0\", :FindSitesUniqueToFileTwoOnly.disk_size_gb nil, :CheckChunks.bcftools_docker \"us.gcr.io/broad-dsde-methods/imputation_bcftools_vcftools_docker:v1.0.0\", :CountSamples.bcftools_docker \"us.gcr.io/broad-dsde-methods/imputation_bcftools_vcftools_docker:v1.0.0\", :optional_qc_max_missing 0.05, :OptionalQCSites.memory_mb 16000, :ExtractIdsVcfToImpute.cpu 1, :StoreChunksInfo.disk_size_gb 10, :multi_sample_vcf_index nil, :CountSamples.disk_size_gb nil, :SeparateMultiallelics.disk_size_gb nil, :single_sample_vcf_indices [\"drs://data.terra.bio/v1_97ef7104-d9d0-4a99-9cbf-0eb0591bcec1_61696bd5-7a01-4d3e-8f84-e6f31bb29581\" \"drs://data.terra.bio/v1_97ef7104-d9d0-4a99-9cbf-0eb0591bcec1_7ffbbbf7-d071-4f55-9601-f10c63e33232\" \"drs://data.terra.bio/v1_97ef7104-d9d0-4a99-9cbf-0eb0591bcec1_2778dfb3-4ac5-4a09-9409-7af0694d7909\" \"drs://data.terra.bio/v1_97ef7104-d9d0-4a99-9cbf-0eb0591bcec1_322f2a28-7b11-45dc-8bfc-20ef88d35d44\"], :MergeImputationQCMetrics.disk_size_gb nil, :ExtractIDs.cpu 1, :ExtractIdsVcfToImpute.memory_mb 4000, :RemoveSymbolicAlleles.cpu 1, :SeparateMultiallelics.cpu 1, :PhaseVariantsEagle.cpu 8, :MergeImputationQCMetrics.cpu 1, :CalculateChromosomeLength.ubuntu_docker \"ubuntu:20.04\", :CheckChunks.cpu 1, :Minimac4.cpu 1, :InterleaveVariants.disk_size_gb nil, :CalculateChromosomeLength.memory_mb 2000, :Minimac4.disk_size_gb nil, :SplitMultiSampleVcf.memory_mb 8000, :multi_sample_vcf nil, :UpdateHeader.memory_mb 8000, :InterleaveVariants.gatk_docker \"us.gcr.io/broad-gatk/gatk:4.1.9.0\", :GenerateChunk.cpu 1, :ExtractIDs.memory_mb 4000, :frac_well_imputed_threshold 0.9, :InterleaveVariants.memory_mb 16000, :GatherVcfs.disk_size_gb nil, :RemoveAnnotations.bcftools_docker \"us.gcr.io/broad-dsde-methods/imputation_bcftools_vcftools_docker:v1.0.0\", :CalculateChromosomeLength.disk_size_gb nil, :SetIdsVcfToImpute.disk_size_gb nil, :RemoveAnnotations.memory_mb 3000, :GenerateChunk.gatk_docker \"us.gcr.io/broad-gatk/gatk:4.1.9.0\", :single_sample_vcfs [\"drs://data.terra.bio/v1_97ef7104-d9d0-4a99-9cbf-0eb0591bcec1_ed719b05-9e28-491b-84ef-975aee7dcdaf\" \"drs://data.terra.bio/v1_97ef7104-d9d0-4a99-9cbf-0eb0591bcec1_77d7659a-79ba-47e7-a1bd-993793c7786f\" \"drs://data.terra.bio/v1_97ef7104-d9d0-4a99-9cbf-0eb0591bcec1_bf2df1d4-e33f-44cf-b1b6-fa90ffe076bd\" \"drs://data.terra.bio/v1_97ef7104-d9d0-4a99-9cbf-0eb0591bcec1_38578750-b73a-4618-aa6b-38e6e255620d\"], :contigs [\"21\" \"22\"], :bcf_suffix \".bcf\", :CalculateChromosomeLength.cpu 1, :CheckChunks.memory_mb 4000, :FindSitesUniqueToFileTwoOnly.cpu 1, :split_output_to_single_sample false, :RemoveAnnotations.cpu 1, :UpdateHeader.disk_size_gb nil, :CountVariantsInChunks.disk_size_gb 100, :FindSitesUniqueToFileTwoOnly.ubuntu_docker \"ubuntu:20.04\", :ExtractIDs.disk_size_gb nil, :SelectVariantsByIds.cpu 1, :PhaseVariantsEagle.eagle_docker \"us.gcr.io/broad-dsde-methods/imputation_eagle_docker:v1.0.0\", :CountVariantsInChunks.cpu 1, :MergeSingleSampleVcfs.disk_size_gb nil, :SetIDs.disk_size_gb nil, :CountVariantsInChunks.memory_mb 4000, :UpdateHeader.cpu 1, :perform_extra_qc_steps false, :InterleaveVariants.cpu 1, :CheckChunks.disk_size_gb nil, :StoreChunksInfo.cpu 1, :vcf_index_suffix \".vcf.gz.tbi\", :output_callset_name \"emerge_test_WFL_identifier_as_input_variable\", :chunkLength 25000000, :ExtractIdsVcfToImpute.bcftools_docker \"us.gcr.io/broad-dsde-methods/imputation_bcftools_vcftools_docker:v1.0.0\", :GenerateChunk.memory_mb 8000, :SetIDs.bcftools_docker \"us.gcr.io/broad-dsde-methods/imputation_bcftools_vcftools_docker:v1.0.0\", :SelectVariantsByIds.disk_size_gb nil, :AggregateImputationQCMetrics.rtidyverse_docker \"rocker/tidyverse:4.1.0\", :UpdateHeader.gatk_docker \"us.gcr.io/broad-gatk/gatk:4.1.9.0\", :RemoveSymbolicAlleles.disk_size_gb nil, :OptionalQCSites.bcftools_vcftools_docker \"us.gcr.io/broad-dsde-methods/imputation_bcftools_vcftools_docker:v1.0.0\", :bcf_index_suffix \".bcf.csi\", :RemoveSymbolicAlleles.gatk_docker \"us.gcr.io/broad-gatk/gatk:4.1.9.0\", :chunks_fail_threshold 1, :RemoveSymbolicAlleles.memory_mb 4000, :OptionalQCSites.disk_size_gb nil, :SetIDs.memory_mb 4000, :AggregateImputationQCMetrics.disk_size_gb nil, :vcf_suffix \".vcf.gz\", :GatherVcfs.memory_mb 16000, :SeparateMultiallelics.bcftools_docker \"us.gcr.io/broad-dsde-methods/imputation_bcftools_vcftools_docker:v1.0.0\", :SetIDs.cpu 1, :CountVariantsInChunks.gatk_docker \"us.gcr.io/broad-gatk/gatk:4.1.9.0\", :genetic_maps_eagle \"gs://broad-gotc-test-storage/imputation/eagle_genetic_map/genetic_map_hg19_withX.txt.gz\", :chunkOverlaps 5000000, :ExtractIdsVcfToImpute.disk_size_gb nil, :m3vcf_suffix \".cleaned.m3vcf.gz\", :StoreChunksInfo.memory_mb 2000, :GatherVcfs.cpu 1, :SelectVariantsByIds.gatk_docker \"us.gcr.io/broad-gatk/gatk:4.1.9.0\", :SeparateMultiallelics.memory_mb 4000, :ExtractIDs.bcftools_docker \"us.gcr.io/broad-dsde-methods/imputation_bcftools_vcftools_docker:v1.0.0\", :SplitMultiSampleVcf.cpu 1, :SplitMultiSampleVcf.disk_size_gb nil, :PhaseVariantsEagle.disk_size_gb nil, :AggregateImputationQCMetrics.memory_mb 2000, :StoreChunksInfo.rtidyverse_docker \"rocker/tidyverse:4.1.0\", :SelectVariantsByIds.memory_mb 16000, :GatherVcfs.gatk_docker \"us.gcr.io/broad-gatk/gatk:4.1.9.0\", :Minimac4.minimac4_docker \"us.gcr.io/broad-dsde-methods/imputation-minimac-docker:v1.0.0\", :CountSamples.cpu 1, :GenerateChunk.disk_size_gb nil, :optional_qc_hwe 1.0E-6, :PhaseVariantsEagle.memory_mb 32000}, :uuid \"1a6a697b-f877-47a4-80fc-674aa29eee0d\", :status \"Succeeded\", :outputs {:imputed_single_sample_vcfs nil, :failed_chunks \"gs://fc-5ac2145c-7c19-4be4-bfb4-b41850e7f4e1/14bffc69-6ce7-4615-b318-7ef1c457c894/Imputation/1a6a697b-f877-47a4-80fc-674aa29eee0d/call-StoreChunksInfo/emerge_test_WFL_identifier_as_input_variable_failed_chunks.tsv\", :imputed_single_sample_vcf_indices nil, :imputed_multisample_vcf \"gs://fc-5ac2145c-7c19-4be4-bfb4-b41850e7f4e1/14bffc69-6ce7-4615-b318-7ef1c457c894/Imputation/1a6a697b-f877-47a4-80fc-674aa29eee0d/call-InterleaveVariants/emerge_test_WFL_identifier_as_input_variable.vcf.gz\", :aggregated_imputation_metrics \"gs://fc-5ac2145c-7c19-4be4-bfb4-b41850e7f4e1/14bffc69-6ce7-4615-b318-7ef1c457c894/Imputation/1a6a697b-f877-47a4-80fc-674aa29eee0d/call-MergeImputationQCMetrics/emerge_test_WFL_identifier_as_input_variable_aggregated_imputation_metrics.tsv\", :n_failed_chunks \"gs://fc-5ac2145c-7c19-4be4-bfb4-b41850e7f4e1/14bffc69-6ce7-4615-b318-7ef1c457c894/Imputation/1a6a697b-f877-47a4-80fc-674aa29eee0d/call-StoreChunksInfo/n_failed_chunks.txt\", :chunks_info \"gs://fc-5ac2145c-7c19-4be4-bfb4-b41850e7f4e1/14bffc69-6ce7-4615-b318-7ef1c457c894/Imputation/1a6a697b-f877-47a4-80fc-674aa29eee0d/call-StoreChunksInfo/emerge_test_WFL_identifier_as_input_variable_chunk_info.tsv\", :imputed_multisample_vcf_index \"gs://fc-5ac2145c-7c19-4be4-bfb4-b41850e7f4e1/14bffc69-6ce7-4615-b318-7ef1c457c894/Imputation/1a6a697b-f877-47a4-80fc-674aa29eee0d/call-InterleaveVariants/emerge_test_WFL_identifier_as_input_variable.vcf.gz.tbi\"}, :updated #inst \"2021-11-05T16:06:15.503727000-00:00\"}}"}
```

When setting `sink.identifier` to a workflow input not present in the workflow's outputs:
```
{"severity":"DEBUG","logging.googleapis.com/sourceLocation":{"file":"wfl/sink.clj","line":189},"timestamp":"2021-11-05T16:33:15.912004Z","message":"coercing workflow 1a6a697b-f877-47a4-80fc-674aa29eee0d outputs to Imputation_Outputs_Table"}
{"severity":"DEBUG","logging.googleapis.com/sourceLocation":{"file":"wfl/sink.clj","line":198},"timestamp":"2021-11-05T16:33:16.700403Z","message":"entity emerge_test_WFL_identifier_as_input_variable exists - deleting previous entity."}
{"severity":"DEBUG","logging.googleapis.com/sourceLocation":{"file":"wfl/sink.clj","line":200},"timestamp":"2021-11-05T16:33:17.188490Z","message":"upserting workflow 1a6a697b-f877-47a4-80fc-674aa29eee0d outputs as emerge_test_WFL_identifier_as_input_variable"}
{"severity":"DEBUG","logging.googleapis.com/sourceLocation":{"file":"wfl/executor.clj","line":329},"timestamp":"2021-11-05T16:33:17.856191Z","message":"jdbc/query: okotsopo@jdbc:postgresql:wfl#734 SELECT * FROM TerraExecutor_000000231\n               WHERE consumed IS NULL\n               AND   status = 'Succeeded'\n               ORDER BY id ASC\n               LIMIT 1"}
{"severity":"INFO","logging.googleapis.com/sourceLocation":{"file":"wfl/executor.clj","line":371},"timestamp":"2021-11-05T16:33:17.863614Z","message":"jdbc/update! okotsopo@jdbc:postgresql:wfl#734 TerraExecutor_000000231 {:consumed #object[java.time.OffsetDateTime 0x20cde482 \"2021-11-05T16:33:17.863349Z\"], :updated #object[java.time.OffsetDateTime 0x20cde482 \"2021-11-05T16:33:17.863349Z\"]} [\"id = ?\" 2]"}
{"severity":"INFO","logging.googleapis.com/sourceLocation":{"file":"wfl/sink.clj","line":203},"timestamp":"2021-11-05T16:33:17.866055Z","message":"sunk workflow 1a6a697b-f877-47a4-80fc-674aa29eee0d to emerge_prod/Imputation_test as emerge_test_WFL_identifier_as_input_variable"}
{"severity":"INFO","logging.googleapis.com/sourceLocation":{"file":"wfl/sink.clj","line":205},"timestamp":"2021-11-05T16:33:17.871406Z","message":"jdbc/insert okotsopo@jdbc:postgresql:wfl#734 TerraWorkspaceSink_000000231 {:entity \"emerge_test_WFL_identifier_as_input_variable\", :updated #object[java.time.OffsetDateTime 0x6c0a8eaa \"2021-11-05T16:33:17.871183Z\"], :workflow \"1a6a697b-f877-47a4-80fc-674aa29eee0d\"}"}
{"severity":"INFO","logging.googleapis.com/sourceLocation":{"file":"wfl/module/covid.clj","line":49},"timestamp":"2021-11-05T16:33:17.880820Z","message":"jdbc/update! okotsopo@jdbc:postgresql:wfl#734 :workload {:updated #object[java.time.OffsetDateTime 0x3c279037 \"2021-11-05T16:33:10.125489Z\"]} [\"id = ?\" 231]"}
```

The workflow in question:
https://job-manager.dsde-prod.broadinstitute.org/jobs/1a6a697b-f877-47a4-80fc-674aa29eee0d

And its written outputs:
<img width="1788" alt="Screen Shot 2021-11-05 at 3 13 45 PM" src="https://user-images.githubusercontent.com/79769153/140565982-282ed5ce-9205-403a-a459-c34f88c8a1df.png">

### TODO

- GitHub Pages documentation changes