### PR TITLE
[GH-1604] Disable / hide Slacking behind WFL_SLACK_ENABLED

### DIFF
--- a/api/src/wfl/environment.clj
+++ b/api/src/wfl/environment.clj
@@ -53,6 +53,10 @@
    (fn [] "https://rawls.dsde-dev.broadinstitute.org")
    "WFL_DOCKSTORE_URL"
    (fn [] "https://dockstore.org")
+   ;; To enable Slack notifications, set to "enabled":
+   ;; all other values disable them.
+   "WFL_SLACK_ENABLED"
+   (fn [] "disabled")
 
    ;; -- variables used in test code below this line --
    "WFL_CROMWELL_URL"

--- a/api/src/wfl/service/slack.clj
+++ b/api/src/wfl/service/slack.clj
@@ -12,7 +12,7 @@
 (defonce ^:private token
   (delay (:bot-user-token (#'env/vault-secrets "secret/dsde/gotc/dev/wfl/slack"))))
 
-(def feature-env-var-name "WFL_SLACK_FEATURE_SWITCH")
+(def enabled-env-var-name "WFL_SLACK_ENABLED")
 
 ;; FIXME: suppress warning `javax.mail.internet.AddressException: Missing final '@domain'`
 ;;
@@ -89,7 +89,7 @@
 (defn notify-watchers
   "Send `message` associated with workload `uuid` to Slack `watchers`."
   [{:keys [watchers uuid project labels] :as _workload} message]
-  (let [feature-switch (env/getenv feature-env-var-name)]
+  (let [feature-switch (env/getenv enabled-env-var-name)]
     (if (= "enabled" feature-switch)
       (let [channels (filter slack-channel-watcher? watchers)
             project  (or project (util/label-value labels "project"))
@@ -103,7 +103,7 @@
                     (add-notification notifier payload)))]
           (run! notify channels)))
       (log/info {:slackDisabled
-                 {:env-var-name       feature-env-var-name
+                 {:env-var-name       enabled-env-var-name
                   :env-var-val        feature-switch
                   :workload           uuid
                   :would-have-slacked (pr-str message)}}))))

--- a/api/src/wfl/service/slack.clj
+++ b/api/src/wfl/service/slack.clj
@@ -12,6 +12,8 @@
 (defonce ^:private token
   (delay (:bot-user-token (#'env/vault-secrets "secret/dsde/gotc/dev/wfl/slack"))))
 
+(def feature-env-var-name "WFL_SLACK_FEATURE_SWITCH")
+
 ;; FIXME: suppress warning `javax.mail.internet.AddressException: Missing final '@domain'`
 ;;
 (defn ^:private valid-channel-id?
@@ -87,17 +89,24 @@
 (defn notify-watchers
   "Send `message` associated with workload `uuid` to Slack `watchers`."
   [{:keys [watchers uuid project labels] :as _workload} message]
-  (let [channels (filter slack-channel-watcher? watchers)
-        project  (or project (util/label-value labels "project"))
-        swagger  (str/join "/" [(env/getenv "WFL_WFL_URL") "swagger"])
-        header   (format "%s workload %s *%s*"
-                         (link swagger "WFL") project uuid)]
-    (letfn [(notify [[_tag channel-id _channel-name]]
-              (let [payload {:channel channel-id
-                             :message (str/join \newline [header message])}]
-                (log/info payload)
-                (add-notification notifier payload)))]
-      (run! notify channels))))
+  (let [feature-switch (env/getenv feature-env-var-name)]
+    (if (= "enabled" feature-switch)
+      (let [channels (filter slack-channel-watcher? watchers)
+            project  (or project (util/label-value labels "project"))
+            swagger  (str/join "/" [(env/getenv "WFL_WFL_URL") "swagger"])
+            header   (format "%s workload %s *%s*"
+                             (link swagger "WFL") project uuid)]
+        (letfn [(notify [[_tag channel-id _channel-name]]
+                  (let [payload {:channel channel-id
+                                 :message (str/join \newline [header message])}]
+                    (log/info payload)
+                    (add-notification notifier payload)))]
+          (run! notify channels)))
+      (log/info {:slackDisabled
+                 {:env-var-name       feature-env-var-name
+                  :env-var-val        feature-switch
+                  :workload           uuid
+                  :would-have-slacked (pr-str message)}}))))
 
 (defn start-notification-loop
   "Return a future that listens at `agent` and

--- a/api/test/wfl/system/v1_endpoint_test.clj
+++ b/api/test/wfl/system/v1_endpoint_test.clj
@@ -485,9 +485,11 @@
           (finally
             (endpoints/stop-workload workload)))
         ;; Note: when the workload's workflows have finished,
+        ;; if Slacking is enabled via
+        ;; `wfl.service.slack/feature-env-var-name`
         ;; we expect a notification for each workflow
         ;; to be emitted to the Slack channels in
-        ;; wfl.tools.workloads/watchers.
+        ;; `wfl.tools.workloads/watchers`.
         (is (util/poll
              #(-> workload :uuid endpoints/get-workload-status :finished)
              20 100)

--- a/api/test/wfl/unit/slack_test.clj
+++ b/api/test/wfl/unit/slack_test.clj
@@ -1,6 +1,8 @@
 (ns wfl.unit.slack-test
-  (:require [clojure.test      :refer [deftest is testing]]
-            [wfl.service.slack :as slack])
+  (:require [clojure.string     :as str]
+            [clojure.test       :refer [deftest is testing]]
+            [wfl.service.slack  :as slack]
+            [wfl.tools.fixtures :as fixtures])
   (:import [clojure.lang PersistentQueue]))
 
 (def ^:private testing-agent (agent (PersistentQueue/EMPTY)))
@@ -14,3 +16,23 @@
         (slack/add-notification testing-agent (testing-slack-notification)))
       (await testing-agent)
       (is (= num-msg (count (seq @testing-agent)))))))
+
+(deftest test-notify-watchers-behind-feature-switch
+  (let [notification (testing-slack-notification)
+        workload     {:uuid     "workload-uuid"
+                      :watchers [["slack" (:channel notification)]]}
+        message      (:message notification)]
+    (letfn [(mock-add-notification [switch]
+              (fn [_notifier payload]
+                (if (= "enabled" switch)
+                  (do (is (= (:channel notification) (:channel payload)))
+                      (is (str/includes? (:message payload) message)))
+                  (throw (ex-info "Should not notify"
+                                  {:switch switch})))))
+            (verify [switch]
+              (fixtures/with-temporary-environment
+                {slack/feature-env-var-name switch}
+                #(with-redefs-fn
+                   {#'slack/add-notification (mock-add-notification switch)}
+                   (fn [] (slack/notify-watchers workload message)))))]
+      (run! verify ["enabled" "anything-else-is-disabled"]))))


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1604

Any time we try to emit Slack notifications in WFL Dev or Prod, the Kubernetes pod restarts and we see this error message:

`java.lang.RuntimeException: Agent is failed, needs restart`

I'm hiding Slacking behind a feature switch at environment variable `WFL_SLACK_ENABLED`.  By default, we'll disable sending Slack notifications, instead emitting a log of what we would have sent.  To enable, set to "enabled".

If a WFL user creates a workload in the mean time with Slack watchers specified, we'll honor the request but not send anything to their channels.

### Intention

If enough time, I'd like to create a patch release v0.14.1 and deploy to WFL dev today.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Slacking now hidden behind feature switch to cut off agent failures driving Kubernetes pod restarts
- Added unit test to verify feature switch behavior

### Verification

I ran `wfl.system.v1-endpoint-test/test-workload-sink-outputs-to-tdr`.  Confirmed that no Slack notification was emitted to #hornet-slack-app-testing, and that we've logged what would have been emitted.

```
{"severity":"DEBUG","logging.googleapis.com/sourceLocation":{"file":"wfl/environment.clj","line":84},"timestamp":"2022-02-11T21:33:13.316806Z","message":"Reading environment variable WFL_SLACK_ENABLED"}
{"severity":"INFO","logging.googleapis.com/sourceLocation":{"file":"wfl/service/slack.clj","line":105},"timestamp":"2022-02-11T21:33:13.316970Z","message":{"slackDisabled":{"env-var-name":"WFL_SLACK_ENABLED","env-var-val":"disabled","workload":"383feae1-c130-42b4-bff2-785c17ccd1ac","would-have-slacked":"\"*:cromwell-succeeded: Workflow <https://job-manager.dsde-prod.broadinstitute.org/jobs/3e29754d-5ef8-431a-9a5e-ef654ead6cc2|3e29754d-5ef8-431a-9a5e-ef654ead6cc2> Succeeded*\\nSubmission *<https://app.terra.bio/#workspaces/wfl-dev/Illumina-Genotyping-Array-Template5af842a09bef4a5a8cabbd0b382996a1/job_history/d2a5553d-a107-4262-b22d-c7c85429a11b|d2a5553d-a107-4262-b22d-c7c85429a11b>*\""}}}
```

Otherwise, system tests pass:

```
wm111-e35:wfl okotsopo$ make TARGET=system
clojure -M -e "(compile 'wfl.main)"
wfl.main
clojure -M:uberjar -m uberdeps.uberjar \
		--level error --multi-release --main-class wfl.main \
		--target /Users/okotsopo/wfl/derived/api/target/wfl-0.13.0.jar
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
ln -f -s /Users/okotsopo/wfl/derived/api/target/wfl-0.13.0.jar /Users/okotsopo/wfl/derived/api/target/wfl.jar
export CPCACHE=/Users/okotsopo/wfl/api/.cpcache;            \
	export WFL_WFL_URL=http://localhost:3000; \
	clojure  -M:parallel-test wfl.system.v1-endpoint-test | \
	tee /Users/okotsopo/wfl/derived/api/system.log
WARNING: Specified path is external to project: ../derived/api/src
WARNING: Specified path is external to project: ../derived/api/resources

Ran 32 tests containing 371 assertions.
0 failures, 0 errors.
api system finished on Fri Feb 11 16:36:28 EST 2022
docs system finished on Fri Feb 11 16:36:28 EST 2022
functions/aou system finished on Fri Feb 11 16:36:28 EST 2022
functions/sg system finished on Fri Feb 11 16:36:28 EST 2022
helm system finished on Fri Feb 11 16:36:28 EST 2022
ui system finished on Fri Feb 11 16:36:28 EST 2022
```