### PR TITLE
GH-1521 Pull v0.10.0 changelog into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# Release 0.10.0
+- [GH-1475] Update test inputs buckets ([#538](https://github.com/broadinstitute/wfl/pull/538))
+- [GH-1529] Bump WFL develop version to 0.10.0 ([#537](https://github.com/broadinstitute/wfl/pull/537))
+- [GH-1474] [GH-1475] [GH-1494] TDR Sink Changes ([#520](https://github.com/broadinstitute/wfl/pull/520))
+- [GH-1522] TerraWorkspaceSink: identifier can be a workflow input ([#534](https://github.com/broadinstitute/wfl/pull/534))
+- [GH-1515] WFL-created TDR snapshots include table in name ([#536](https://github.com/broadinstitute/wfl/pull/536))
+- [GH-1463] WFL API retry by status also requires submission id ([#525](https://github.com/broadinstitute/wfl/pull/525))
+- [GH-1473] Update GitHub Pages with new Swagger access ([#516](https://github.com/broadinstitute/wfl/pull/516))
+- [GH-1448] Exceptions fail to be logged as JSON. ([#531](https://github.com/broadinstitute/wfl/pull/531))
+- [GH-1472] Merge main into develop ([#533](https://github.com/broadinstitute/wfl/pull/533))
+- [GH-1517] Add automated test for updating method configurations with mismatched versions ([#528](https://github.com/broadinstitute/wfl/pull/528))
+- [GH-1517] Log instead of throw on TerraExecutor method config version mismatch ([#527](https://github.com/broadinstitute/wfl/pull/527))
+
 # Release 0.9.24
 - Fix WFL deployment. ([#526](https://github.com/broadinstitute/wfl/pull/526))
 
@@ -24,15 +37,10 @@
 - Github actions should build docs on develop. ([#495](https://github.com/broadinstitute/wfl/pull/495))
 - [GH-1418] sourceLocation null fix ([#487](https://github.com/broadinstitute/wfl/pull/487))
 - [GH-1303] Google Cloud Logging Alerts ([#486](https://github.com/broadinstitute/wfl/pull/486))
-- ENG-1394 Update post-retry error maps per QA feedback ([#494](https://github.com/broadinstitute/wfl/pull/494))
-- GH-1328 Migrate to new Rawls Snapshot V2 endpoints ([#493](https://github.com/broadinstitute/wfl/pull/493))
-- [GH-1402] Write Workflow Outputs to the Terra Data Repository ([#474](https://github.com/broadinstitute/wfl/pull/474))
-- Mkdocs updates that improve the doc nav and security holes. ([#492](https://github.com/broadinstitute/wfl/pull/492))
-- Bump path-parse from 1.0.6 to 1.0.7 in /ui ([#491](https://github.com/broadinstitute/wfl/pull/491))
 
 # Release 0.8.2
 * [GH-1454] Update covid and executor integration tests to reflect updated method configuration version ([#504](https://github.com/broadinstitute/wfl/pull/504))
-* [ENG-1394] Update post-retry error maps per QA feedback ([#494](https://github.com/broadinstitute/wfl/pull/494))
+* [GH-1394] Update post-retry error maps per QA feedback ([#494](https://github.com/broadinstitute/wfl/pull/494))
 * [GH-1328] Migrate to new Rawls Snapshot V2 endpoints ([#493](https://github.com/broadinstitute/wfl/pull/493))
 * Mkdocs updates that improve the doc nav and security holes. ([#492](https://github.com/broadinstitute/wfl/pull/492))
 * Bump path-parse from 1.0.6 to 1.0.7 in /ui ([#491](https://github.com/broadinstitute/wfl/pull/491))


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1521

WFL v0.10.0 has been [released](https://github.com/broadinstitute/wfl/pull/541), deployed to dev, and deployed to prod.  Running log is available in [Confluence](https://broadinstitute.atlassian.net/wiki/spaces/~206513899/pages/3020554245/WFL+v0.10.x+release+and+deployment+notes).

My intention here is to pull the changelog alterations to `develop`, as they were only merged into `main`.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Cherry-picked our v0.10.0 release commit to `main`

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

I am iffy on the right course of action when generating a changelog and pulling it in, but it may be a moot point if we change our branching and release structure.

I requested Rich specifically since he finished the previous release, v0.9.24.
