### PR TITLE
Update test inputs buckets

### DIFF
--- a/api/src/wfl/sink.clj
+++ b/api/src/wfl/sink.clj
@@ -433,6 +433,7 @@
   [{:keys [details] :as _sink}]
   (let [query "SELECT COUNT(*) FROM %s
                WHERE status <> 'failed' AND consumed IS NULL"]
+    (log/info "Checking stage/done?")
     (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
       (postgres/throw-unless-table-exists tx details)
       (-> (jdbc/query tx (format query details)) first :count zero?))))

--- a/api/src/wfl/sink.clj
+++ b/api/src/wfl/sink.clj
@@ -433,7 +433,6 @@
   [{:keys [details] :as _sink}]
   (let [query "SELECT COUNT(*) FROM %s
                WHERE status <> 'failed' AND consumed IS NULL"]
-    (log/info "Checking stage/done?")
     (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
       (postgres/throw-unless-table-exists tx details)
       (-> (jdbc/query tx (format query details)) first :count zero?))))

--- a/api/test/resources/workflows/illumina_genotyping_array/inputs.json
+++ b/api/test/resources/workflows/illumina_genotyping_array/inputs.json
@@ -1,8 +1,8 @@
 {
   "analysis_version_number": 1,
   "chip_well_barcode": "7991775143_R01C01",
-  "green_idat_cloud_path": "gs://broad-gotc-dev-wfl-datarepo-outputs/test-inputs/illumina-genotyping-array_inputs_7991775143_R01C01_Grn.idat",
-  "red_idat_cloud_path": "gs://broad-gotc-dev-wfl-datarepo-outputs/test-inputs/illumina-genotyping-array_inputs_7991775143_R01C01_Red.idat",
+  "green_idat_cloud_path": "gs://broad-gotc-dev-wfl-ptc-test-inputs/illumina-genotyping-array/inputs/7991775143_R01C01_Grn.idat",
+  "red_idat_cloud_path": "gs://broad-gotc-dev-wfl-ptc-test-inputs/illumina-genotyping-array/inputs/7991775143_R01C01_Red.idat",
   "sample_alias": "NA12878",
   "reported_gender": "Female"
 }

--- a/api/test/wfl/integration/datarepo_test.clj
+++ b/api/test/wfl/integration/datarepo_test.clj
@@ -48,7 +48,7 @@
 
 (def ^:private outputs
   {:outbool   true
-   :outfile   "gs://broad-gotc-dev-wfl-datarepo-outputs/test-inputs/external-reprocessing_exome_develop_not-a-real.unmapped.bam"
+   :outfile   "gs://broad-gotc-dev-wfl-ptc-test-inputs/external-reprocessing/exome/develop/not-a-real.unmapped.bam"
    :outfloat  pi
    :outint    27
    :outstring "Hello, World!"})

--- a/api/test/wfl/integration/sinks/datarepo_sink_test.clj
+++ b/api/test/wfl/integration/sinks/datarepo_sink_test.clj
@@ -133,15 +133,15 @@
   "Update sink until there is a truthy result or the max number of attempts is reached."
   [executor sink seconds max-attempts]
   (letfn [(update-and-check []
-                            (sink/update-sink! executor sink)
-                            (stage/done? sink))]
+            (sink/update-sink! executor sink)
+            (stage/done? sink))]
     (loop [attempt 1]
-     (if-let [result (update-and-check)]
-       result
-       (if (<= max-attempts attempt)
-         false
-         (do (.sleep TimeUnit/SECONDS seconds)
-             (recur (inc attempt))))))))
+      (if-let [result (update-and-check)]
+        result
+        (if (<= max-attempts attempt)
+          false
+          (do (.sleep TimeUnit/SECONDS seconds)
+              (recur (inc attempt))))))))
 
 (deftest test-update-datarepo-sink
   (let [description      (resources/read-resource "primitive.edn")


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->
In the TDR Sink PR, there were a couple of changes to which buckets some of the test inputs come from. These changes were not correct, as the bucket that was being used has a 14 day lifecycle. This PR reverts those bucket changes.

Related PR: https://github.com/broadinstitute/gotc-deploy/pull/309
Related Ticket: https://broadinstitute.atlassian.net/browse/GH-1475

In making these changes, it was found that there was an integration test that was giving a false negative result. The test was checking that a UserException was thrown when there would not be because the ingest succeeds. This PR contains the rework of the test to correctly check for UserException on an actual failing ingest.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Restore the buckets used to ingest inputs into TDR Sink test datasets
- Rework `update-datarepo-sink` integration test

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
