### PR TITLE
[GH-1540] Apply User Comments to Terra Submissions

### DIFF
--- a/api/src/wfl/executor.clj
+++ b/api/src/wfl/executor.clj
@@ -26,7 +26,7 @@
    tasks asynchronously between invocations.  Note that the `Executor` and
    `Queue` are parameterised types and the `Queue`'s parameterisation must be
    convertible to the `Executor`s."
-  (fn [_upstream-queue executor] (:type executor)))
+  (fn [{:keys [executor] :as _workload}] (:type executor)))
 
 (defmulti executor-workflows
   "Return the workflows managed by the `executor"
@@ -43,7 +43,7 @@
 
 (defmulti executor-retry-workflows!
   "Retry/resubmit the `workflows` managed by the `executor`."
-  (fn [executor _workflows] (:type executor)))
+  (fn [_workload executor _workflows] (:type executor)))
 
 ;; load/save operations
 (defmulti create-executor!
@@ -134,6 +134,11 @@
     (throw (UserException. "Only Dockstore methods are supported."
                            {:status 400 :methodRepoMethod methodRepoMethod}))))
 
+(defn ^:private create-user-comment
+  "Create a user comment to be added to an executor submission."
+  [note {:keys [uuid] :as _workload}]
+  (str note "Workload: " uuid))
+
 (defn terra-executor-validate-request-or-throw
   "Verify the method-configuration exists."
   [{:keys [skipValidation
@@ -199,11 +204,11 @@
 (defn ^:private create-submission!
   "Update `methodConfiguration` to use `reference`.
   Create and return submission in `workspace` for `methodConfiguration` via Firecloud."
-  [{:keys [workspace methodConfiguration] :as executor} reference]
+  [{:keys [workspace methodConfiguration] :as executor} userComment reference]
   (update-method-configuration! executor reference)
   (log/debug (format "%s Submitting %s to %s..."
                      (log-prefix executor) methodConfiguration workspace))
-  (firecloud/submit-method workspace methodConfiguration))
+  (firecloud/submit-method workspace methodConfiguration userComment))
 
 (defn ^:private allocate-submission
   "Write or allocate workflow records for `submission` in `details` table,
@@ -308,15 +313,16 @@
   writing its workflows to `details` table.
   Update statuses for active or failed workflows in `details` table.
   Return `executor`."
-  [source executor]
+  [{:keys [executor source] :as workload}]
   (when-let [object (stage/peek-queue source)]
-    (let [entity     (from-source executor object)
-          submission (create-submission! executor entity)]
+    (let [entity      (from-source executor object)
+          userComment (create-user-comment "New submission" workload)
+          submission  (create-submission! executor userComment entity)]
       (allocate-submission executor entity submission)
       (stage/pop-queue! source)))
   (update-unassigned-workflow-uuids! executor)
   (update-terra-workflow-statuses! executor)
-  executor)
+  workload)
 
 (defn ^:private combine-record-workflow-and-outputs
   [{:keys [updated] :as _record}
@@ -604,14 +610,15 @@
 (defn ^:private terra-executor-retry-workflows
   "Resubmit the snapshot references associated with `workflows` in `workspace`
   and update each original workflow record with the row ID of its retry."
-  [{:keys [workspace] :as executor} workflows]
+  [workload {:keys [workspace] :as executor} workflows]
   (letfn [(submit-reference [reference-id]
             ;; Further work required to deal in generic entities
             ;; rather than assumed snapshot references:
             ;; https://broadinstitute.atlassian.net/browse/GH-1422
-            (let [reference (rawls/get-snapshot-reference workspace reference-id)]
+            (let [reference (rawls/get-snapshot-reference workspace reference-id)
+                  userComment (create-user-comment "Retry" workload)]
               (->> reference
-                   (create-submission! executor)
+                   (create-submission! executor userComment)
                    (allocate-submission executor reference))))]
     (->> (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
            (workflow-and-sibling-records tx executor workflows))

--- a/api/src/wfl/executor.clj
+++ b/api/src/wfl/executor.clj
@@ -43,7 +43,7 @@
 
 (defmulti executor-retry-workflows!
   "Retry/resubmit the `workflows` managed by the `executor`."
-  (fn [_workload executor _workflows] (:type executor)))
+  (fn [{:keys [executor] :as _workload} _workflows] (:type executor)))
 
 ;; load/save operations
 (defmulti create-executor!
@@ -610,7 +610,7 @@
 (defn ^:private terra-executor-retry-workflows
   "Resubmit the snapshot references associated with `workflows` in `workspace`
   and update each original workflow record with the row ID of its retry."
-  [workload {:keys [workspace] :as executor} workflows]
+  [{{:keys [workspace] :as executor} :executor :as workload} workflows]
   (letfn [(submit-reference [reference-id]
             ;; Further work required to deal in generic entities
             ;; rather than assumed snapshot references:

--- a/api/src/wfl/executor.clj
+++ b/api/src/wfl/executor.clj
@@ -19,13 +19,14 @@
 
 ;; executor operations
 (defmulti update-executor!
-  "Consume items from the `upstream-queue` and enqueue to the `executor` queue
-   for consumption by a later processing stage, performing any external effects
-   as necessary. Implementations should avoid maintaining in-memory state and
-   making long-running external calls, favouring internal queues to manage such
-   tasks asynchronously between invocations.  Note that the `Executor` and
-   `Queue` are parameterised types and the `Queue`'s parameterisation must be
-   convertible to the `Executor`s."
+  "Consume items from the `workload`'s source queue and enqueue to its executor
+   queue for consumption by a later processing stage,
+   performing any external effects as necessary.
+   Implementations should avoid maintaining in-memory state and making long-
+   running external calls, favouring internal queues to manage such tasks
+   asynchronously between invocations.  Note that the `Workload`'s Source queue and Executor
+   are parameterised types and the Source queue's parameterisation must be
+   convertible to the Executor's."
   (fn [{:keys [executor] :as _workload}] (:type executor)))
 
 (defmulti executor-workflows
@@ -312,7 +313,7 @@
   "Create new submission from new `source` snapshot if available,
   writing its workflows to `details` table.
   Update statuses for active or failed workflows in `details` table.
-  Return `executor`."
+  Return updated `workload`."
   [{:keys [executor source] :as workload}]
   (when-let [object (stage/peek-queue source)]
     (let [entity      (from-source executor object)

--- a/api/src/wfl/executor.clj
+++ b/api/src/wfl/executor.clj
@@ -140,7 +140,7 @@
 (defn ^:private create-user-comment
   "Create a user comment to be added to an executor submission."
   [note {:keys [uuid] :as _workload} snapshot-id]
-  (str/join \newline [note "Workload:" uuid "Snapshot ID:" snapshot-id "origin:" (env/getenv "WFL_WFL_URL")]))
+  (str/join \space [note "Workload:" uuid "Snapshot ID:" snapshot-id "origin:" (env/getenv "WFL_WFL_URL")]))
 
 (defn terra-executor-validate-request-or-throw
   "Verify the method-configuration exists."

--- a/api/src/wfl/executor.clj
+++ b/api/src/wfl/executor.clj
@@ -5,6 +5,7 @@
             [clojure.string        :as str]
             [ring.util.codec       :refer [url-encode]]
             [wfl.api.workloads     :refer [defoverload]]
+            [wfl.environment       :as env]
             [wfl.jdbc              :as jdbc]
             [wfl.log               :as log]
             [wfl.module.all        :as all]
@@ -138,7 +139,7 @@
 (defn ^:private create-user-comment
   "Create a user comment to be added to an executor submission."
   [note {:keys [uuid] :as _workload}]
-  (str note "Workload: " uuid))
+  (str note " Workload: " uuid " host: " (env/getenv "WFL_WFL_URL")))
 
 (defn terra-executor-validate-request-or-throw
   "Verify the method-configuration exists."

--- a/api/src/wfl/module/covid.clj
+++ b/api/src/wfl/module/covid.clj
@@ -128,9 +128,10 @@
   "Use transaction `tx` to update `workload` statuses."
   [tx {:keys [started finished] :as workload}]
   (letfn [(update! [{:keys [id source executor sink] :as workload} now]
-            (-> (source/update-source! source)
-                (executor/update-executor! executor)
-                (sink/update-sink! sink))
+            (-> workload
+                (source/update-source!)
+                (executor/update-executor!)
+                (sink/update-sink!))
             (patch-workload tx workload {:updated now})
             (when (every? stage/done? [source executor sink])
               (patch-workload tx workload {:finished now}))
@@ -160,7 +161,7 @@
                            {:workload workload})))
   ;; TODO: validate workload's executor and sink objects.
   ;; https://broadinstitute.atlassian.net/browse/GH-1421
-  (executor/executor-retry-workflows! executor workflows)
+  (executor/executor-retry-workflows! workload executor workflows)
   (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
     (when-not (stage/done? executor)
       (patch-workload tx workload {:finished nil :updated (utc-now)}))

--- a/api/src/wfl/module/covid.clj
+++ b/api/src/wfl/module/covid.clj
@@ -161,7 +161,7 @@
                            {:workload workload})))
   ;; TODO: validate workload's executor and sink objects.
   ;; https://broadinstitute.atlassian.net/browse/GH-1421
-  (executor/executor-retry-workflows! workload executor workflows)
+  (executor/executor-retry-workflows! workload workflows)
   (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
     (when-not (stage/done? executor)
       (patch-workload tx workload {:finished nil :updated (utc-now)}))

--- a/api/src/wfl/service/firecloud.clj
+++ b/api/src/wfl/service/firecloud.clj
@@ -65,18 +65,21 @@
 
 (defn submit-method
   "Submit the`methodconfig` for processing in the Terra `workspace`."
-  [workspace methodconfig]
-  {:pre [(every? string? [workspace methodconfig])]}
-  (let [[mcns mcn] (str/split methodconfig #"/")]
-    (-> (workspace-api-url workspace "submissions")
-        (http/post {:headers      (auth/get-auth-header)
-                    :content-type :application/json
-                    :body         (json/write-str
-                                   {:methodConfigurationNamespace mcns
-                                    :methodConfigurationName mcn
-                                    :useCallCache true}
-                                   :escape-slash false)})
-        util/response-body-json)))
+  ([workspace methodconfig]
+   (submit-method workspace methodconfig ""))
+  ([workspace methodconfig usercomment]
+   {:pre [(every? string? [workspace methodconfig usercomment])]}
+   (let [[mcns mcn] (str/split methodconfig #"/")]
+     (-> (workspace-api-url workspace "submissions")
+         (http/post {:headers      (auth/get-auth-header)
+                     :content-type :application/json
+                     :body         (json/write-str
+                                    {:methodConfigurationNamespace mcns
+                                     :methodConfigurationName mcn
+                                     :useCallCache true
+                                     :userComment usercomment}
+                                    :escape-slash false)})
+         util/response-body-json))))
 
 (defn create-workspace
   "Create an empty Terra workspace with the fully-qualified `workspace` name,

--- a/api/src/wfl/sink.clj
+++ b/api/src/wfl/sink.clj
@@ -44,13 +44,13 @@
   (fn [_transaction workload] (:sink_type workload)))
 
 (defmulti update-sink!
-  "Update the internal state of the `sink`, consuming objects from the
-   Queue `upstream-queue`, performing any external effects as required.
+  "Update the internal state of the `Workload`'s sink, consuming objects from the
+   `Workload`'s executor queue, performing any external effects as required.
    Implementations should avoid maintaining in-memory state and making long-
    running external calls, favouring internal queues to manage such tasks
-   asynchronously between invocations.
-   Note that the `Sink` and `Queue` are parameterised types
-   and the `Queue`'s parameterisation must be convertible to the `Sink`s."
+   asynchronously between invocations. Note that the `Workload`'s Sink and its Executor Queue are
+   parameterised types and the Executor Queue's parameterisation must be convertible
+   to the Sink's."
   (fn [{:keys [sink] :as _workload}] (:type sink)))
 
 (defmethod create-sink! :default
@@ -414,7 +414,7 @@
          (push-job sink))))
 
 (defn ^:private update-datarepo-sink
-  "Attempt to a pull a workflow off the upstream `executor` queue and write its
+  "Attempt to a pull a workflow off the `Workload`'s `executor` queue and write its
    outputs as new rows in a tdr dataset table asynchronously."
   [{:keys [executor sink] :as _workload}]
   (when-let [[_ workflow] (stage/peek-queue executor)]

--- a/api/src/wfl/sink.clj
+++ b/api/src/wfl/sink.clj
@@ -51,7 +51,7 @@
    asynchronously between invocations.
    Note that the `Sink` and `Queue` are parameterised types
    and the `Queue`'s parameterisation must be convertible to the `Sink`s."
-  (fn [_upstream-queue sink] (:type sink)))
+  (fn [{:keys [sink] :as _workload}] (:type sink)))
 
 (defmethod create-sink! :default
   [_ _ {:keys [name] :as request}]
@@ -199,7 +199,8 @@
 (defn ^:private update-terra-workspace-sink
   "Write outputs from consumable `executor` workflows
    to `entityType` table in `workspace`."
-  [executor {:keys [fromOutputs workspace entityType details] :as sink}]
+  [{executor :executor
+    {:keys [fromOutputs workspace entityType details] :as sink} :sink :as _workload}]
   (when-let [[_ {:keys [uuid] :as workflow}] (stage/peek-queue executor)]
     (log/debug {:action     "Attempting to sink workflow outputs"
                 :workflow   uuid
@@ -415,7 +416,7 @@
 (defn ^:private update-datarepo-sink
   "Attempt to a pull a workflow off the upstream `executor` queue and write its
    outputs as new rows in a tdr dataset table asynchronously."
-  [executor sink]
+  [{:keys [executor sink] :as _workload}]
   (when-let [[_ workflow] (stage/peek-queue executor)]
     (start-ingesting-outputs sink workflow)
     (stage/pop-queue! executor))

--- a/api/src/wfl/source.clj
+++ b/api/src/wfl/source.clj
@@ -336,7 +336,7 @@
   (update-pending-snapshot-jobs source)
   ;; load and return the source table
   (let [new-source (:source (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
-                   (load-tdr-source tx {:source_items (str (:id source))})))]
+                              (load-tdr-source tx {:source_items (str (:id source))})))]
     (merge workload new-source)))
 
 (defn ^:private start-tdr-source [tx source]

--- a/api/src/wfl/source.clj
+++ b/api/src/wfl/source.clj
@@ -444,7 +444,7 @@
 
 (defn ^:private start-tdr-snapshot-list [_ source] source)
 (defn ^:private stop-tdr-snapshot-list  [_ source] source)
-(defn ^:private update-tdr-snapshot-list [{:keys [source] :as _workload}]  source)
+(defn ^:private update-tdr-snapshot-list [workload]  workload)
 
 (defn ^:private peek-tdr-snapshot-details-table [{:keys [items] :as _source}]
   (let [query "SELECT *        FROM %s

--- a/api/src/wfl/source.clj
+++ b/api/src/wfl/source.clj
@@ -326,7 +326,7 @@
     (<= polling-interval minutes-since-poll)))
 
 (defn ^:private update-tdr-source
-  "Check for new data in TDR from `source`, create new snapshots,
+  "Check for new data in TDR from `Workload`'s `source`, create new snapshots,
   insert resulting job creation ids into database and update the
   timestamp for next time."
   [{{:keys [stopped] :as source} :source :as workload}]

--- a/api/src/wfl/source.clj
+++ b/api/src/wfl/source.clj
@@ -56,7 +56,7 @@
   (fn [_transaction source] (:type source)))
 
 (defmulti update-source!
-  "Enqueue items onto the `source` queue to be consumed by a later processing
+  "Enqueue items onto the `workload`'s source queue to be consumed by a later processing
    stage unless stopped, performing any external effects as necessary.
    Implementations should avoid maintaining in-memory state and making long-
    running external calls, favouring internal queues to manage such tasks

--- a/api/test/wfl/integration/executor_test.clj
+++ b/api/test/wfl/integration/executor_test.clj
@@ -312,8 +312,8 @@
     (is (== 2 (stage/queue-length executor))
         "Two workflows should be enqueued prior to retry.")
     (let [executor           (reload-terra-executor executor)
-        workload-uuid        (UUID/randomUUID)
-        workload             {:uuid workload-uuid :source source :executor executor}]
+          workload-uuid        (UUID/randomUUID)
+          workload             {:uuid workload-uuid :source source :executor executor}]
       (is (== 2 (:methodConfigurationVersion executor))
           "Reloaded executor's method config should have version 2 post-update.")
       (with-redefs-fn

--- a/api/test/wfl/integration/executor_test.clj
+++ b/api/test/wfl/integration/executor_test.clj
@@ -299,7 +299,8 @@
     (is (zero? (stage/queue-length source)) "The snapshot was not consumed.")
     (is (== 2 (stage/queue-length executor))
         "Two workflows should be enqueued prior to retry.")
-    (let [executor           (reload-terra-executor executor)]
+    (let [executor           (reload-terra-executor executor)
+          workload           {:uuid (UUID/randomUUID) :executor executor}]
       (is (== 2 (:methodConfigurationVersion executor))
           "Reloaded executor's method config should have version 2 post-update.")
       (with-redefs-fn
@@ -314,7 +315,7 @@
                  (executor/executor-workflows-by-filters tx executor {:status "Running"}))]
            (is (== 1 (count workflows-to-retry))
                "Should have one running workflow to retry.")
-           (executor/executor-retry-workflows! executor workflows-to-retry)))
+           (executor/executor-retry-workflows! workload workflows-to-retry)))
       ;; We only specify 1 workflow to retry,
       ;; but must retry both workflows from its submission.
       (is (== 4 (stage/queue-length executor))

--- a/api/test/wfl/integration/source_test.clj
+++ b/api/test/wfl/integration/source_test.clj
@@ -107,7 +107,7 @@
           (source/update-source!
            (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
              (source/start-source! tx source)
-             (reload-source tx source))))
+             {:uuid (UUID/randomUUID) :source (reload-source tx source)})))
         (let [miss-count (dec mock-new-rows-size)
               miss-set   (set (rows-from source))]
           (is (== record-count (stage/queue-length source)))
@@ -120,7 +120,7 @@
                           source/create-snapshots        mock-create-snapshots]
               (source/update-source!
                (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
-                 (reload-source tx source))))
+                 {:uuid (UUID/randomUUID) :source (reload-source tx source)})))
             (let [all-rows (rows-from source)
                   missing  (set/difference (set all-rows) miss-set)]
               (is (== (inc record-count) (stage/queue-length source)))
@@ -179,7 +179,7 @@
         (source/update-source!
          (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
            (source/start-source! tx source)
-           (reload-source tx source)))
+           {:uuid (UUID/randomUUID) :source (reload-source tx source)}))
         (is (== expected-num-records (stage/queue-length source))
             "snapshots should be enqueued")
         (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
@@ -195,7 +195,7 @@
         (let [stopped-source (source/update-source!
                               (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
                                 (source/stop-source! tx source)
-                                (reload-source tx source)))]
+                                {:uuid (UUID/randomUUID) :source (reload-source tx source)}))]
           (is (== expected-num-records (stage/queue-length stopped-source))
               "no more snapshots should be enqueued")
           (is (not (stage/done? stopped-source))
@@ -215,12 +215,12 @@
         (source/update-source!
          (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
            (source/start-source! tx source)
-           (reload-source tx source)))
+           {:uuid (UUID/randomUUID) :source (reload-source tx source)}))
         (is (zero? (stage/queue-length source)) "No snapshots should be enqueued")
         (let [stopped-source (source/update-source!
                               (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
                                 (source/stop-source! tx source)
-                                (reload-source tx source)))]
+                                {:uuid (UUID/randomUUID) :source (reload-source tx source)}))]
           (is (stage/done? stopped-source)
               "the tdr source should be done if no snapshots to consume"))))))
 

--- a/docs/md/executor.md
+++ b/docs/md/executor.md
@@ -121,18 +121,17 @@ An executor is a `Queue` that satisfies the `Executor` protocol below:
 ```clojure
 (defprotocol Executor
   (update-executor!
-    ^Executor
-    [^Queue    upstream  ;; The queue from which to pull items to execute
-     ^Executor executor  ;; This executor instance
+    ^Workload
+    [^Workload workload
     ]
-    "Consume items from the `upstream` queue and enqueue
-     to the `executor` queue for consumption by a later processing stage,
+    "Consume items from the `workload`'s source queue and enqueue to its executor
+     queue for consumption by a later processing stage,
      performing any external effects as necessary.
      Implementations should avoid maintaining in-memory state and making long-
      running external calls, favouring internal queues to manage such tasks
-     asynchronously between invocations.  Note that the `Executor` and `Queue`
-     are parameterised types and the `Queue`'s parameterisation must be
-     convertible to the `Executor`s.")
+     asynchronously between invocations.  Note that the `Workload`'s Source queue and Executor
+     are parameterised types and the Source queue's parameterisation must be
+     convertible to the Executor's.")
   (executor-workflows
     ^IPersistentVector
     [^Connection transaction  ;; JDBC Connection

--- a/docs/md/sink.md
+++ b/docs/md/sink.md
@@ -173,17 +173,16 @@ A sink is one satisfying the `Sink` protocol as below:
 ```clojure
 (defprotocol Sink
   (update-sink!
-    ^Sink
-    [^Queue upstream ;; The queue to sink outputs from
-     ^Sink  sink     ;; This sink instance
+    ^Workload
+    [^Workload workload  ;; This sink instance
     ]
-    "Update the internal state of the `sink`, consuming objects from the
-     Queue `upstream`, performing any external effects as required.
+    "Update the internal state of the `Workload`'s sink, consuming objects from the
+     `Workload`'s executor queue, performing any external effects as required.
      Implementations should avoid maintaining in-memory state and making long-
      running external calls, favouring internal queues to manage such tasks
-     asynchronously between invocations. Note that The `Sink` and `Queue` are
-     parameterised types and the `Queue`'s parameterisation must be convertible
-     to the `Sink`s."))
+     asynchronously between invocations. Note that the `Workload`'s Sink and its Executor Queue are
+     parameterised types and the Executor Queue's parameterisation must be convertible
+     to the Sink's."))
 ```
 
 !!! note

--- a/docs/md/source.md
+++ b/docs/md/source.md
@@ -150,9 +150,9 @@ A source is a `Queue` that satisfies the `Source` protocol below:
      be called after `start-source!`. Any outstanding items on the `source`
      queue may still be consumed by a later processing stage.")
   (update-source!
-    ^Source
-    [^Source source]
-    "Enqueue items onto the `source` queue to be consumed by a later processing
+    ^Workload
+    [^Workload workload]
+    "Enqueue items onto the `workload`'s source queue to be consumed by a later processing
      stage unless stopped, performing any external effects as necessary.
      Implementations should avoid maintaining in-memory state and making long-
      running external calls, favouring internal queues to manage such tasks


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->
We want to be able to utilize the user comment field in a Terra submission. In this comment, we would like to include the information necessary to be able to commence a retry such as workload uuid and environment. In order to accomplish this, WFL also needs to be updated to have the workload available for the submission creation to be able to send a user comment.

- (https://broadinstitute.atlassian.net/browse/GH-1540)

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Added user comment to submission creation
- Updated the three workload update functions (source, executor, sink) to be passed a workload instead of their object and upstream from the workload.
- Updated tests to accommodate

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- Run tests
- Verify that a user comment with the workload uuid and the current running environment makes it into a Terra submission
