### PR TITLE
GH-1433 Test TDR snapshot creation within temporary dataset

### DIFF
--- a/api/test/wfl/tools/fixtures.clj
+++ b/api/test/wfl/tools/fixtures.clj
@@ -193,6 +193,10 @@
    datarepo/delete-snapshots-then-dataset
    f))
 
+;; Recommendation: only call this within a temporary dataset.
+;; If calling within a fixed dataset, running the same test concurrently
+;; may fail due to exclusive dataset locking on snapshot deletion.
+;;
 (defn with-temporary-snapshot
   "Create a temporary Terra Data Repository Snapshot with `snapshot-request`"
   [snapshot-request f]


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1433

In normal operations, WFL does not programmatically delete TDR snapshots.  The exception: within the `create-temporary-snapshot` fixture used to clean up in testing.

Deleting a snapshot obtains an exclusive lock on the underlying dataset, and can block other concurrent operations on that dataset.  We've seen `wfl.integration.datarepo-test/test-create-snapshot` fail when run concurrently for this reason since it used a fixed existing dataset.

Solution: test snapshot creation within a temporary dataset, per Trevyn's recommendation.
