### PR TITLE
[GH-1566] Cannot log ExceptionInfo http-client as JSON

### DIFF
--- a/api/src/wfl/log.clj
+++ b/api/src/wfl/log.clj
@@ -104,11 +104,15 @@
   "A logger to write to standard output"
   (reify Logger
     (-write [logger edn]
-      (-> edn
-          (json/write-str :escape-slash false
-                          :key-fn       key-fn
-                          :value-fn     value-fn)
-          println))))
+      (let [to-log
+            (try (json/write-str edn
+                                 :escape-slash false
+                                 :key-fn       key-fn
+                                 :value-fn     value-fn)
+                 (catch Exception x
+                   {:to-log                   (str edn)
+                    :exception-json-write-str (str x)}))]
+        (println to-log)))))
 
 (def ^:dynamic *logger*
   "The logger now."

--- a/api/test/wfl/unit/logging_test.clj
+++ b/api/test/wfl/unit/logging_test.clj
@@ -63,11 +63,11 @@
   (let [workspace  "wfl-dev/Illumina-Genotyping-Array-Templateecf09d017b8d4033bab8d5feeae86987"
         submission "6ac9a307-5eeb-4e20-9321-b32d0f80adf4"
         thrown    (try
-                     (firecloud/get-submission workspace submission)
-                     (catch ExceptionInfo x
-                       (println "Caught exception when fetching submission for deleted workspace")
-                       (println (str x))
-                       x))
+                    (firecloud/get-submission workspace submission)
+                    (catch ExceptionInfo x
+                      (println "Caught exception when fetching submission for deleted workspace")
+                      (println (str x))
+                      x))
         remove-bad (ex-info (.getMessage thrown)
                             (dissoc (ex-data thrown) :http-client)
                             (.getCause thrown))]


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

Easiest way to share my debugging.

Discovered this bug while reviewing expanded logging PR, though it already existed:
- https://broadinstitute.atlassian.net/browse/GH-1566

Is the likely cause of our many SG woes:
- https://broadinstitute.atlassian.net/browse/GH-1534
- https://broadinstitute.atlassian.net/browse/GH-1589

I was running system test `wfl.system.v1-endpoint-test/test-workload-sink-outputs-to-tdr`.  The workspace was deleted, but WFL DB still had a record of an active submission.  An exception was thrown when WFL tried to fetch the submission for a deleted workspace.  However, what I saw in the logs was evidence of a failure in the full "update all workloads" loop,
not the individual workload's update loop:

```
{"message":{"column":7,"namespace":"wfl.server","result":"Failed to update workloads","throwable":{"via":[{"type":"java.lang.Exception","message":"Don't know how to write JSON of class org.apache.http.impl.client.InternalHttpClient","at":["clojure.data.json$write_generic","invokeStatic","json.clj",598]}],"trace":[["clojure.data.json$write_generic","invokeStatic","json.clj",598],["clojure.data.json$write_generic","invoke","json.clj",595],["clojure.data.json$fn__266$G__261__275","invoke","json.clj",423],["clojure.data.json$write_object","invokeStatic","json.clj",516],["clojure.data.json$write_object","invoke","json.clj",489],["clojure.data.json$fn__266$G__261__275","invoke","json.clj",423],["clojure.data.json$write_object","invokeStatic","json.clj",516],["clojure.data.json$write_object","invoke","json.clj",489],["clojure.data.json$fn__266$G__261__275","invoke","json.clj",423],["clojure.data.json$write_array","invokeStatic","json.clj",536],["clojure.data.json$write_array","invoke","json.clj",525],["clojure.data.json$fn__266$G__261__275","invoke","json.clj",423],["clojure.data.json$write_object","invokeStatic","json.clj",516],["clojure.data.json$write_object","invoke","json.clj",489],["clojure.lang.Var","invoke","Var.java",393],["wfl.log$write_throwable","invokeStatic","log.clj",86],["wfl.log$write_throwable","invoke","log.clj",83],["clojure.data.json$fn__266$G__261__275","invoke","json.clj",423],["clojure.data.json$write_object","invokeStatic","json.clj",516],["clojure.data.json$write_object","invoke","json.clj",489],["clojure.data.json$fn__266$G__261__275","invoke","json.clj",423],["clojure.data.json$write_object","invokeStatic","json.clj",516],["clojure.data.json$write_object","invoke","json.clj",489],["clojure.data.json$fn__266$G__261__275","invoke","json.clj",423],["clojure.data.json$write_str","invokeStatic","json.clj",712],["clojure.data.json$write_str","doInvoke","json.clj",707],["clojure.lang.RestFn","invoke","RestFn.java",559],["wfl.log$reify__424","_write","log.clj",108],["wfl.log$log","invokeStatic","log.clj",130],["wfl.log$log","doInvoke","log.clj",117],["clojure.lang.RestFn","invoke","RestFn.java",846],["wfl.server$try_update","invokeStatic","server.clj",100],["wfl.server$try_update","invoke","server.clj",93],["clojure.core$run_BANG_$fn__8813","invoke","core.clj",7717],["clojure.core.protocols$fn__8181","invokeStatic","protocols.clj",168],["clojure.core.protocols$fn__8181","invoke","protocols.clj",124],["clojure.core.protocols$fn__8136$G__8131__8145","invoke","protocols.clj",19],["clojure.core.protocols$seq_reduce","invokeStatic","protocols.clj",31],["clojure.core.protocols$fn__8168","invokeStatic","protocols.clj",75],["clojure.core.protocols$fn__8168","invoke","protocols.clj",75],["clojure.core.protocols$fn__8110$G__8105__8123","invoke","protocols.clj",13],["clojure.core$reduce","invokeStatic","core.clj",6830],["clojure.core$run_BANG_","invokeStatic","core.clj",7712],["clojure.core$run_BANG_","invoke","core.clj",7712],["wfl.server$update_workloads","invokeStatic","server.clj",108],["wfl.server$update_workloads","invoke","server.clj",103],["wfl.server$start_workload_manager$fn__15017","invoke","server.clj",125],["clojure.core$binding_conveyor_fn$fn__5772","invoke","core.clj",2034],["clojure.lang.AFn","call","AFn.java",18],["java.util.concurrent.FutureTask","run","FutureTask.java",264],["java.util.concurrent.ThreadPoolExecutor","runWorker","ThreadPoolExecutor.java",1128],["java.util.concurrent.ThreadPoolExecutor$Worker","run","ThreadPoolExecutor.java",628],["java.lang.Thread","run","Thread.java",834]],"cause":"Don't know how to write JSON of class org.apache.http.impl.client.InternalHttpClient"}},"severity":"ERROR","logging.googleapis.com/sourceLocation":{"file":"wfl/server.clj","function":"Failed to update workloads","line":114},"time":"2022-02-10T14:57:04.512961Z"}
```

The stack trace included indicated that WFL was choking when trying to write a log as JSON.  Wrapping `wfl.log/stdout-logger` in a `(try... catch...)` to see the root cause error as well yielded the following:

```
{:to-log #:wfl.log{:message {:column 7, :namespace wfl.server, :result "Failed to update workload %s", :labels ["hornet:test" "project:(Test) rfricke/GH-1566-workloadinfologs"], :throwable \
#error {
 :cause "clj-http: status 404"
 :data {:cached nil, :request-time 6437, :repeatable? false, :protocol-version {:name "HTTP", :major 1, :minor 1}, :streaming? true, :http-client #object[org.apache.http.impl.client.Interna\
lHttpClient 0x14af73e1 "org.apache.http.impl.client.InternalHttpClient@14af73e1"], :chunked? false, :type :clj-http.client/unexceptional-status, :reason-phrase "Not Found", :headers {"Acces\
s-Control-Max-Age" "1728000", "Access-Control-Allow-Headers" "authorization,content-type,accept,origin,x-app-id", "Server" "akka-http/10.2.6", "Via" "1.1 google, 1.1 google", "Content-Type"\
 "application/json", "Access-Control-Allow-Origin" "*", "X-Content-Type-Options" "nosniff", "Content-Length" "256", "Alt-Svc" ["h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000" "h3=\":44\
3\"; ma=2592000,h3-29=\":443\"; ma=2592000"], "X-Frame-Options" "SAMEORIGIN", "Strict-Transport-Security" "max-age=31536000; includeSubDomains", "Connection" "close", "Access-Control-Allow-\
Methods" "GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD", "Date" "Thu, 10 Feb 2022 17:13:18 GMT", "X-XSS-Protection" "1; mode=block"}, :orig-content-encoding nil, :status 404, :length 256, :body "\
{\n  \"causes\": [],\n  \"message\": \"wfl-dev/Illumina-Genotyping-Array-Templateecf09d017b8d4033bab8d5feeae86987 does not exist or you do not have permission to use it\",\n  \"source\": \"\
rawls\",\n  \"stackTrace\": [],\n  \"statusCode\": 404,\n  \"timestamp\": 1644513199370\n}", :trace-redirects []}
 :via
 [{:type clojure.lang.ExceptionInfo
   :message "clj-http: status 404"
   :data {:cached nil, :request-time 6437, :repeatable? false, :protocol-version {:name "HTTP", :major 1, :minor 1}, :streaming? true, :http-client #object[org.apache.http.impl.client.Inter\
nalHttpClient 0x14af73e1 "org.apache.http.impl.client.InternalHttpClient@14af73e1"], :chunked? false, :type :clj-http.client/unexceptional-status, :reason-phrase "Not Found", :headers {"Acc\
ess-Control-Max-Age" "1728000", "Access-Control-Allow-Headers" "authorization,content-type,accept,origin,x-app-id", "Server" "akka-http/10.2.6", "Via" "1.1 google, 1.1 google", "Content-Typ\
e" "application/json", "Access-Control-Allow-Origin" "*", "X-Content-Type-Options" "nosniff", "Content-Length" "256", "Alt-Svc" ["h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000" "h3=\":\
443\"; ma=2592000,h3-29=\":443\"; ma=2592000"], "X-Frame-Options" "SAMEORIGIN", "Strict-Transport-Security" "max-age=31536000; includeSubDomains", "Connection" "close", "Access-Control-Allo\
w-Methods" "GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD", "Date" "Thu, 10 Feb 2022 17:13:18 GMT", "X-XSS-Protection" "1; mode=block"}, :orig-content-encoding nil, :status 404, :length 256, :body\
 "{\n  \"causes\": [],\n  \"message\": \"wfl-dev/Illumina-Genotyping-Array-Templateecf09d017b8d4033bab8d5feeae86987 does not exist or you do not have permission to use it\",\n  \"source\": \
\"rawls\",\n  \"stackTrace\": [],\n  \"statusCode\": 404,\n  \"timestamp\": 1644513199370\n}", :trace-redirects []}
   :at [slingshot.support$stack_trace invoke "support.clj" 201]}]
 :trace
[[slingshot.support$stack_trace invoke "support.clj" 201]
  [clj_http.client$exceptions_response invokeStatic "client.clj" 245]
  [clj_http.client$exceptions_response invoke "client.clj" 236]
  [clj_http.client$wrap_exceptions$fn__10934 invoke "client.clj" 254]
  [clj_http.client$wrap_accept$fn__11136 invoke "client.clj" 737]
  [clj_http.client$wrap_accept_encoding$fn__11143 invoke "client.clj" 759]
  [clj_http.client$wrap_content_type$fn__11130 invoke "client.clj" 720]
  [clj_http.client$wrap_form_params$fn__11229 invoke "client.clj" 961]
  [clj_http.client$wrap_nested_params$fn__11250 invoke "client.clj" 995]
  [clj_http.client$wrap_flatten_nested_params$fn__11259 invoke "client.clj" 1019]
  [clj_http.client$wrap_method$fn__11197 invoke "client.clj" 895]
  [clj_http.cookies$wrap_cookies$fn__8908 invoke "cookies.clj" 131]
  [clj_http.links$wrap_links$fn__10011 invoke "links.clj" 63]
  [clj_http.client$wrap_unknown_host$fn__11267 invoke "client.clj" 1048]
  [clj_http.client$request_STAR_ invokeStatic "client.clj" 1176]
  [clj_http.client$request_STAR_ invoke "client.clj" 1169]
  [clj_http.client$get invokeStatic "client.clj" 1182]
  [clj_http.client$get doInvoke "client.clj" 1178]
  [clojure.lang.RestFn invoke "RestFn.java" 423]
  [wfl.service.firecloud$get_workspace_json invokeStatic "firecloud.clj" 35]
  [wfl.service.firecloud$get_workspace_json doInvoke "firecloud.clj" 33]
  [clojure.lang.RestFn invoke "RestFn.java" 436]
  [wfl.service.firecloud$get_submission invokeStatic "firecloud.clj" 150]
  [wfl.service.firecloud$get_submission invoke "firecloud.clj" 147]
  [wfl.executor$update_unassigned_workflow_uuids_BANG_ invokeStatic "executor.clj" 341]
  [wfl.executor$update_unassigned_workflow_uuids_BANG_ invoke "executor.clj" 309]
  [wfl.executor$update_terra_executor invokeStatic "executor.clj" 403]
  [wfl.executor$update_terra_executor invoke "executor.clj" 389]
  [clojure.lang.AFn applyToHelper "AFn.java" 154]
  [clojure.lang.AFn applyTo "AFn.java" 144]
  [clojure.core$apply invokeStatic "core.clj" 667]
  [clojure.core$apply invoke "core.clj" 662]
  [wfl.executor$fn__440 invokeStatic "executor.clj" 697]
  [wfl.executor$fn__440 doInvoke "executor.clj" 697]
  [clojure.lang.RestFn invoke "RestFn.java" 408]
  [clojure.lang.MultiFn invoke "MultiFn.java" 229]
  [wfl.module.covid$update_covid_workload$update_BANG___14523 invoke "covid.clj" 133]
  [wfl.module.covid$update_covid_workload invokeStatic "covid.clj" 139]
  [wfl.module.covid$update_covid_workload invoke "covid.clj" 127]
  [clojure.lang.AFn applyToHelper "AFn.java" 156]
[clojure.lang.AFn applyTo "AFn.java" 144]
  [clojure.core$apply invokeStatic "core.clj" 667]
  [clojure.core$apply invoke "core.clj" 662]
  [wfl.module.covid$fn__14546 invokeStatic "covid.clj" 180]
  [wfl.module.covid$fn__14546 doInvoke "covid.clj" 180]
  [clojure.lang.RestFn invoke "RestFn.java" 421]
  [clojure.lang.MultiFn invoke "MultiFn.java" 234]
  [wfl.server$do_update_BANG_$fn__15006 invoke "server.clj" 87]
  [clojure.java.jdbc$db_transaction_STAR_ invokeStatic "jdbc.clj" 807]
  [clojure.java.jdbc$db_transaction_STAR_ invoke "jdbc.clj" 776]
  [clojure.java.jdbc$db_transaction_STAR_ invokeStatic "jdbc.clj" 852]
  [clojure.java.jdbc$db_transaction_STAR_ invoke "jdbc.clj" 776]
  [clojure.java.jdbc$db_transaction_STAR_ invokeStatic "jdbc.clj" 789]
  [clojure.java.jdbc$db_transaction_STAR_ invoke "jdbc.clj" 776]
  [wfl.server$do_update_BANG_ invokeStatic "server.clj" 84]
  [wfl.server$do_update_BANG_ invoke "server.clj" 81]
  [wfl.server$try_update invokeStatic "server.clj" 98]
  [wfl.server$try_update invoke "server.clj" 93]
  [clojure.core$run_BANG_$fn__8813 invoke "core.clj" 7717]
  [clojure.core.protocols$fn__8181 invokeStatic "protocols.clj" 168]
  [clojure.core.protocols$fn__8181 invoke "protocols.clj" 124]
  [clojure.core.protocols$fn__8136$G__8131__8145 invoke "protocols.clj" 19]
  [clojure.core.protocols$seq_reduce invokeStatic "protocols.clj" 31]
  [clojure.core.protocols$fn__8168 invokeStatic "protocols.clj" 75]
  [clojure.core.protocols$fn__8168 invoke "protocols.clj" 75]
  [clojure.core.protocols$fn__8110$G__8105__8123 invoke "protocols.clj" 13]
  [clojure.core$reduce invokeStatic "core.clj" 6830]
  [clojure.core$run_BANG_ invokeStatic "core.clj" 7712]
  [clojure.core$run_BANG_ invoke "core.clj" 7712]
  [wfl.server$update_workloads invokeStatic "server.clj" 108]
  [wfl.server$update_workloads invoke "server.clj" 103]
  [wfl.server$start_workload_manager invokeStatic "server.clj" 122]
[wfl.server$start_workload_manager invoke "server.clj" 116]
  [wfl.server$run invokeStatic "server.clj" 170]
  [wfl.server$run doInvoke "server.clj" 165]
  [clojure.lang.RestFn applyTo "RestFn.java" 137]
  [clojure.lang.Var applyTo "Var.java" 705]
  [clojure.core$apply invokeStatic "core.clj" 667]
  [clojure.core$apply invoke "core.clj" 662]
  [wfl.main$_main$fn__15045 invoke "main.clj" 71]
  [wfl.main$_main invokeStatic "main.clj" 68]
  [wfl.main$_main doInvoke "main.clj" 65]
  [clojure.lang.RestFn applyTo "RestFn.java" 137]
  [clojure.lang.Var applyTo "Var.java" 705]
  [clojure.core$apply invokeStatic "core.clj" 667]
  [clojure.main$main_opt invokeStatic "main.clj" 514]
  [clojure.main$main_opt invoke "main.clj" 510]
  [clojure.main$main invokeStatic "main.clj" 664]
  [clojure.main$main doInvoke "main.clj" 616]
  [clojure.lang.RestFn applyTo "RestFn.java" 137]
  [clojure.lang.Var applyTo "Var.java" 705]
  [clojure.main main "main.java" 40]]}, :workload "e66439f4-cb6d-4d8b-93e8-03a1c309dcd6"}, :severity "ERROR", :sourceLocation {:file "wfl/server.clj", :function "Failed to update workload %\
s", :line 100}, :time #object[java.time.Instant 0x5d0e703a "2022-02-10T17:13:19.336130Z"]}, :exception-json-write-str java.lang.Exception: Don't know how to write JSON of class org.apache.h\
ttp.impl.client.InternalHttpClient}
```

This is the pair within ExceptionInfo data that can't be written as JSON:

`:http-client #object[org.apache.http.impl.client.InternalHttpClient 0x14af73e1]`

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Added backstop handling to logger in case we try to log something can't be written as JSON. Otherwise, the workload update loop will throw.
- Demoed specific failure case: `ExceptionInfo` with JSON-incompatible `:http-client`.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- Run the unit test (really a demo) and look at the printed output.

### Open for discussion

- I'd like a catch-all backstop as insurance against a weird log tanking the workload update process, but there's probably some more elegant handling we can add to writing objects as JSON.