### PR TITLE
[DDO-1920] Configure GKE LB Backend Service timeout in Helm

### DIFF
--- a/helm/wfl/templates/ingress.yaml
+++ b/helm/wfl/templates/ingress.yaml
@@ -3,6 +3,15 @@
 {{- $fullName := include "wfl.fullname" . -}}
 {{- $servicePort := .Values.ingress.servicePort -}}
 
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: {{ $fullName }}-backend-config
+spec:
+  timeoutSec: {{ .Values.ingress.backendTimeout }}
+
+---
+
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
@@ -15,6 +24,7 @@ metadata:
     {{- include "wfl.labels" . | nindent 4 }}
 {{- with .Values.ingress.annotations }}
   annotations:
+    cloud.google.com/backend-config: '{"default": "{{ $fullName }}-backend-config"}'
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:

--- a/helm/wfl/values.yaml
+++ b/helm/wfl/values.yaml
@@ -125,3 +125,5 @@ ingress:
   annotations: {}
   hosts: []
   tls: []
+  # -- Seconds to use for the backend service's timeout, see GH-1601
+  backendTimeout: 60


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadworkbench.atlassian.net/browse/DDO-1920
- https://broadinstitute.atlassian.net/browse/GH-1601

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Codifies the change from https://broadworkbench.atlassian.net/browse/DDO-1917 in Helm
- Adds a BackendConfig as the default, per https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-features#same_backendconfig_for_all_service_ports and https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-features#timeout

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- This has already been implemented in dev and prod in the UI, from https://broadworkbench.atlassian.net/browse/DDO-1917
- I suggest making sure that we redeploy WFL to dev first--any issues at all will crop up there and would be in the form of Kubernetes API errors (but we have tons of BackendConfigs in Terra and I don't expect any issues)
