### PR TITLE
[GH-1618] Add workload info to executor logs

### DIFF
--- a/api/src/wfl/service/slack.clj
+++ b/api/src/wfl/service/slack.clj
@@ -94,9 +94,7 @@
   [{:keys [watchers uuid project labels] :as workload} message]
   (let [channels (filter slack-channel-watcher? watchers)
         project  (or project (util/label-value labels "project"))
-        swagger  (str/join "/" [(env/getenv "WFL_WFL_URL") "swagger"])
-        header   (format "%s workload %s *%s*"
-                         (link swagger "WFL") project uuid)]
+        header   (format "WFL workload %s *%s*" project uuid)]
     (letfn [(notify [[_tag channel-id _channel-name]]
               (let [payload {:channel channel-id
                              :message (str/join \newline [header message])}]

--- a/api/test/wfl/integration/executor_test.clj
+++ b/api/test/wfl/integration/executor_test.clj
@@ -454,13 +454,15 @@
       {#'rawls/create-snapshot-reference        throw-if-called
        #'rawls/create-or-get-snapshot-reference mock-rawls-snapshot-reference}
       #(let [executor  (create-terra-executor (rand-int 1000000))
-             reference (#'executor/entity-from-snapshot executor (mock-datarepo-snapshot))]
+             workload  {:uuid (UUID/randomUUID) :executor executor}
+             reference (#'executor/entity-from-snapshot workload (mock-datarepo-snapshot))]
          (is (and (= snapshot-reference-id (get-in reference [:metadata :resourceId]))
                   (= snapshot-name (get-in reference [:metadata :name]))))))))
 
 (deftest test-update-method-configuration-with-version-mismatch
   (let [id                    (rand-int 1000000)
         executor              (create-terra-executor id)
+        workload              {:uuid (UUID/randomUUID) :executor executor}
         dataReferenceNamePre  "snapshotReferenceNamePreUpdate"
         dataReferenceNamePost "snapshotReferenceNamePostUpdate"
         reference             {:metadata {:name dataReferenceNamePost}}
@@ -488,7 +490,7 @@
         {#'firecloud/method-configuration        firecloud-method-configuration
          #'datarepo/snapshot                     mock-datarepo-snapshot
          #'firecloud/update-method-configuration verify-firecloud-update-params}
-        #(#'executor/update-method-configuration! executor reference))
+        #(#'executor/update-method-configuration! workload reference))
       (let [reloaded (reload-terra-executor executor)]
         (is (nil? (:methodConfigurationVersion executor))
             "Method configuration's version in DB should initially be unpopulated")

--- a/api/test/wfl/unit/executor_test.clj
+++ b/api/test/wfl/unit/executor_test.clj
@@ -113,7 +113,7 @@
         (is (nil? (verify-filter-errors-then-throw {:submission submission-valid :status status-valid})))))))
 
 (deftest test-terra-executor-table-from-snapshot-reference
-  (let [executor  {}
+  (let [workload  {}
         reference {:attributes {:snapshot (str (UUID/randomUUID))}}
         table1    "table1"
         table2    "table2"]
@@ -124,15 +124,15 @@
                 {:tables (vec (map table table-names))}))]
       (with-redefs-fn
         {#'datarepo/snapshot (datarepo-snapshot [])}
-        #(is (nil? (#'executor/table-from-snapshot-reference executor reference))
+        #(is (nil? (#'executor/table-from-snapshot-reference workload reference))
              "A snapshot with no table should log error but return nil"))
       (with-redefs-fn
         {#'datarepo/snapshot (datarepo-snapshot [table1])}
-        #(is (= table1 (#'executor/table-from-snapshot-reference executor reference))
+        #(is (= table1 (#'executor/table-from-snapshot-reference workload reference))
              "A snapshot with exactly 1 table should resolve to the table name"))
       (with-redefs-fn
         {#'datarepo/snapshot (datarepo-snapshot [table1 table2])}
-        #(is (nil? (#'executor/table-from-snapshot-reference executor reference))
+        #(is (nil? (#'executor/table-from-snapshot-reference workload reference))
              "A snapshot with more than 1 tables should log error but return nil")))))
 
 (deftest test-notify-on-workflow-completion


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1618

Similar logging treatment as previously applied to staged workload source: https://github.com/broadinstitute/wfl/pull/579

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

`executor.clj`

- Many methods refactored to pass around `workload` which includes `executor`, rather than just the `executor`.
- Where appropriate, logs emitted within this stage are JSON rather than strings and include the workload's log representation.
- Updated automated tests accordingly.

### System Tests

Passed:
```
wm111-e35:wfl okotsopo$ make TARGET=system
…
export CPCACHE=/Users/okotsopo/wfl/api/.cpcache;            \
	export WFL_WFL_URL=http://localhost:3000; \
	clojure  -M:parallel-test wfl.system.v1-endpoint-test | \
	tee /Users/okotsopo/wfl/derived/api/system.log
…
Ran 33 tests containing 374 assertions.
0 failures, 0 errors.
api system finished on Wed Mar 9 16:36:13 EST 2022
docs system finished on Wed Mar 9 16:36:13 EST 2022
functions/aou system finished on Wed Mar 9 16:36:13 EST 2022
functions/sg system finished on Wed Mar 9 16:36:13 EST 2022
helm system finished on Wed Mar 9 16:36:13 EST 2022
ui system finished on Wed Mar 9 16:36:13 EST 2022
```

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

Can run system test off of a local WFL and observe the executor logs:
```
cd path/to/wfl/api;
WFL_WFL_URL=http://localhost:3000 clojure -M:test --focus wfl.system.v1-endpoint-test/test-workload-sink-outputs-to-tdr
```
