### PR TITLE
[GH-1555] add null check to rename-gather-bulk

### DIFF
--- a/api/src/wfl/sink.clj
+++ b/api/src/wfl/sink.clj
@@ -382,6 +382,7 @@
                    (string?  v) [k (values (keyword v))]
                    (map?     v) [k (rename-gather-bulk workflow-id dataset table values v)]
                    (coll?    v) [k (keep (go! k v))]
+                   (nil?     v) [k nil]
                    :else        (throw (ex-info "Unknown operation"
                                                 {:operation v}))))]
      (into {} (for [[k v] mapping] (go! k v))))))

--- a/api/src/wfl/sink.clj
+++ b/api/src/wfl/sink.clj
@@ -371,11 +371,12 @@
                  (storage/gs-url bucket (str/join "/" [workflow-id (util/basename obj)]))
                  (str target-bucket workflow-id "/" (util/basename obj)))))
            (go! [k v]
-             (cond (fileref? k) (let [val (values (keyword v))]
+             (cond (fileref? k) (if-let [val (values (keyword v))]
                                   [k {:description (util/basename val)
                                       :mimeType   (mime-type/ext-mime-type val)
                                       :sourcePath val
-                                      :targetPath (get-target val)}])
+                                      :targetPath (get-target val)}]
+                                  [k nil])
                    (literal? v) [k (subs v 1 (count v))]
                    (boolean? v) [k (values (keyword v))]
                    (string?  v) [k (values (keyword v))]

--- a/api/test/wfl/unit/sink_test.clj
+++ b/api/test/wfl/unit/sink_test.clj
@@ -25,11 +25,13 @@
   (let [inputs (resources/read-resource "sarscov2_illumina_full/inputs.edn")
         dataset (resources/read-resource "sarscov2-illumina-full-inputs.json")
         result (sink/rename-gather-bulk (UUID/randomUUID) dataset "flowcell" inputs {:flowcell_tgz "flowcell_tgz"
-                                                                                     :flowcell_id "flowcell_id"})]
+                                                                                     :flowcell_id "flowcell_id"
+                                                                                     :sample_rename_map "sample_rename_map"})]
     (is (= (:flowcell_id inputs)
            (:flowcell_id result)))
     (is (= (:flowcell_tgz inputs)
-           (-> result :flowcell_tgz :sourcePath)))))
+           (-> result :flowcell_tgz :sourcePath)))
+    (is (= nil (:sample_rename_map result)))))
 
 (def ^:private workspace-sink-request
   {:name        @#'sink/terra-workspace-sink-name

--- a/api/test/wfl/unit/sink_test.clj
+++ b/api/test/wfl/unit/sink_test.clj
@@ -31,7 +31,7 @@
            (:flowcell_id result)))
     (is (= (:flowcell_tgz inputs)
            (-> result :flowcell_tgz :sourcePath)))
-    (is (= nil (:sample_rename_map result)))))
+    (is (nil? (:sample_rename_map result)))))
 
 (def ^:private workspace-sink-request
   {:name        @#'sink/terra-workspace-sink-name


### PR DESCRIPTION
### Purpose
During eMerge testing, an error occurred. This error was as a result of there being a null output in a fileref field. The null output was not specifically being handled when trying to create the request for the TDR sink and thus, an error was born.

https://broadinstitute.atlassian.net/browse/GH-1555

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Added null check to `rename-gather-bulk`
- Added test case from null output

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- Run unit test `test-rename-gather-bulk`
