### PR TITLE
[GH-1598] Update TerraExecutor documentation

### DIFF
--- a/docs/md/executor.md
+++ b/docs/md/executor.md
@@ -62,7 +62,7 @@ in the Terra UI.
 Prerequisites:
 
 - The workspace must exist prior to workload creation.
-- `workflow-launcher@firecloud.org` must be a workspace "Owner" in order to
+- `workflow-launcher@firecloud.org` must be a workspace "Writer" in order to
   import snapshots to the workspace.
 - The workspace must be compatible with any downstream processing stage that
   consumes its workflows.


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1598

In the process of testing the Twist/TCAP staged workload, we confirmed that WFL Firecloud groups don't need to be workspace "Owners", only "Writers".  Updated our documentation accordingly.

(Fine by me with the downgrade: owners can delete workspaces, better to not have the ability to do so accidentally.)