### PR TITLE
[GH-1629] TerraExecutor gets method configuration version from Firecloud

### DIFF
--- a/api/src/wfl/executor.clj
+++ b/api/src/wfl/executor.clj
@@ -128,8 +128,8 @@
         (update :fromSource edn/read-string))
     (throw (ex-info "Invalid executor_items" {:workload workload}))))
 
-(defn ^:private error-on-method-config-version-mismatch
-  "Throw or log error if `methodConfigVersion` does not match `expected`."
+(defn ^:private warn-on-method-config-version-mismatch
+  "Throw or log warning if `methodConfigVersion` does not match `expected`."
   ([{:keys [methodConfigVersion] :as methodconfig} expected throw?]
    (when-not (== expected methodConfigVersion)
      (let [cause "Unexpected method configuration version"
@@ -138,9 +138,9 @@
                   :methodConfiguration methodconfig}]
        (if throw?
          (throw (UserException. cause data))
-         (log/error (merge {:cause cause} data))))))
+         (log/warning (merge {:cause cause} data))))))
   ([methodconfig expected]
-   (error-on-method-config-version-mismatch methodconfig expected false)))
+   (warn-on-method-config-version-mismatch methodconfig expected false)))
 
 (defn ^:private throw-unless-dockstore-method
   "Throw unless the `sourceRepo` of `methodRepoMethod` is \"dockstore\"."
@@ -168,7 +168,7 @@
       (throw
        (UserException. "Unsupported coercion" (util/make-map fromSource))))
     (let [m (firecloud/method-configuration workspace methodConfiguration)]
-      (error-on-method-config-version-mismatch m methodConfigurationVersion true)
+      (warn-on-method-config-version-mismatch m methodConfigurationVersion true)
       (throw-unless-dockstore-method (:methodRepoMethod m))))
   executor)
 
@@ -221,7 +221,7 @@
    reference]
   (let [name    (get-in reference [:metadata :name])
         current (firecloud/method-configuration workspace methodConfiguration)
-        _       (error-on-method-config-version-mismatch
+        _       (warn-on-method-config-version-mismatch
                  current methodConfigurationVersion)
         inc'd   (inc (:methodConfigVersion current))
         newMc   (merge

--- a/api/test/wfl/integration/executor_test.clj
+++ b/api/test/wfl/integration/executor_test.clj
@@ -464,7 +464,7 @@
         dataReferenceNamePre  "snapshotReferenceNamePreUpdate"
         dataReferenceNamePost "snapshotReferenceNamePostUpdate"
         reference             {:metadata {:name dataReferenceNamePost}}
-        inc'dMcVersion        (+ testing-method-configuration-version 1)
+        inc'dMcVersion        (inc testing-method-configuration-version)
         rootEntityTypePre     "rootEntityTypePreUpdate"]
     (letfn [(firecloud-method-configuration
               [_workspace qualifiedMcName]

--- a/api/test/wfl/integration/executor_test.clj
+++ b/api/test/wfl/integration/executor_test.clj
@@ -28,36 +28,36 @@
     fixtures/temporary-postgresql-database))
 
 (deftest test-validate-terra-executor-with-valid-executor-request
-  (let [request {:name                       "Terra"
-                 :workspace                  testing-workspace
-                 :methodConfiguration        testing-method-configuration
-                 :fromSource                 "importSnapshot"}]
+  (let [request {:name                "Terra"
+                 :workspace           testing-workspace
+                 :methodConfiguration testing-method-configuration
+                 :fromSource          "importSnapshot"}]
     (letfn [(check-mc-version [executor]
               (is executor)
               (is (== testing-method-configuration-version
                       (:methodConfigurationVersion executor))))]
       (testing "request without method configuration version"
         (-> request
-            executor/terra-executor-validate-request-or-throw
+            (#'executor/terra-executor-validate-request-or-throw)
             check-mc-version))
       (testing "request ignores specified method configuration version"
         (-> (assoc request :methodConfigurationVersion -1)
-            executor/terra-executor-validate-request-or-throw
+            (#'executor/terra-executor-validate-request-or-throw)
             check-mc-version)))))
 
 (deftest test-validate-terra-executor-with-invalid-executor-request
   (is (thrown-with-msg?
        UserException #"Unsupported coercion"
-       (executor/terra-executor-validate-request-or-throw
-        {:name                       "Terra"
-         :workspace                  testing-workspace
-         :methodConfiguration        testing-method-configuration
-         :fromSource                 "frobnicate"}))))
+       (#'executor/terra-executor-validate-request-or-throw
+        {:name                "Terra"
+         :workspace           testing-workspace
+         :methodConfiguration testing-method-configuration
+         :fromSource          "frobnicate"}))))
 
 (deftest test-validate-terra-executor-with-wrong-method-configuration
   (is (thrown-with-msg?
        UserException #"Cannot access method configuration"
-       (executor/terra-executor-validate-request-or-throw
+       (#'executor/terra-executor-validate-request-or-throw
         {:name                "Terra"
          :workspace           testing-workspace
          :methodConfiguration "no_such/method_configuration"
@@ -200,11 +200,11 @@
 
 (defn ^:private create-terra-executor [id]
   (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
-    (->> {:name                       "Terra"
-          :workspace                  "workspace-ns/workspace-name"
-          :methodConfiguration        fake-method-config
-          :fromSource                 "importSnapshot"
-          :skipValidation             true}
+    (->> {:name                "Terra"
+          :workspace           "workspace-ns/workspace-name"
+          :methodConfiguration fake-method-config
+          :fromSource          "importSnapshot"
+          :skipValidation      true}
          (executor/create-executor! tx id)
          (zipmap [:executor_type :executor_items])
          (executor/load-executor! tx))))

--- a/api/test/wfl/integration/executor_test.clj
+++ b/api/test/wfl/integration/executor_test.clj
@@ -54,8 +54,6 @@
          :methodConfiguration        testing-method-configuration
          :fromSource                 "frobnicate"}))))
 
-
-
 (deftest test-validate-terra-executor-with-wrong-method-configuration
   (is (thrown-with-msg?
        UserException #"Cannot access method configuration"

--- a/api/test/wfl/integration/modules/staged_test.clj
+++ b/api/test/wfl/integration/modules/staged_test.clj
@@ -132,7 +132,6 @@
         {:skipValidation true}
         {:workspace                  testing-workspace
          :methodConfiguration        testing-method-configuration
-         :methodConfigurationVersion testing-method-configuration-version
          :fromSource                 "importSnapshot"}
         {:skipValidation true}))))
 

--- a/api/test/wfl/integration/modules/staged_test.clj
+++ b/api/test/wfl/integration/modules/staged_test.clj
@@ -130,9 +130,9 @@
   (is (workloads/create-workload!
        (workloads/staged-workload-request
         {:skipValidation true}
-        {:workspace                  testing-workspace
-         :methodConfiguration        testing-method-configuration
-         :fromSource                 "importSnapshot"}
+        {:workspace           testing-workspace
+         :methodConfiguration testing-method-configuration
+         :fromSource          "importSnapshot"}
         {:skipValidation true}))))
 
 (deftest test-start-workload

--- a/api/test/wfl/system/automation_test.clj
+++ b/api/test/wfl/system/automation_test.clj
@@ -23,7 +23,6 @@
    :executor {:name                       "Terra"
               :workspace                  workspace
               :methodConfiguration        "wfl-dev/sarscov2_illumina_full"
-              :methodConfigurationVersion 1
               :fromSource                 "importSnapshot"}
    :sink     {:name           "Terra Workspace"
               :workspace      workspace

--- a/api/test/wfl/system/automation_test.clj
+++ b/api/test/wfl/system/automation_test.clj
@@ -20,10 +20,10 @@
   [workspace]
   {:source   {:name      "TDR Snapshots"
               :snapshots ["f9242ab8-c522-4305-966d-7c51419377ab"]}
-   :executor {:name                       "Terra"
-              :workspace                  workspace
-              :methodConfiguration        "wfl-dev/sarscov2_illumina_full"
-              :fromSource                 "importSnapshot"}
+   :executor {:name                "Terra"
+              :workspace           workspace
+              :methodConfiguration "wfl-dev/sarscov2_illumina_full"
+              :fromSource          "importSnapshot"}
    :sink     {:name           "Terra Workspace"
               :workspace      workspace
               :entityType     "run_date"

--- a/api/test/wfl/system/v1_endpoint_test.clj
+++ b/api/test/wfl/system/v1_endpoint_test.clj
@@ -276,7 +276,6 @@
         executor  {:name                       "Terra"
                    :workspace                  workspace
                    :methodConfiguration        (terra-ns "sarscov2_illumina_full")
-                   :methodConfigurationVersion 2
                    :fromSource                 "importSnapshot"}
         sink      {:name           "Terra Workspace"
                    :workspace      workspace
@@ -432,7 +431,6 @@
             executor {:name                       "Terra"
                       :workspace                  workspace
                       :methodConfiguration        "warp-pipelines/IlluminaGenotypingArray"
-                      :methodConfigurationVersion 1
                       :fromSource                 "importSnapshot"}
             sink     {:name        "Terra DataRepo"
                       :dataset     dataset-id

--- a/api/test/wfl/system/v1_endpoint_test.clj
+++ b/api/test/wfl/system/v1_endpoint_test.clj
@@ -273,10 +273,10 @@
                    :table                  "flowcells"
                    :snapshotReaders        ["hornet@firecloud.org"]
                    :pollingIntervalMinutes 1}
-        executor  {:name                       "Terra"
-                   :workspace                  workspace
-                   :methodConfiguration        (terra-ns "sarscov2_illumina_full")
-                   :fromSource                 "importSnapshot"}
+        executor  {:name                "Terra"
+                   :workspace           workspace
+                   :methodConfiguration (terra-ns "sarscov2_illumina_full")
+                   :fromSource          "importSnapshot"}
         sink      {:name           "Terra Workspace"
                    :workspace      workspace
                    :entityType     "assemblies"
@@ -428,10 +428,10 @@
                       :snapshotReaders        ["hornet@firecloud.org"]
                       :pollingIntervalMinutes 1
                       :loadTag                "loadTagToMonitor"}
-            executor {:name                       "Terra"
-                      :workspace                  workspace
-                      :methodConfiguration        "warp-pipelines/IlluminaGenotypingArray"
-                      :fromSource                 "importSnapshot"}
+            executor {:name                "Terra"
+                      :workspace           workspace
+                      :methodConfiguration "warp-pipelines/IlluminaGenotypingArray"
+                      :fromSource          "importSnapshot"}
             sink     {:name        "Terra DataRepo"
                       :dataset     dataset-id
                       :table       "outputs"

--- a/api/test/wfl/tools/workloads.clj
+++ b/api/test/wfl/tools/workloads.clj
@@ -134,7 +134,6 @@
                {:name                       "Terra"
                 :workspace                  "namespace/name"
                 :methodConfiguration        "namespace/name"
-                :methodConfigurationVersion 0
                 :fromSource                 "importSnapshot"}
                executor)
     :sink     (merge

--- a/api/test/wfl/tools/workloads.clj
+++ b/api/test/wfl/tools/workloads.clj
@@ -131,10 +131,10 @@
                 :snapshotReaders []}
                source)
     :executor (merge
-               {:name                       "Terra"
-                :workspace                  "namespace/name"
-                :methodConfiguration        "namespace/name"
-                :fromSource                 "importSnapshot"}
+               {:name                "Terra"
+                :workspace           "namespace/name"
+                :methodConfiguration "namespace/name"
+                :fromSource          "importSnapshot"}
                executor)
     :sink     (merge
                {:name        "Terra Workspace"

--- a/database/changelog.xml
+++ b/database/changelog.xml
@@ -48,4 +48,5 @@
     <include file="changesets/20211110_AddPollingIntervalColumn.xml"                  relativeToChangelogFile="true"/>
     <include file="changesets/20220119_TerraDataRepoSourceAddLoadTagColumn.xml"       relativeToChangelogFile="true"/>
     <include file="changesets/20220125_TerraDataRepoSourceRemoveTableColumnName.xml"  relativeToChangelogFile="true"/>
+    <include file="changesets/20220228_TerraExecutorNullableMethodConfigVersion.xml"  relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/database/changesets/20220228_TerraExecutorNullableMethodConfigVersion.xml
+++ b/database/changesets/20220228_TerraExecutorNullableMethodConfigVersion.xml
@@ -1,0 +1,28 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext
+                        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
+                        http://www.liquibase.org/xml/ns/dbchangelog
+                        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+    <changeSet author="okotsopo@broadinstitute.org"
+               dbms="postgresql"
+               id="20220228"
+               logicalFilePath="20220228_TerraExecutorNullableMethodConfigVersion.xml"
+               runInTransaction="false">
+        <comment>
+            Staged workloads with TerraExecutors no longer need to be created
+            with the method configuration version specified.
+
+            We will get this ourselves from Firecloud
+            during workload request validation,
+            and update it when triggering Terra submissions.
+        </comment>
+        <sql>
+            ALTER TABLE TerraExecutor
+            ALTER COLUMN method_configuration_version DROP NOT NULL;
+        </sql>
+    </changeSet>
+</databaseChangeLog>

--- a/docs/md/staged-api-usage.md
+++ b/docs/md/staged-api-usage.md
@@ -73,7 +73,6 @@ An example workload response at the time of this writing is formatted thusly:
     "executor" : {
     "workspace" : "wfl-dev/CDC_Viral_Sequencing_okotsopo_20210707",
     "methodConfiguration" : "wfl-dev/sarscov2_illumina_full",
-    "methodConfigurationVersion" : 41,
     "fromSource" : "importSnapshot",
     "name" : "Terra"
     },
@@ -289,7 +288,6 @@ with an assigned `uuid`.
                     "name": "Terra",
                     "workspace": "wfl-dev/CDC_Viral_Sequencing _ranthony_bashing_copy",
                     "methodConfiguration": "wfl-dev/sarscov2_illumina_full",
-                    "methodConfigurationVersion": 2,
                     "fromSource": "importSnapshot"
                 },
                 "sink": {
@@ -378,7 +376,6 @@ with an assigned `uuid`.
                     "name": "Terra",
                     "workspace": "wfl-dev/CDC_Viral_Sequencing _ranthony_bashing_copy",
                     "methodConfiguration": "wfl-dev/sarscov2_illumina_full",
-                    "methodConfigurationVersion": 2,
                     "fromSource": "importSnapshot"
                 },
                 "sink": {

--- a/docs/md/staged-executor.md
+++ b/docs/md/staged-executor.md
@@ -26,7 +26,6 @@ A typical `Terra` executor configuration in the workload request looks like:
   "name": "Terra",
   "workspace": "{workspace-namespace}/{workspace-name}",
   "methodConfiguration": "{method-configuration-namespace}/{method-configuration-name}",
-  "methodConfigurationVersion": 1,
   "fromSource": "importSnapshot"
 }
 ```
@@ -37,7 +36,6 @@ And a real-life example for a known method configuration:
   "name": "Terra",
   "workspace": "wfl-dev/CDC_Viral_Sequencing",
   "methodConfiguration": "wfl-dev/sarscov2_illumina_full",
-  "methodConfigurationVersion": 1,
   "fromSource": "importSnapshot"
 }
 ```
@@ -51,7 +49,6 @@ The table below summarises the purpose of each attribute in the above request.
 | `name`                       | Selects the `Terra` executor implementation.                                                      |
 | `workspace`                  | Terra Workspace in which to execute workflows.                                                    |
 | `methodConfiguration`        | Method configuration from which to generate submissions.                                          |
-| `methodConfigurationVersion` | Expected version of the method configuration.                                                     |
 | `fromSource`                 | Instruction to coerce an output from an upstream `Source` to a type understood by this `executor`.|
 
 #### `workspace`
@@ -74,39 +71,6 @@ Prerequisites:
 
 - The method configuration must exist within `workspace` prior to
   workload creation.
-
-#### `methodConfigurationVersion`
-The expected version of `methodConfiguration`, stored as an integer in
-[Firecloud](https://firecloud-orchestration.dsde-prod.broadinstitute.org/#/Method%20Configurations/getWorkspaceMethodConfig).
-
-Example fetch of a method configuration's version from the appropriate
-Firecloud instance (prod):
-
-```shell
-FIRECLOUD=https://firecloud-orchestration.dsde-prod.broadinstitute.org
-
-# Should be as they'd appear in a Terra UI URL path:
-WORKSPACE=emerge_prod/Arrays_test
-METHOD_CONFIG=warp-pipelines/Arrays
-
-curl -X GET \
-  "$FIRECLOUD/api/workspaces/$WORKSPACE/method_configs/$METHOD_CONFIG" \
-  -H 'accept: */*' \
-  -H 'Authorization: Bearer '$(gcloud auth print-access-token) \
-  | jq .methodConfigVersion
-7
-```
-
-Prerequisites:
-
-- The `methodConfiguration` version when fetched from Firecloud
-  at workload creation should match `methodConfigurationVersion`.
-
-!!! warning "Implications of Version Mismatch"
-    A version mismatch may indicate a possible concurrent modification of the
-    method configuration used for launching submissions.  Modification is possible
-    programmatically or via the Terra UI.  An unexpected modification may cause
-    submission and/or workflow creation to fail.
 
 #### `fromSource`
 This attribute tells workflow-launcher how to coerce an output

--- a/docs/md/staged-executor.md
+++ b/docs/md/staged-executor.md
@@ -44,12 +44,12 @@ And a real-life example for a known method configuration:
 
 The table below summarises the purpose of each attribute in the above request.
 
-| Attribute                    | Description                                                                                       |
-|------------------------------|---------------------------------------------------------------------------------------------------|
-| `name`                       | Selects the `Terra` executor implementation.                                                      |
-| `workspace`                  | Terra Workspace in which to execute workflows.                                                    |
-| `methodConfiguration`        | Method configuration from which to generate submissions.                                          |
-| `fromSource`                 | Instruction to coerce an output from an upstream `Source` to a type understood by this `executor`.|
+| Attribute             | Description                                                                                       |
+|-----------------------|---------------------------------------------------------------------------------------------------|
+| `name`                | Selects the `Terra` executor implementation.                                                      |
+| `workspace`           | Terra Workspace in which to execute workflows.                                                    |
+| `methodConfiguration` | Method configuration from which to generate submissions.                                          |
+| `fromSource`          | Instruction to coerce an output from an upstream `Source` to a type understood by this `executor`.|
 
 #### `workspace`
 A `{workspace-namespace}/{workspace-name}` string as it appears in the URL path

--- a/docs/md/staged-workload.md
+++ b/docs/md/staged-workload.md
@@ -55,7 +55,6 @@ via WFL API, see [API Usage](./staged-api-usage.md).
         "name": "Terra",
         "workspace": "wfl-dev/CDC_Viral_Sequencing",
         "methodConfiguration": "wfl-dev/sarscov2_illumina_full",
-        "methodConfigurationVersion": 1,
         "fromSource": "importSnapshot"
     },
     "sink": {


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1629

Previously, when creating a staged workload's `TerraExecutor` the caller first needed to query Firecloud API directly for their method configuration's present version.  The intention was to make up for a lack of audit trail for method configuration changes, to make debugging easier in the case that workflows started failing after a change.

User feedback indicated that this Firecloud fetch was one of the more annoying start-up costs of launching a staged workload, without much benefit.  I agree!

Now, we save the method configuration's version from Firecloud on workload creation rather than making the caller do the fetch themselves.  When triggering Terra submissions, if the method configuration has an unexpected version we log a warning (previously an error) but proceed with processing.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- `TerraExecutor` gets its initial method configuration version from Firecloud, not the user's request.
- Downgraded mismatched version log from `ERROR -> WARNING`.
- Updated and expanded tests.
- Removed `methodConfigurationVersion` references from public-facing docs.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- Take a look at changes to `wfl.executor/terra-executor-validate-request-or-throw`.
- Then, take a look at changes to `wfl.integration.executor-test/test-validate-terra-executor-with-valid-executor-request`.
- See documentation removed in `docs/md/staged-executor.md` and smile.
- If you'd like to see this in action, could run `wfl.system.v1-endpoint-test/test-staged-workload`, load the resulting workload, and see that the executor has its method configuration version set.

### System Tests:

1 known unrelated failure ([Slack](https://broadinstitute.slack.com/archives/CFA6Q2QBU/p1646254288854259), [ticket](https://broadinstitute.atlassian.net/browse/GH-1632)):

```
$ make TARGET=system
export CPCACHE=/Users/okotsopo/wfl/api/.cpcache;            \
	export WFL_WFL_URL=http://localhost:3000; \
	clojure  -M:parallel-test wfl.system.v1-endpoint-test | \
	tee /Users/okotsopo/wfl/derived/api/system.log
WARNING: Specified path is external to project: ../derived/api/src
WARNING: Specified path is external to project: ../derived/api/resources

ERROR in (test-workload-sink-outputs-to-tdr) (util.clj:390)
The workload should have finished
expected: (util/poll (fn* [] (-> workload :uuid endpoints/get-workload-status :finished)) 20 100)
  actual: java.util.concurrent.TimeoutException: Max number of attempts exceeded
 at wfl.util$poll.invokeStatic (util.clj:390)
    wfl.util$poll.invoke (util.clj:383)
    clojure.lang.AFn.applyToHelper (AFn.java:160)
    clojure.lang.AFn.applyTo (AFn.java:144)
    clojure.core$apply.invokeStatic (core.clj:667)
    clojure.core$apply.invoke (core.clj:662)
    wfl.system.v1_endpoint_test$fn__793$fn__796$fn__797$fn__799$fn__827.invoke (v1_endpoint_test.clj:476)
    wfl.system.v1_endpoint_test$fn__793$fn__796$fn__797$fn__799.invoke (v1_endpoint_test.clj:476)
    wfl.system.v1_endpoint_test$fn__793$fn__796$fn__797.invoke (v1_endpoint_test.clj:413)
    wfl.util$bracket.invokeStatic (util.clj:362)
    wfl.util$bracket.invoke (util.clj:352)
    wfl.tools.fixtures$with_shared_temporary_workspace_clone.invokeStatic (fixtures.clj:242)
    wfl.tools.fixtures$with_shared_temporary_workspace_clone.invoke (fixtures.clj:229)
    wfl.system.v1_endpoint_test$fn__793$fn__796.invoke (v1_endpoint_test.clj:413)
    wfl.util$bracket.invokeStatic (util.clj:362)
    wfl.util$bracket.invoke (util.clj:352)
    wfl.tools.fixtures$with_temporary_dataset.invokeStatic (fixtures.clj:191)
    wfl.tools.fixtures$with_temporary_dataset.invoke (fixtures.clj:188)
    wfl.system.v1_endpoint_test$fn__793.invokeStatic (v1_endpoint_test.clj:413)
    wfl.system.v1_endpoint_test/fn (v1_endpoint_test.clj:412)
    clojure.test$test_var$fn__9761.invoke (test.clj:717)
    clojure.test$test_var.invokeStatic (test.clj:717)
    clojure.test$test_var.invoke (test.clj:708)
    wfl.system.v1_endpoint_test$test_workload_sink_outputs_to_tdr.invokeStatic (v1_endpoint_test.clj:412)
    wfl.system.v1_endpoint_test$test_workload_sink_outputs_to_tdr.invoke (v1_endpoint_test.clj:412)
    clojure.lang.Var.invoke (Var.java:380)
    wfl.tools.parallel_runner$_main$run_test_BANG___12.invoke (parallel_runner.clj:18)
    wfl.tools.parallel_runner$_main$fn__15$fn__16.invoke (parallel_runner.clj:26)
    clojure.core$binding_conveyor_fn$fn__5772.invoke (core.clj:2034)
    clojure.lang.AFn.call (AFn.java:18)
    java.util.concurrent.FutureTask.run (FutureTask.java:264)
    java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1128)
    java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:628)
    java.lang.Thread.run (Thread.java:834)

FAIL in (test-workload-sink-outputs-to-tdr) (v1_endpoint_test.clj:480)
outputs should have been written to the dataset
expected: (seq (:rows (datarepo/query-table dataset "outputs")))
  actual: (not (seq ()))


Ran 33 tests containing 374 assertions.
1 failures, 1 errors.
```