### PR TITLE
[GH-1593] Notify Slack watchers on failed TDR snapshot jobs

### DIFF
--- a/api/src/wfl/source.clj
+++ b/api/src/wfl/source.clj
@@ -1,17 +1,18 @@
 (ns wfl.source
-  (:require [clojure.edn           :as edn]
-            [clojure.instant       :as instant]
-            [clojure.spec.alpha    :as s]
-            [clojure.set           :as set]
-            [clojure.string        :as str]
-            [wfl.api.workloads     :refer [defoverload] :as workloads]
-            [wfl.jdbc              :as jdbc]
-            [wfl.log               :as log]
-            [wfl.module.all        :as all]
-            [wfl.service.datarepo  :as datarepo]
-            [wfl.service.postgres  :as postgres]
-            [wfl.stage             :as stage]
-            [wfl.util              :as util])
+  (:require [clojure.edn          :as edn]
+            [clojure.instant      :as instant]
+            [clojure.spec.alpha   :as s]
+            [clojure.set          :as set]
+            [clojure.string       :as str]
+            [wfl.api.workloads    :refer [defoverload] :as workloads]
+            [wfl.jdbc             :as jdbc]
+            [wfl.log              :as log]
+            [wfl.module.all       :as all]
+            [wfl.service.datarepo :as datarepo]
+            [wfl.service.postgres :as postgres]
+            [wfl.service.slack    :as slack]
+            [wfl.stage            :as stage]
+            [wfl.util             :as util])
   (:import [clojure.lang ExceptionInfo]
            [java.sql Timestamp]
            [java.time OffsetDateTime ZoneId]
@@ -240,20 +241,32 @@
         {:status status
          :body   (util/response-body-json data)}))))
 
-(defn ^:private check-tdr-job
+(defn ^:private tdr-job-failed-slack-msg
+  "Return a mrkdwn Slack message to be emitted for failed TDR jobs."
+  [{:keys [id job_status] :as _metadata}
+   {:keys [status body]   :as _caught-job-result}]
+  (str/join \newline
+            [(format "*:sadpanda: Snapshot creation job %s %s*" id job_status)
+             (format "`%s: %s`" status (:message body))]))
+
+(defn ^:private check-tdr-job-and-notify-on-failure
   "Check TDR job status for `job-id` and return job metadata,
-   with snapshot_id attached if the job succeeded."
+   with snapshot_id attached if the job succeeded.
+   Notify `workload` watchers if the job failed."
   [workload job-id]
   (let [{:keys [job_status] :as metadata} (datarepo/job-metadata job-id)
         get-job-result                    #(datarepo/job-result job-id)]
     (case job_status
       "running"   metadata
       "succeeded" (assoc metadata :snapshot_id (:id (get-job-result)))
-      (do (log/warning "TDR job failed or has otherwise unknown status"
-                       :workload   (workloads/to-log workload)
-                       :metadata    metadata
-                       :job-result (result-or-catch get-job-result))
-          metadata))))
+      (let [caught  (result-or-catch get-job-result)
+            message (tdr-job-failed-slack-msg metadata caught)]
+        (log/warning "TDR job failed or has otherwise unknown status"
+                     :workload   (workloads/to-log workload)
+                     :metadata   metadata
+                     :job-result caught)
+        (slack/notify-watchers workload message)
+        metadata))))
 
 (defn ^:private write-snapshot-id
   "Write `snapshot_id` and `job_status` into `source` details table
@@ -324,7 +337,7 @@
   (let [pending-tdr-jobs (get-pending-tdr-jobs workload)]
     (when (seq pending-tdr-jobs)
       (->> pending-tdr-jobs
-           (map #(update % 1 (partial check-tdr-job workload)))
+           (map #(update % 1 (partial check-tdr-job-and-notify-on-failure workload)))
            (run! #(write-snapshot-id workload %)))
       (log/debug "Running snapshot jobs updated."
                  :workload (workloads/to-log workload)))))

--- a/api/test/wfl/integration/modules/staged_test.clj
+++ b/api/test/wfl/integration/modules/staged_test.clj
@@ -219,21 +219,21 @@
     (is (empty? (workloads/workflows workload)))))
 
 (deftest test-workload-state-transition
-  (with-redefs-fn
-    {#'source/find-new-rows                   mock-find-new-rows
-     #'source/create-snapshots                mock-create-snapshots
-     #'source/check-tdr-job                   mock-check-tdr-job
-     #'rawls/create-or-get-snapshot-reference mock-rawls-snapshot-reference
-     #'firecloud/method-configuration         mock-firecloud-get-method-configuration
-     #'firecloud/update-method-configuration  mock-firecloud-update-method-configuration
-     #'firecloud/submit-method                mock-firecloud-create-submission
-     #'firecloud/get-submission               mock-firecloud-get-submission
-     #'firecloud/get-workflow                 mock-workflow-keep-status}
-    #(shared/run-workload-state-transition-test!
-      (workloads/staged-workload-request
-       {:skipValidation true}
-       {:skipValidation true}
-       {:skipValidation true}))))
+  (with-redefs
+   [source/find-new-rows                       mock-find-new-rows
+    source/create-snapshots                    mock-create-snapshots
+    source/check-tdr-job-and-notify-on-failure mock-check-tdr-job
+    rawls/create-or-get-snapshot-reference     mock-rawls-snapshot-reference
+    firecloud/method-configuration             mock-firecloud-get-method-configuration
+    firecloud/update-method-configuration      mock-firecloud-update-method-configuration
+    firecloud/submit-method                    mock-firecloud-create-submission
+    firecloud/get-submission                   mock-firecloud-get-submission
+    firecloud/get-workflow                     mock-workflow-keep-status]
+    (shared/run-workload-state-transition-test!
+     (workloads/staged-workload-request
+      {:skipValidation true}
+      {:skipValidation true}
+      {:skipValidation true}))))
 
 (deftest test-staged-workload-state-transition
   (shared/run-workload-state-transition-test!
@@ -251,20 +251,20 @@
     {:skipValidation true})))
 
 (deftest test-workload-state-transition-with-failed-workflow
-  (with-redefs-fn
-    {#'source/find-new-rows                   mock-find-new-rows
-     #'source/create-snapshots                mock-create-snapshots
-     #'source/check-tdr-job                   mock-check-tdr-job
-     #'rawls/create-or-get-snapshot-reference mock-rawls-snapshot-reference
-     #'firecloud/method-configuration         mock-firecloud-get-method-configuration
-     #'firecloud/update-method-configuration  mock-firecloud-update-method-configuration
-     #'firecloud/submit-method                mock-firecloud-create-submission
-     #'firecloud/get-workflow                 (constantly {:status "Failed"})}
-    #(shared/run-workload-state-transition-test!
-      (workloads/staged-workload-request
-       {:skipValidation true}
-       {:skipValidation true}
-       {:skipValidation true}))))
+  (with-redefs
+   [source/find-new-rows                       mock-find-new-rows
+    source/create-snapshots                    mock-create-snapshots
+    source/check-tdr-job-and-notify-on-failure mock-check-tdr-job
+    rawls/create-or-get-snapshot-reference     mock-rawls-snapshot-reference
+    firecloud/method-configuration             mock-firecloud-get-method-configuration
+    firecloud/update-method-configuration      mock-firecloud-update-method-configuration
+    firecloud/submit-method                    mock-firecloud-create-submission
+    firecloud/get-workflow                     (constantly {:status "Failed"})]
+    (shared/run-workload-state-transition-test!
+     (workloads/staged-workload-request
+      {:skipValidation true}
+      {:skipValidation true}
+      {:skipValidation true}))))
 
 (deftest test-create-workload-coercion
   (let [app     (endpoints/coercion-tester
@@ -289,21 +289,21 @@
            app))))
 
 (deftest test-retry-workload-throws-when-not-started
-  (with-redefs-fn
-    {#'source/find-new-rows                   mock-find-new-rows
-     #'source/create-snapshots                mock-create-snapshots
-     #'source/check-tdr-job                   mock-check-tdr-job
-     #'rawls/create-or-get-snapshot-reference mock-rawls-snapshot-reference
-     #'firecloud/method-configuration         mock-firecloud-get-method-configuration
-     #'firecloud/update-method-configuration  mock-firecloud-update-method-configuration
-     #'firecloud/submit-method                mock-firecloud-create-submission
-     #'firecloud/get-workflow                 (constantly {:status "Failed"})}
-    #(let [workload-request (workloads/staged-workload-request
-                             {:skipValidation true}
-                             {:skipValidation true}
-                             {:skipValidation true})
-           workload         (workloads/create-workload! workload-request)]
-       (is (not (:started workload)))
-       (is (thrown-with-msg?
-            UserException #"Cannot retry workload before it's been started."
-            (workloads/retry workload []))))))
+  (with-redefs
+   [source/find-new-rows                       mock-find-new-rows
+    source/create-snapshots                    mock-create-snapshots
+    source/check-tdr-job-and-notify-on-failure mock-check-tdr-job
+    rawls/create-or-get-snapshot-reference     mock-rawls-snapshot-reference
+    firecloud/method-configuration             mock-firecloud-get-method-configuration
+    firecloud/update-method-configuration      mock-firecloud-update-method-configuration
+    firecloud/submit-method                    mock-firecloud-create-submission
+    firecloud/get-workflow                     (constantly {:status "Failed"})]
+    (let [workload-request (workloads/staged-workload-request
+                            {:skipValidation true}
+                            {:skipValidation true}
+                            {:skipValidation true})
+          workload         (workloads/create-workload! workload-request)]
+      (is (not (:started workload)))
+      (is (thrown-with-msg?
+           UserException #"Cannot retry workload before it's been started."
+           (workloads/retry workload []))))))

--- a/docs/md/staged-workload.md
+++ b/docs/md/staged-workload.md
@@ -112,14 +112,15 @@ of your channel's "Get channel details" dropdown:
 - Ex. Issues accessing TDR dataset, snapshot, etc.
 
 **Notable state changes**
-- Ex. Workflow has completed
+- TDR snapshot creation job failed
+- Terra workflow has completed
 
 ![](assets/staged-workload/workflow-finished-notifications.png)
 
 In the future, WFL may allow for these two notification streams
 to be configured separately.
 High-volume use cases (ex. 100s of workflows/day) may find
-state change notifications too noisy.
+some state change notifications too noisy.
 
 ### Prerequisites
 


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1593

Staged workloads with `TerraDataRepoSource` snapshot new rows as they land in TDR.  If/when the snapshot job succeeds, the associated snapshot is eligible for a consumption by a downstream stage (ex. imported to a Terra workspace as a snapshot reference and submitted).

We've seen a few flavors of snapshot creation job failure over the past few months of running staged workloads:

1. Transient issues: rows which failed to snapshot are picked up on subsequent snapshot attempts, capped at 2 hours from row discovery.  No manual intervention needed.
2. Dataset and/or billing profile permissions issues: most common for new workloads and projects.  Appropriate `workflow-launcher` Firecloud group must be granted appropriate resource permissions for snapshotting to be picked up.  (As an aside, maybe these permissions are something we could check for when validating the `TerraDataRepoSource` request, but that's outside the scope of this ticket.)
3. Persistent issue TDR-side: as an example, a past TDR permission change broke snapshotting and we needed them to remediate ([Slack](https://broadinstitute.slack.com/archives/CD4HBRFMG/p1639153492303600)).

Prompt discovery of these issues (especially 2 and 3) make it more likely that they'll be corrected within the 2 hour window of WFL's automatic retry.  To get this information, I've previously created GCP Stackdriver alerts and looked at WFL logs.

In this PR I call the Slacker directly when we've registered that an active TDR snapshot creation job has failed or reached some unknown state.  The messages emitted reflect feedback from key stakeholders and Jade team re: what info would help them, and include:

- Snapshot job ID
- The snapshot job result's error code and message

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Call the Slack notifier when we register that an active TDR snapshot creation job has failed
- Update public-facing docs
- In test files that I touched, converted `with-redefs-fn` -> `with-redefs` for better readability

### Manual Verification

Here's some scratch code I ran in `wfl.source` to generate Slack notifications for a [past failed snapshot creation job](https://broadinstitute.slack.com/archives/C031GKEHCKF/p1643922140903049):

```
  (let [workload {:watchers [["slack" "C026PTM4XPA" "#hornet-slack-app-testing"]]
                  :uuid     "12c92a7c-79ac-4b0d-9617-b7cc48277459"
                  :project  "test-notify-on-failed-snapshot-job"}
        job-id   "hzycMuapS2GW2eUpt_uH-w"]
    (slack/start-notification-loop)
    (check-tdr-job-and-notify-on-failure workload job-id)) 
```

And the result:

<img width="862" alt="Screen Shot 2022-03-10 at 12 37 43 PM" src="https://user-images.githubusercontent.com/79769153/157722360-65807dd6-bdcc-40a4-999e-a33bfcc6c2ea.png">

https://broadinstitute.slack.com/archives/C026PTM4XPA/p1646931430498359


### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->


