### PR TITLE
GH-1516 Documentation updates - TerraExecutor retry

### DIFF
--- a/docs/md/executor.md
+++ b/docs/md/executor.md
@@ -77,13 +77,25 @@ Prerequisites:
   workload creation.
 
 #### `methodConfigurationVersion`
-The expected version of `methodConfiguration`, stored as an integer
-in Firecloud.
+The expected version of `methodConfiguration`, stored as an integer in
+[Firecloud](https://firecloud-orchestration.dsde-prod.broadinstitute.org/#/Method%20Configurations/getWorkspaceMethodConfig).
+
+Example fetch of a method configuration's version from the appropriate
+Firecloud instance (prod):
+
+```shell
+curl -X 'GET' \
+  'https://firecloud-orchestration.dsde-prod.broadinstitute.org/api/workspaces/emerge_prod/Arrays_test/method_configs/warp-pipelines/Arrays' \
+  -H 'accept: */*' \
+  -H 'Authorization: Bearer '$(gcloud auth print-access-token) \
+  | jq .methodConfigVersion
+7
+```
 
 Prerequisites:
 
-- The `methodConfiguration` version when fetched from Firecloud should match
-  `methodConfigurationVersion`.
+- The `methodConfiguration` version when fetched from Firecloud
+  at workload creation should match `methodConfigurationVersion`.
 
 !!! warning "Implications of Version Mismatch"
     A version mismatch may indicate a possible concurrent modification of the
@@ -127,14 +139,21 @@ An executor is a `Queue` that satisfies the `Executor` protocol below:
      ^Executor   executor     ;; This executor instance
      ]
     "Use database `transaction` to return workflows created by the `executor`.")
-  (executor-workflows-by-status
+  (executor-workflows-by-filters
     ^IPersistentVector
-    [^Connection transaction  ;; JDBC Connection
-     ^Executor   executor     ;; This executor instance
-     ^String     status       ;; workflow status to match
+    [^Connection        transaction  ;; JDBC Connection
+     ^Executor          executor     ;; This executor instance
+     ^IPersistentVector filters      ;; Workflow filters to match
+                                     ;; (ex. status, submission)
     ]
     "Use database `transaction` to return workflows created by the `executor`
-     matching the workflow `status`.")
+     matching the workflow `filters` (ex. status, submission).")
+  (executor-throw-if-invalid-retry-filters
+    ;; Executed for side effects
+    [^IPersistentHashmap workload  ;; Workload for which a retry is requested
+     ^IPersistentVector  filters   ;; Workflow filters
+    ]
+    "Throw if workflow `filters` are invalid for `workload`'s retry request.")
   (executor-retry-workflows!
     ;; Executed for side effects
     [^Executor          executor   ;; This executor instance

--- a/docs/md/modules-covid.md
+++ b/docs/md/modules-covid.md
@@ -11,15 +11,15 @@ which includes a source, executor, and sink.
 
 The `covid` module supports the following API endpoints:
 
-| Verb | Endpoint                            | Description                                                              |
-|------|-------------------------------------|--------------------------------------------------------------------------|
-| GET  | `/api/v1/workload`                  | List all workloads, optionally filtering by uuid or project              |
-| GET  | `/api/v1/workload/{uuid}/workflows` | List all workflows for workload `uuid`, optionally filtering by status   |
-| POST | `/api/v1/workload/{uuid}/retry`     | Retry workflows matching a given status in workload `uuid`               |
-| POST | `/api/v1/create`                    | Create a new workload                                                    |
-| POST | `/api/v1/start`                     | Start a workload                                                         |
-| POST | `/api/v1/stop`                      | Stop a running workload                                                  |
-| POST | `/api/v1/exec`                      | Create and start (execute) a workload                                    |
+| Verb | Endpoint                            | Description                                                           |
+|------|-------------------------------------|-----------------------------------------------------------------------|
+| GET  | `/api/v1/workload`                  | List all workloads, optionally filtering by uuid or project           |
+| GET  | `/api/v1/workload/{uuid}/workflows` | List all workflows for workload `uuid`, filtering by supplied filters |
+| POST | `/api/v1/workload/{uuid}/retry`     | Retry workflows matching given filters in workload `uuid`             |
+| POST | `/api/v1/create`                    | Create a new workload                                                 |
+| POST | `/api/v1/start`                     | Start a workload                                                      |
+| POST | `/api/v1/stop`                      | Stop a running workload                                               |
+| POST | `/api/v1/exec`                      | Create and start (execute) a workload                                 |
 
 The life-cycle of a workload is a multi-stage process:
 
@@ -56,7 +56,7 @@ The life-cycle of a workload is a multi-stage process:
       if maintenance is required on the underlying method.
 
 The caller can also [retry](#retry-workload) workflows in a workload
-matching a given status (ex. "Failed").
+matching a Terra submission ID and optional workflow status (ex. "Failed").
 
 ## API Usage Examples
 
@@ -154,17 +154,18 @@ The response is an array of [workload objects](#workload-response-format).
 
 **GET /api/v1/workload/{uuid}/workflows**
 
-Query WFL for all workflows associated with workload `uuid`.
+Query WFL for all unretried workflows associated with workload `uuid`.
 
 The response is a list of Firecloud-derived
 [workflows](https://firecloud-orchestration.dsde-prod.broadinstitute.org/#/Submissions/workflowMetadata)
-and their [outputs](https://firecloud-orchestration.dsde-prod.broadinstitute.org/#/Submissions/workflowOutputsInSubmission)
+and their
+[outputs](https://firecloud-orchestration.dsde-prod.broadinstitute.org/#/Submissions/workflowOutputsInSubmission)
 when available (when the workflow has succeeded).
 
 === "Request"
 
     ```
-    curl -X GET 'http://localhost:3000/api/v1/workload/e66c86b2-120d-4f7f-9c3a-b9eaadeb1919/workflows' \
+    curl -X GET 'http://localhost:3000/api/v1/workload/8d67a71e-9afd-4fca-bcf6-a7a74984a0e8/workflows' \
          -H 'Authorization: Bearer '$(gcloud auth print-access-token) \
          -H 'Accept: application/json'
     ```
@@ -185,31 +186,35 @@ when available (when the workflow has succeeded).
     } ]
     ```
 
-**GET /api/v1/workload/{uuid}/workflows?status={status}**
+**GET /api/v1/workload/{uuid}/workflows?submission={submission}&status={status}**
 
-Query WFL for all workflows with `status` associated with workload `uuid`.
+Query WFL for all unretried workflows associated with workload `uuid`,
+filtering by any **optional** workflow filters specified as query params:
 
-The response has the same format as when querying without the status restriction.
+- `submission` - Terra submission ID (must be a valid UUID)
+- `status` - Workflow status (must be a valid Cromwell workflow status)
+
+The response has the same format as when querying without filters.
 
 === "Request"
 
     ```
-    curl -X GET 'http://localhost:3000/api/v1/workload/e66c86b2-120d-4f7f-9c3a-b9eaadeb1919/workflows' \
-        -H 'Authorization: Bearer '$(gcloud auth print-access-token) \
-        -H 'Accept: application/json' \
-        -d $'{ "status": "Failed" }'
+    curl -X GET 'http://localhost:3000/api/v1/workload/8d67a71e-9afd-4fca-bcf6-a7a74984a0e8/workflows?submission=14bffc69-6ce7-4615-b318-7ef1c457c894&status=Succeeded' \
+         -H 'Authorization: Bearer '$(gcloud auth print-access-token) \
+         -H 'Accept: application/json'
     ```
 
 ### Retry Workload
 
-**POST /api/v1/workload/{uuid}/retry?status={status}**
+**POST /api/v1/workload/{uuid}/retry**
 
-Resubmit all workflows matching `status` associated with workload `uuid`.
+Resubmit all unretried workflows associated with workload `uuid`
+and request body filters.
 
 Prerequisites:
 
-- The status is [supported](./usage-retry.md#supported-statuses)
-- Workflows must exist in the workload for the specified status
+- The request body filters must be [valid](./usage-retry.md#request-body)
+- Workflows must exist in the workload for the specified filters
 - The workload should be started
 
 With all prerequisite fulfilled, WFL will then...
@@ -229,7 +234,7 @@ Further information found in general
     curl -X POST "http://localhost:3000/api/v1/workload/e66c86b2-120d-4f7f-9c3a-b9eaadeb1919/retry" \
         -H 'Authorization: Bearer '$(gcloud auth print-access-token) \
         -H "Content-Type: application/json" \
-        -d '{ "status": "Aborted" }'
+        -d '{ "submission": "14bffc69-6ce7-4615-b318-7ef1c457c894" }'
     ```
 
 ### Create Workload

--- a/docs/md/modules-covid.md
+++ b/docs/md/modules-covid.md
@@ -189,7 +189,7 @@ when available (when the workflow has succeeded).
 **GET /api/v1/workload/{uuid}/workflows?submission={submission}&status={status}**
 
 Query WFL for all unretried workflows associated with workload `uuid`,
-filtering by any **optional** workflow filters specified as query params:
+filtering by any workflow filters specified as query params:
 
 - `submission` - Terra submission ID (must be a valid UUID)
 - `status` - Workflow status (must be a valid Cromwell workflow status)


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1516

Documenting `/retry` behavior changes stemming from https://github.com/broadinstitute/wfl/pull/525

Namely, Terra submission ID is now a required filter, and workflow status is optional (and decorative).

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

Review is easiest off of a local docsite.  Per `docs/readme.md`:
```
make docs
. derived/.venv/docs/bin/activate && (  cd derived/docs; python3 -m mkdocs serve  )
```

Altered pages:
http://127.0.0.1:8000/executor/
http://127.0.0.1:8000/modules-covid/
http://127.0.0.1:8000/usage-retry/

Please read through and let me know if it makes sense.  I will merge following the v0.10.x release, when the corresponding functionality is live.