### PR TITLE
GH-1560 TerraExecutor tries to set root entity table on submission

### DIFF
--- a/api/src/wfl/executor.clj
+++ b/api/src/wfl/executor.clj
@@ -9,6 +9,7 @@
             [wfl.log               :as log]
             [wfl.module.all        :as all]
             [wfl.service.cromwell  :as cromwell]
+            [wfl.service.datarepo  :as datarepo]
             [wfl.service.dockstore :as dockstore]
             [wfl.service.firecloud :as firecloud]
             [wfl.service.postgres  :as postgres]
@@ -171,9 +172,27 @@
                     {:executor executor
                      :object   object}))))
 
+(def ^:private table-from-snapshot-reference-error-message
+  (str/join \space
+            ["Will not set method configuration root entity table:"
+             "expected exactly one table in snapshot."]))
+
+(defn ^:private table-from-snapshot-reference
+  "Return singular table in snapshot from `reference`, or log error."
+  [executor reference]
+  (let [snapshot-id               (get-in reference [:attributes :snapshot])
+        snapshot                  (datarepo/snapshot snapshot-id)
+        [table & rest :as tables] (map :name (:tables snapshot))]
+    (if (and table (empty? rest))
+      table
+      (log/error {:cause     table-from-snapshot-reference-error-message
+                  :executor  executor
+                  :reference reference
+                  :tables    tables}))))
+
 (defn ^:private update-method-configuration!
-  "Update `methodConfiguration` in `workspace` with snapshot reference `name`
-  as :dataReferenceName via Firecloud.
+  "Update `methodConfiguration` in `workspace` with snapshot `reference` name
+  and table as its root entity via Firecloud.
   Update executor table record ID with incremented `methodConfigurationVersion`."
   [{:keys [id
            workspace
@@ -184,13 +203,16 @@
         current (firecloud/method-configuration workspace methodConfiguration)
         _       (error-on-method-config-version-mismatch
                  current methodConfigurationVersion)
-        inc'd   (inc (:methodConfigVersion current))]
-    (-> "%s Updating %s in %s with {:dataReferenceName %s :methodConfigVersion %s}"
-        (format (log-prefix executor) methodConfiguration workspace name inc'd)
-        log/debug)
-    (firecloud/update-method-configuration
-     workspace methodConfiguration
-     (assoc current :dataReferenceName name :methodConfigVersion inc'd))
+        inc'd   (inc (:methodConfigVersion current))
+        newMc   (merge
+                 current
+                 {:dataReferenceName name :methodConfigVersion inc'd}
+                 (when-let [table (table-from-snapshot-reference executor reference)]
+                   {:rootEntityType table}))]
+    (log/debug {:action                 "Updating method configuration"
+                :executor               executor
+                :newMethodConfiguration newMc})
+    (firecloud/update-method-configuration workspace methodConfiguration newMc)
     (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
       (jdbc/update! tx terra-executor-table
                     {:method_configuration_version inc'd}

--- a/api/test/wfl/integration/executor_test.clj
+++ b/api/test/wfl/integration/executor_test.clj
@@ -67,7 +67,9 @@
 
 ;; Snapshot and snapshot reference mocks
 (def ^:private snapshot
-  {:name "test-snapshot-name" :id (str (UUID/randomUUID))})
+  {:name   "test-snapshot-name"
+   :id     (str (UUID/randomUUID))
+   :tables [{:name "table"}]})
 
 (def ^:private snapshot-reference-id (str (UUID/randomUUID)))
 (def ^:private snapshot-reference-name (str (:name snapshot) "-ref"))


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1560

`TerraExecutor` now sets a method configuration's `rootEntityType` to be the source snapshot's table.  Previously, it only set the `dataReferenceName` to be the snapshot reference's name, and the submission was triggered with whatever root entity table previously existed.

For a method configuration that has previously run successfully, this has worked with the prior table setting is used.  Here are a few ways this can go wrong:
- A fresh method configuration with no previous submissions may have this table unset
- Method configuration last triggered with a data table as its root entity type, not a snapshot
- Method configuration last triggered with a snapshot of a different TDR table

Edge case: if the `TerraExecutor` doesn't find exactly one table in the source snapshot, we don't know definitively the right table to use in our submission.  This wouldn't happen with snapshots created by WFL's `TerraDataRepoSource` which polls and snapshots from a single table, but could with `TDRSnapshotListSource` (list of existing snapshots to submit).  In this case, we log an error but do not block processing or try to overwrite the method configuration's table value.

Future enhancements if necessary might involve verifying that snapshots in a `TDRSnapshotListSource` only contain single tables and/or allowing the executor request object to optionally specify the table to use in its root entity configuratoin.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Executor method configuration update tries to set root entity table from the supplied snapshot reference.
- Added unit test, supplemented integration test.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

You might like to run the unit test to see the error logs emitted when WFL can't resolve a snapshot reference to a single table:

```
$ cd path/to/wfl/api
$ clojure -M:test --focus wfl.unit.executor-test/test-terra-executor-table-from-snapshot-reference --no-capture-output
--- unit (clojure.test) ---------------------------
wfl.unit.executor-test
  test-terra-executor-table-from-snapshot-reference{"severity":"ERROR","logging.googleapis.com/sourceLocation":{"file":"wfl/executor.clj","line":188},"timestamp":"2022-01-03T23:37:58.296881Z","message":{"cause":"Will not set method configuration root entity table: expected exactly one table in snapshot.","executor":{},"reference":{"attributes":{"snapshot":"931542fb-e453-47d6-bc0b-7ae9c3dc3a17"}},"tables":[]}}
{"severity":"ERROR","logging.googleapis.com/sourceLocation":{"file":"wfl/executor.clj","line":188},"timestamp":"2022-01-03T23:37:58.299561Z","message":{"cause":"Will not set method configuration root entity table: expected exactly one table in snapshot.","executor":{},"reference":{"attributes":{"snapshot":"931542fb-e453-47d6-bc0b-7ae9c3dc3a17"}},"tables":["table1","table2"]}}


1 tests, 3 assertions, 0 failures.
```

### Manual Verification

1. Altered eMerge Arrays test [method configuration](https://app.terra.bio/#workspaces/emerge_prod/Arrays_test_AD/workflows/emerge_prod/Arrays_TDR_GH-1560) existing root entity so that no table was selected:

<img width="1775" alt="Screen Shot 2022-01-03 at 4 31 33 PM" src="https://user-images.githubusercontent.com/79769153/147990742-48f6ce0c-eb21-4e74-946d-2ee006c4c126.png">

2. Created and started workload off of local WFL with existing eMerge Arrays [snapshot](https://data.terra.bio/snapshots/details/b407ebca-08ec-4262-858c-71f51a7eea79) as the source:

```
{
  "project": "GH-1560",
  "labels": [
    "snapshot:emerge_prs_12152021_v1_ArraysInputsTable_20211216T154109_0"
  ],
  "source": {
    "name": "TDR Snapshots",
    "snapshots": ["b407ebca-08ec-4262-858c-71f51a7eea79"]
  },
  "executor": {
    "name": "Terra",
    "workspace": "emerge_prod/Arrays_test_AD",
    "methodConfiguration": "emerge_prod/Arrays_TDR_GH-1560",
    "methodConfigurationVersion": 2,
    "fromSource": "importSnapshot"
  },
  "sink": {
    "name": "Terra Workspace",
    "workspace": "emerge_prod/Arrays_test_AD",
    "entityType": "Arrays_Outputs_Table",
    "fromOutputs": {
      "analysis_version_number_output": "analysis_version_number_output",
      "arrays_variant_calling_control_metrics_file": "arrays_variant_calling_control_metrics_file",
      "arrays_variant_calling_detail_metrics_file": "arrays_variant_calling_detail_metrics_file",
      "arrays_variant_calling_summary_metrics_file": "arrays_variant_calling_summary_metrics_file",
      "baf_regress_metrics_file": "baf_regress_metrics_file",
      "chip_well_barcode_output": "chip_well_barcode_output",
      "fingerprint_detail_metrics_file": "fingerprint_detail_metrics_file",
      "fingerprint_summary_metrics_file": "fingerprint_summary_metrics_file",
      "genotype_concordance_contingency_metrics_file": "genotype_concordance_contingency_metrics_file",
      "genotype_concordance_detail_metrics_file": "genotype_concordance_detail_metrics_file",
      "genotype_concordance_summary_metrics_file": "genotype_concordance_summary_metrics_file",
      "gtc_file": "gtc_file",
      "output_vcf": "output_vcf",
      "output_vcf_index": "output_vcf_index"
    },
    "identifier": "chip_well_barcode_output"
  }
}
```

3. Observed debug log indicating that snapshot table `ArraysInputsTable` was set as root entity table:

```
{"severity":"DEBUG","logging.googleapis.com/sourceLocation":{"file":"wfl/executor.clj","line":212},"timestamp":"2022-01-03T21:33:15.629391Z","message":{"action":"Updating method configuration","executor":{"id":65,"details":"TerraExecutor_000000664","type":"TerraExecutor","workspace":"emerge_prod/Arrays_test_AD","methodConfiguration":"emerge_prod/Arrays_TDR_GH-1560","methodConfigurationVersion":2,"fromSource":"importSnapshot"},"newMethodConfiguration":{"rootEntityType":"ArraysInputsTable","deleted":false,"name":"Arrays_TDR_GH-1560", … "dataReferenceName":"emerge_prs_12152021_v1_ArraysInputsTable_20211216T154109_0","namespace":"emerge_prod","methodConfigVersion":3}}}
```

4. Observed [submission](https://app.terra.bio/#workspaces/emerge_prod/Arrays_test_AD/job_history/fbb96180-f6a5-4895-a154-72d133e442db) successfully triggered, and [method configuration](https://app.terra.bio/#workspaces/emerge_prod/Arrays_test_AD/workflows/emerge_prod/Arrays_TDR_GH-1560) UI now shows expected root entity:

<img width="1770" alt="Screen Shot 2022-01-03 at 4 33 36 PM" src="https://user-images.githubusercontent.com/79769153/147991131-47371f5d-f32b-47f1-bb94-e1cc3bfd3376.png">

