### PR TITLE
[GH-1592] Notify Slack watchers on Terra submission creation

### DIFF
--- a/api/src/wfl/service/datarepo.clj
+++ b/api/src/wfl/service/datarepo.clj
@@ -236,6 +236,11 @@
                    :query-params {:include include}})
         util/response-body-json)))
 
+(defn snapshot-url
+  "Return a link to `snapshot` in TDR UI."
+  [{:keys [id] :as _snapshot}]
+  (datarepo-url "snapshots/details" id))
+
 (defn delete-dataset-snapshots
   "Delete snapshots on dataset with `dataset-id`."
   [dataset-id]

--- a/api/src/wfl/service/firecloud.clj
+++ b/api/src/wfl/service/firecloud.clj
@@ -17,11 +17,21 @@
   (let [url (util/de-slashify (env/getenv "WFL_TERRA_URL"))]
     (str/join "/" (cons url parts))))
 
+(defn submission-url
+  "Return a link to `submission` job history in Terra UI."
+  [submission workspace]
+  (terra-ui-url "#workspaces" workspace "job_history" submission))
+
 (defn job-manager-ui-url
   "Return a link within the Terra Job Manager UI constructed from `parts`."
   [& parts]
   (let [url (util/de-slashify (env/getenv "WFL_TERRA_JOB_MANAGER_URL"))]
     (str/join "/" (cons url parts))))
+
+(defn workflow-url
+  "Return a link to `workflow` in Job Manager UI."
+  [workflow]
+  (job-manager-ui-url "jobs" workflow))
 
 (defn ^:private firecloud-url [& parts]
   (let [url (util/de-slashify (env/getenv "WFL_FIRECLOUD_URL"))]

--- a/api/test/wfl/integration/executor_test.clj
+++ b/api/test/wfl/integration/executor_test.clj
@@ -231,16 +231,16 @@
                   "The record ID was incorrect given the workflow order in mocked submission")
               (is (= (:workflowId workflow) (:workflow record))
                   "The workflow ID was incorrect and should match corresponding record"))]
-      (with-redefs-fn
-        {#'rawls/create-or-get-snapshot-reference mock-rawls-snapshot-reference
-         #'firecloud/method-configuration         mock-firecloud-get-method-configuration-init
-         #'datarepo/snapshot                      mock-datarepo-snapshot
-         #'firecloud/update-method-configuration  mock-firecloud-update-method-configuration-init
-         #'firecloud/submit-method                (mock-firecloud-create-submission init-submission-id)
-         #'firecloud/get-submission               mock-firecloud-get-submission
-         #'firecloud/get-workflow                 mock-firecloud-get-running-workflow-update-status
-         #'workloads/load-workload-for-uuid       (mock-load-workload-for-uuid source executor)}
-        #(executor/update-executor! workload))
+      (with-redefs
+       [rawls/create-or-get-snapshot-reference mock-rawls-snapshot-reference
+        firecloud/method-configuration         mock-firecloud-get-method-configuration-init
+        datarepo/snapshot                      mock-datarepo-snapshot
+        firecloud/update-method-configuration  mock-firecloud-update-method-configuration-init
+        firecloud/submit-method                (mock-firecloud-create-submission init-submission-id)
+        firecloud/get-submission               mock-firecloud-get-submission
+        firecloud/get-workflow                 mock-firecloud-get-running-workflow-update-status
+        workloads/load-workload-for-uuid       (mock-load-workload-for-uuid source executor)]
+        (executor/update-executor! workload))
       (is (zero? (stage/queue-length source)) "The snapshot was not consumed.")
       (is (== 2 (stage/queue-length executor)) "Two workflows should be enqueued")
       (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
@@ -272,171 +272,166 @@
         executor      (create-terra-executor (rand-int 1000000))
         workload-uuid (UUID/randomUUID)
         workload      {:uuid workload-uuid :source source :executor executor}]
-    (with-redefs-fn
-      {#'rawls/create-or-get-snapshot-reference mock-rawls-snapshot-reference
-       #'firecloud/method-configuration         mock-firecloud-get-method-configuration-init
-       #'datarepo/snapshot                      mock-datarepo-snapshot
-       #'firecloud/update-method-configuration  mock-firecloud-update-method-configuration-init
-       #'firecloud/submit-method                (mock-firecloud-create-submission init-submission-id)
-       #'firecloud/get-submission               mock-firecloud-get-submission
-       #'firecloud/get-workflow                 mock-firecloud-get-known-workflow
-       #'workloads/load-workload-for-uuid       (mock-load-workload-for-uuid source executor)}
-      #(executor/update-executor! workload))
-    (with-redefs-fn
-      {#'executor/describe-method       (constantly nil)
-       #'firecloud/get-workflow         mock-firecloud-get-known-workflow
-       #'firecloud/get-workflow-outputs mock-firecloud-get-workflow-outputs}
-      #(let [[_ workflow] (stage/peek-queue executor)
-             succeeded-workflow-id
-             (get-in submission-base [init-submission-id :succeeded :workflow-id])]
-         (is (succeeded? (:status workflow)))
-         (is (= succeeded-workflow-id (:uuid workflow)))
-         (is (contains? workflow :updated))
-         (is (= "value" (-> workflow :inputs :input)))
-         (is (= "value" (-> workflow :outputs :output)))
-         (is (not (-> workflow :outputs :noise)))
-         (stage/pop-queue! executor)
-         (is (nil? (stage/peek-queue executor)))
-         (is (== 1 (stage/queue-length executor)))
-         (is (not (stage/done? executor)))))))
+    (with-redefs
+     [rawls/create-or-get-snapshot-reference mock-rawls-snapshot-reference
+      firecloud/method-configuration         mock-firecloud-get-method-configuration-init
+      datarepo/snapshot                      mock-datarepo-snapshot
+      firecloud/update-method-configuration  mock-firecloud-update-method-configuration-init
+      firecloud/submit-method                (mock-firecloud-create-submission init-submission-id)
+      firecloud/get-submission               mock-firecloud-get-submission
+      firecloud/get-workflow                 mock-firecloud-get-known-workflow
+      firecloud/get-workflow-outputs         mock-firecloud-get-workflow-outputs
+      workloads/load-workload-for-uuid       (mock-load-workload-for-uuid source executor)
+      executor/describe-method               (constantly nil)]
+      (executor/update-executor! workload)
+      (let [[_ workflow] (stage/peek-queue executor)
+            succeeded-workflow-id
+            (get-in submission-base [init-submission-id :succeeded :workflow-id])]
+        (is (succeeded? (:status workflow)))
+        (is (= succeeded-workflow-id (:uuid workflow)))
+        (is (contains? workflow :updated))
+        (is (= "value" (-> workflow :inputs :input)))
+        (is (= "value" (-> workflow :outputs :output)))
+        (is (not (-> workflow :outputs :noise)))
+        (stage/pop-queue! executor)
+        (is (nil? (stage/peek-queue executor)))
+        (is (== 1 (stage/queue-length executor)))
+        (is (not (stage/done? executor)))))))
 
 (deftest test-terra-executor-retry-workflows
   (let [source        (make-queue-from-list [[:datarepo/snapshot (mock-datarepo-snapshot)]])
         executor      (create-terra-executor (rand-int 1000000))
         workload-uuid (UUID/randomUUID)
         workload      {:uuid workload-uuid :source source :executor executor}]
-    (with-redefs-fn
-      {#'rawls/create-or-get-snapshot-reference mock-rawls-snapshot-reference
-       #'firecloud/method-configuration         mock-firecloud-get-method-configuration-init
-       #'datarepo/snapshot                      mock-datarepo-snapshot
-       #'firecloud/update-method-configuration  mock-firecloud-update-method-configuration-init
-       #'firecloud/submit-method                (mock-firecloud-create-submission init-submission-id)
-       #'firecloud/get-submission               mock-firecloud-get-submission
-       #'firecloud/get-workflow                 mock-firecloud-get-known-workflow
-       #'workloads/load-workload-for-uuid       (mock-load-workload-for-uuid source executor)}
-      #(executor/update-executor! workload))
-    (is (zero? (stage/queue-length source)) "The snapshot was not consumed.")
-    (is (== 2 (stage/queue-length executor))
-        "Two workflows should be enqueued prior to retry.")
-    (let [executor           (reload-terra-executor executor)
-          workload-uuid        (UUID/randomUUID)
-          workload             {:uuid workload-uuid :source source :executor executor}]
-      (is (== 2 (:methodConfigurationVersion executor))
-          "Reloaded executor's method config should have version 2 post-update.")
-      (with-redefs-fn
-        {#'rawls/get-snapshot-reference           mock-rawls-snapshot-reference
-         #'firecloud/method-configuration         mock-firecloud-get-method-configuration-post-update
-         #'datarepo/snapshot                      mock-datarepo-snapshot
-         #'firecloud/update-method-configuration  mock-firecloud-update-method-configuration-post-update
-         #'firecloud/submit-method                (mock-firecloud-create-submission retry-submission-id)
-         #'firecloud/get-submission               mock-firecloud-get-submission
-         #'firecloud/get-workflow                 mock-firecloud-get-known-workflow}
-        #(let [workflows-to-retry
-               (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
-                 (executor/executor-workflows tx executor {:status "Running"}))]
-           (is (== 1 (count workflows-to-retry))
-               "Should have one running workflow to retry.")
-           (executor/executor-retry-workflows! workload workflows-to-retry)))
-      ;; We only specify 1 workflow to retry,
-      ;; but must retry both workflows from its submission.
-      (is (== 4 (stage/queue-length executor))
-          "Four workflows should be enqueued following retry.")
-      (let [[running succeeded retry-running retry-succeeded & _ :as records]
-            (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
-              (->> executor :details (postgres/get-table tx) (sort-by :id)))
-            executor-record
-            (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
-              (#'postgres/load-record-by-id! tx "TerraExecutor" (:id executor)))
-            compare-original-with-retry
-            (fn [original retry status-kw]
-              (is (= (:retry original) (:id retry))
-                  (str status-kw " - original record should be linked to its retry."))
-              (is (= init-submission-id (:submission original))
-                  (str status-kw " - original record has incorrect submission id."))
-              (is (= retry-submission-id (:submission retry))
-                  (str status-kw " - retry record has incorrect submission id."))
-              (is (= (get-in submission-base [init-submission-id
-                                              status-kw
-                                              :workflow-id])
-                     (:workflow original))
-                  (str status-kw " - original record has incorrect workflow id."))
-              (is (nil? (:workflow retry))
-                  (str status-kw " - retry record should not have workflow id "
-                       "populated prior to update loop."))
-              (is (every? #(= (get-in submission-base [init-submission-id
-                                                       status-kw
-                                                       :entity])
-                              (:entity %)) [original retry])
-                  (str status-kw " - original record should have "
-                       "same entity as its retry.")))]
-        (is (== 4 (count records))
-            "Exactly 4 workflows should be visible in the database")
-        (is (every? #(= snapshot-reference-id (:reference %)) records)
-            "The snapshot reference ID was incorrect and should match all records")
-        (compare-original-with-retry running retry-running :running)
-        (compare-original-with-retry succeeded retry-succeeded :succeeded)
-        (is (== (inc method-config-version-post-update) (:method_configuration_version executor-record))
-            "Method configuration version was not incremented.")))))
+    (with-redefs
+     [rawls/create-or-get-snapshot-reference mock-rawls-snapshot-reference
+      firecloud/method-configuration         mock-firecloud-get-method-configuration-init
+      datarepo/snapshot                      mock-datarepo-snapshot
+      firecloud/update-method-configuration  mock-firecloud-update-method-configuration-init
+      firecloud/submit-method                (mock-firecloud-create-submission init-submission-id)
+      firecloud/get-submission               mock-firecloud-get-submission
+      firecloud/get-workflow                 mock-firecloud-get-known-workflow
+      workloads/load-workload-for-uuid       (mock-load-workload-for-uuid source executor)]
+      (executor/update-executor! workload)
+      (is (zero? (stage/queue-length source)) "The snapshot was not consumed.")
+      (is (== 2 (stage/queue-length executor))
+          "Two workflows should be enqueued prior to retry.")
+      (let [executor      (reload-terra-executor executor)
+            workload-uuid (UUID/randomUUID)
+            workload      {:uuid workload-uuid :source source :executor executor}]
+        (is (== 2 (:methodConfigurationVersion executor))
+            "Reloaded executor's method config should have version 2 post-update.")
+        (with-redefs
+         [rawls/get-snapshot-reference           mock-rawls-snapshot-reference
+          firecloud/method-configuration         mock-firecloud-get-method-configuration-post-update
+          firecloud/update-method-configuration  mock-firecloud-update-method-configuration-post-update
+          firecloud/submit-method                (mock-firecloud-create-submission retry-submission-id)]
+          (let [workflows-to-retry
+                (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+                  (executor/executor-workflows tx executor {:status "Running"}))]
+            (is (== 1 (count workflows-to-retry))
+                "Should have one running workflow to retry.")
+            (executor/executor-retry-workflows! workload workflows-to-retry))
+          ;; We only specify 1 workflow to retry,
+          ;; but must retry both workflows from its submission.
+          (is (== 4 (stage/queue-length executor))
+              "Four workflows should be enqueued following retry.")
+          (let [[running succeeded retry-running retry-succeeded & _ :as records]
+                (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+                  (->> executor :details (postgres/get-table tx) (sort-by :id)))
+                executor-record
+                (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+                  (#'postgres/load-record-by-id! tx "TerraExecutor" (:id executor)))
+                compare-original-with-retry
+                (fn [original retry status-kw]
+                  (is (= (:retry original) (:id retry))
+                      (str status-kw " - original record should be linked to its retry."))
+                  (is (= init-submission-id (:submission original))
+                      (str status-kw " - original record has incorrect submission id."))
+                  (is (= retry-submission-id (:submission retry))
+                      (str status-kw " - retry record has incorrect submission id."))
+                  (is (= (get-in submission-base [init-submission-id
+                                                  status-kw
+                                                  :workflow-id])
+                         (:workflow original))
+                      (str status-kw " - original record has incorrect workflow id."))
+                  (is (nil? (:workflow retry))
+                      (str status-kw " - retry record should not have workflow id "
+                           "populated prior to update loop."))
+                  (is (every? #(= (get-in submission-base [init-submission-id
+                                                           status-kw
+                                                           :entity])
+                                  (:entity %)) [original retry])
+                      (str status-kw " - original record should have "
+                           "same entity as its retry.")))]
+            (is (== 4 (count records))
+                "Exactly 4 workflows should be visible in the database")
+            (is (every? #(= snapshot-reference-id (:reference %)) records)
+                "The snapshot reference ID was incorrect and should match all records")
+            (compare-original-with-retry running retry-running :running)
+            (compare-original-with-retry succeeded retry-succeeded :succeeded)
+            (is (== (inc method-config-version-post-update) (:method_configuration_version executor-record))
+                "Method configuration version was not incremented.")))))))
 
 (deftest test-terra-executor-get-retried-workflows
-  (with-redefs-fn
-    {#'rawls/create-or-get-snapshot-reference mock-rawls-snapshot-reference
-     #'firecloud/method-configuration         mock-firecloud-get-method-configuration-init
-     #'datarepo/snapshot                      mock-datarepo-snapshot
-     #'firecloud/update-method-configuration  mock-firecloud-update-method-configuration-init
-     #'firecloud/submit-method                (mock-firecloud-create-submission init-submission-id)
-     #'firecloud/get-submission               mock-firecloud-get-submission
-     #'firecloud/get-workflow                 mock-firecloud-get-known-workflow
-     #'firecloud/get-workflow-outputs         mock-firecloud-get-workflow-outputs}
-    #(let [source        (make-queue-from-list [[:datarepo/snapshot (mock-datarepo-snapshot)]])
-           executor      (create-terra-executor (rand-int 1000000))
-           workload-uuid (UUID/randomUUID)
-           workload      {:uuid workload-uuid :source source :executor executor}]
-       (with-redefs-fn
-         {#'workloads/load-workload-for-uuid (mock-load-workload-for-uuid source executor)}
-         (fn [] (executor/update-executor! workload)))
-       (is (== 2 (stage/queue-length executor)))
-       (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
-         (jdbc/update! tx (:details executor) {:retry 2} ["id = ?" 1]))
-       (is (== 2 (stage/queue-length executor))
-           "The retried workflow should remain visible downstream")
-       (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
-         (is (== 1 (count (executor/executor-workflows tx executor {})))
-             "The retried workflow should not be returned")))))
+  (with-redefs
+   [rawls/create-or-get-snapshot-reference mock-rawls-snapshot-reference
+    firecloud/method-configuration         mock-firecloud-get-method-configuration-init
+    datarepo/snapshot                      mock-datarepo-snapshot
+    firecloud/update-method-configuration  mock-firecloud-update-method-configuration-init
+    firecloud/submit-method                (mock-firecloud-create-submission init-submission-id)
+    firecloud/get-submission               mock-firecloud-get-submission
+    firecloud/get-workflow                 mock-firecloud-get-known-workflow
+    firecloud/get-workflow-outputs         mock-firecloud-get-workflow-outputs]
+    (let [source        (make-queue-from-list [[:datarepo/snapshot (mock-datarepo-snapshot)]])
+          executor      (create-terra-executor (rand-int 1000000))
+          workload-uuid (UUID/randomUUID)
+          workload      {:uuid workload-uuid :source source :executor executor}]
+      (with-redefs
+       [workloads/load-workload-for-uuid (mock-load-workload-for-uuid source executor)]
+        (executor/update-executor! workload))
+      (is (== 2 (stage/queue-length executor)))
+      (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+        (jdbc/update! tx (:details executor) {:retry 2} ["id = ?" 1]))
+      (is (== 2 (stage/queue-length executor))
+          "The retried workflow should remain visible downstream")
+      (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+        (is (== 1 (count (executor/executor-workflows tx executor {})))
+            "The retried workflow should not be returned")))))
 
 (deftest test-terra-executor-queue-length
-  (with-redefs-fn
-    {#'rawls/create-or-get-snapshot-reference mock-rawls-snapshot-reference
-     #'firecloud/method-configuration         mock-firecloud-get-method-configuration-init
-     #'datarepo/snapshot                      mock-datarepo-snapshot
-     #'firecloud/update-method-configuration  mock-firecloud-update-method-configuration-init
-     #'firecloud/submit-method                (mock-firecloud-create-submission init-submission-id)
-     #'firecloud/get-submission               mock-firecloud-get-submission
-     #'firecloud/get-workflow                 mock-firecloud-get-known-workflow
-     #'firecloud/get-workflow-outputs         mock-firecloud-get-workflow-outputs}
-    #(let [source                (make-queue-from-list [[:datarepo/snapshot (mock-datarepo-snapshot)]])
-           executor              (create-terra-executor (rand-int 1000000))
-           workload-uuid         (UUID/randomUUID)
-           workload              {:uuid workload-uuid :source source :executor executor}]
-       (with-redefs-fn
-         {#'workloads/load-workload-for-uuid (mock-load-workload-for-uuid source executor)}
-         (fn [] (executor/update-executor! workload)))
-       (let [record                (#'executor/peek-terra-executor-details executor)
-             succeeded-workflow-id (get-in submission-base [init-submission-id :succeeded :workflow-id])]
-         (is (= succeeded-workflow-id (:workflow record))
-             "Peeked record's workflow uuid should match succeeded workflow's")
-         (is (= "Succeeded" (:status record))
-             "Peeked record's status should match succeeded workflow's")
-         (is (== 2 (stage/queue-length executor))
-             "Both running and succeeded workflows in submission should be counted in queue length")
-         (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
-           (jdbc/update! tx (:details executor) {:status nil} ["id = ?" (:id record)]))
-         (is (== 2 (stage/queue-length executor))
-             "Workflows without status should be counted in queue length")
-         (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
-           (jdbc/update! tx (:details executor) {:workflow nil} ["id = ?" (:id record)]))
-         (is (== 2 (stage/queue-length executor))
-             "Workflows without status or uuid should be counted in queue length")))))
+  (with-redefs
+   [rawls/create-or-get-snapshot-reference mock-rawls-snapshot-reference
+    firecloud/method-configuration         mock-firecloud-get-method-configuration-init
+    datarepo/snapshot                      mock-datarepo-snapshot
+    firecloud/update-method-configuration  mock-firecloud-update-method-configuration-init
+    firecloud/submit-method                (mock-firecloud-create-submission init-submission-id)
+    firecloud/get-submission               mock-firecloud-get-submission
+    firecloud/get-workflow                 mock-firecloud-get-known-workflow
+    firecloud/get-workflow-outputs         mock-firecloud-get-workflow-outputs]
+    (let [source                (make-queue-from-list [[:datarepo/snapshot (mock-datarepo-snapshot)]])
+          executor              (create-terra-executor (rand-int 1000000))
+          workload-uuid         (UUID/randomUUID)
+          workload              {:uuid workload-uuid :source source :executor executor}]
+      (with-redefs
+       [workloads/load-workload-for-uuid (mock-load-workload-for-uuid source executor)]
+        (executor/update-executor! workload))
+      (let [record                (#'executor/peek-terra-executor-details executor)
+            succeeded-workflow-id (get-in submission-base [init-submission-id :succeeded :workflow-id])]
+        (is (= succeeded-workflow-id (:workflow record))
+            "Peeked record's workflow uuid should match succeeded workflow's")
+        (is (= "Succeeded" (:status record))
+            "Peeked record's status should match succeeded workflow's")
+        (is (== 2 (stage/queue-length executor))
+            "Both running and succeeded workflows in submission should be counted in queue length")
+        (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+          (jdbc/update! tx (:details executor) {:status nil} ["id = ?" (:id record)]))
+        (is (== 2 (stage/queue-length executor))
+            "Workflows without status should be counted in queue length")
+        (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+          (jdbc/update! tx (:details executor) {:workflow nil} ["id = ?" (:id record)]))
+        (is (== 2 (stage/queue-length executor))
+            "Workflows without status or uuid should be counted in queue length")))))
 
 (deftest test-terra-executor-describe-method
   (let [description (executor/describe-method
@@ -450,14 +445,14 @@
             (throw (ex-info (str "rawls/create-snapshot-reference "
                                  "should not have been called directly")
                             {:called-with args})))]
-    (with-redefs-fn
-      {#'rawls/create-snapshot-reference        throw-if-called
-       #'rawls/create-or-get-snapshot-reference mock-rawls-snapshot-reference}
-      #(let [executor  (create-terra-executor (rand-int 1000000))
-             workload  {:uuid (UUID/randomUUID) :executor executor}
-             reference (#'executor/entity-from-snapshot workload (mock-datarepo-snapshot))]
-         (is (and (= snapshot-reference-id (get-in reference [:metadata :resourceId]))
-                  (= snapshot-name (get-in reference [:metadata :name]))))))))
+    (with-redefs
+     [rawls/create-snapshot-reference        throw-if-called
+      rawls/create-or-get-snapshot-reference mock-rawls-snapshot-reference]
+      (let [executor  (create-terra-executor (rand-int 1000000))
+            workload  {:uuid (UUID/randomUUID) :executor executor}
+            reference (#'executor/entity-from-snapshot workload (mock-datarepo-snapshot))]
+        (is (= snapshot-reference-id (get-in reference [:metadata :resourceId])))
+        (is (= snapshot-name (get-in reference [:metadata :name])))))))
 
 (deftest test-update-method-configuration-with-version-mismatch
   (let [id                    (rand-int 1000000)
@@ -486,11 +481,11 @@
                   "Method configuration's actual version should be incremented")
               (is (= snapshot-table-name (:rootEntityType mc))
                   "Method configuration root entity type should be snapshot's table name"))]
-      (with-redefs-fn
-        {#'firecloud/method-configuration        firecloud-method-configuration
-         #'datarepo/snapshot                     mock-datarepo-snapshot
-         #'firecloud/update-method-configuration verify-firecloud-update-params}
-        #(#'executor/update-method-configuration! workload reference))
+      (with-redefs
+       [firecloud/method-configuration        firecloud-method-configuration
+        firecloud/update-method-configuration verify-firecloud-update-params]
+        (#'executor/update-method-configuration!
+         workload reference (mock-datarepo-snapshot)))
       (let [reloaded (reload-terra-executor executor)]
         (is (nil? (:methodConfigurationVersion executor))
             "Method configuration's version in DB should initially be unpopulated")

--- a/api/test/wfl/unit/executor_test.clj
+++ b/api/test/wfl/unit/executor_test.clj
@@ -2,16 +2,15 @@
   (:require [clojure.test         :refer [deftest is testing]]
             [wfl.executor         :as executor]
             [wfl.service.cromwell :as cromwell]
-            [wfl.service.datarepo :as datarepo]
             [wfl.service.slack    :as slack])
   (:import [java.util UUID]
            [wfl.util UserException]))
 
 (deftest test-terra-executor-workflows-sql-params
-  (let [executor   {:details "TerraExecutor_00000001"}
+  (let [executor {:details "TerraExecutor_00000001"}
         submission (str (UUID/randomUUID))
-        status     "Failed"
-        filters    {:submission submission :status status}]
+        status "Failed"
+        filters {:submission submission :status status}]
     (letfn [(arg-count [sql] (-> sql frequencies (get \? 0)))]
       (testing "No filters"
         (let [[sql & params] (#'executor/terra-executor-workflows-sql-params
@@ -69,12 +68,12 @@
         "No error expected for retriable Cromwell status")))
 
 (deftest test-terra-executor-throw-if-invalid-retry-filters
-  (let [workload-uuid      (str (UUID/randomUUID))
-        workload           {:uuid workload-uuid}
-        submission-valid   (str (UUID/randomUUID))
+  (let [workload-uuid (str (UUID/randomUUID))
+        workload {:uuid workload-uuid}
+        submission-valid (str (UUID/randomUUID))
         submission-invalid nil
-        status-valid       "Failed"
-        status-invalid     "Running"]
+        status-valid "Failed"
+        status-invalid "Running"]
     (letfn [(verify-submission-error
               [{:keys [validation-errors] :as _ex-data}]
               (is (some #(= executor/retry-invalid-submission-error-message %)
@@ -112,28 +111,23 @@
       (testing "Valid filter combination should not throw"
         (is (nil? (verify-filter-errors-then-throw {:submission submission-valid :status status-valid})))))))
 
-(deftest test-terra-executor-table-from-snapshot-reference
-  (let [workload  {}
-        reference {:attributes {:snapshot (str (UUID/randomUUID))}}
-        table1    "table1"
-        table2    "table2"]
+(deftest test-terra-executor-table-from-snapshot
+  (let [workload {}
+        table1   "table1"
+        table2   "table2"]
     (letfn [(table [table-name]
               {:name table-name})
             (datarepo-snapshot [table-names]
-              (fn [_snapshot-id]
-                {:tables (vec (map table table-names))}))]
-      (with-redefs-fn
-        {#'datarepo/snapshot (datarepo-snapshot [])}
-        #(is (nil? (#'executor/table-from-snapshot-reference workload reference))
-             "A snapshot with no table should log error but return nil"))
-      (with-redefs-fn
-        {#'datarepo/snapshot (datarepo-snapshot [table1])}
-        #(is (= table1 (#'executor/table-from-snapshot-reference workload reference))
-             "A snapshot with exactly 1 table should resolve to the table name"))
-      (with-redefs-fn
-        {#'datarepo/snapshot (datarepo-snapshot [table1 table2])}
-        #(is (nil? (#'executor/table-from-snapshot-reference workload reference))
-             "A snapshot with more than 1 tables should log error but return nil")))))
+              {:tables (vec (map table table-names))})]
+      (let [snapshot (datarepo-snapshot [])]
+        (is (nil? (#'executor/table-from-snapshot workload snapshot))
+            "A snapshot with no table should log error but return nil"))
+      (let [snapshot (datarepo-snapshot [table1])]
+        (is (= table1 (#'executor/table-from-snapshot workload snapshot))
+            "A snapshot with 1 table should resolve to the table name"))
+      (let [snapshot (datarepo-snapshot [table1 table2])]
+        (is (nil? (#'executor/table-from-snapshot workload snapshot))
+            "A snapshot with >1 tables should log error but return nil")))))
 
 (deftest test-notify-on-workflow-completion
   (let [records [{:status "Running"}
@@ -144,8 +138,8 @@
               [_executor {:keys [status] :as _record}]
               (is (cromwell/final? status)
                   "Should not notify for non-final workflows"))]
-      (with-redefs-fn
-        {#'executor/workflow-finished-slack-msg mock-workflow-finished-slack-msg
-         #'slack/notify-watchers                (constantly nil)}
-        #(is (= records (#'executor/notify-on-workflow-completion workload records))
-             "Should return all passed-in records")))))
+      (with-redefs
+       [executor/workflow-finished-slack-msg mock-workflow-finished-slack-msg
+        slack/notify-watchers                (constantly nil)]
+        (is (= records (#'executor/notify-on-workflow-completion workload records))
+            "Should return all passed-in records")))))

--- a/docs/md/staged-workload.md
+++ b/docs/md/staged-workload.md
@@ -113,6 +113,7 @@ of your channel's "Get channel details" dropdown:
 
 **Notable state changes**
 - TDR snapshot creation job failed
+- Terra submission created
 - Terra workflow has completed
 
 ![](assets/staged-workload/workflow-finished-notifications.png)


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1592

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- No changes.

### Manual Verification

The system test `wfl.system.v1-endpoint-test/test-workload-sink-outputs-to-tdr` generates a Slack notification when it creates its submission, but its links break when the test cleans up its temporary resources:

https://broadinstitute.slack.com/archives/C026PTM4XPA/p1647364194127229

I launched a workload off of a local WFL with a fixed snapshot:

```
{
  "project": "wfl-dev/CDC_Viral_Sequencing_okotsopo_GH-1592",
  "labels": [
    "hornet:test"
  ],
  "watchers": [
    ["slack", "C026PTM4XPA", "#hornet-slack-app-testing"]
  ],
  "source": {
    "name": "TDR Snapshots",
    "snapshots": ["7c70fb93-34df-49c9-8ef7-26f03fe48816"]
  },
  "executor": {
    "name": "Terra",
    "workspace": "wfl-dev/CDC_Viral_Sequencing_okotsopo_GH-1592",
    "methodConfiguration": "wfl-dev/sarscov2_illumina_full",
    "fromSource": "importSnapshot"
  },
  "sink": {
    "name": "Terra Workspace",
    "workspace": "wfl-dev/CDC_Viral_Sequencing_okotsopo_GH-1592",
    "entityType": "flowcell",
  "fromOutputs": {
…
    },
  "identifier": "run_id",
    "skipValidation": true
  }
}
```

Saw the submission launch Slack message for the [original submission](https://broadinstitute.slack.com/archives/C026PTM4XPA/p1647284942017229) as well as its [retry](https://broadinstitute.slack.com/archives/C026PTM4XPA/p1647285064312919).  The links in these messages work since the snapshot and workspace were not deleted, I clicked through them and confirmed that they work.

### System Tests

Passed:

```
wm111-e35:wfl okotsopo$ make TARGET=system
export CPCACHE=/Users/okotsopo/wfl/api/.cpcache;            \
	export WFL_WFL_URL=http://localhost:3000; \
	clojure  -M:parallel-test wfl.system.v1-endpoint-test | \
	tee /Users/okotsopo/wfl/derived/api/system.log
WARNING: Specified path is external to project: ../derived/api/src
WARNING: Specified path is external to project: ../derived/api/resources

Ran 33 tests containing 374 assertions.
0 failures, 0 errors.
api system finished on Tue Mar 15 13:20:09 EDT 2022
docs system finished on Tue Mar 15 13:20:10 EDT 2022
functions/aou system finished on Tue Mar 15 13:20:10 EDT 2022
functions/sg system finished on Tue Mar 15 13:20:10 EDT 2022
helm system finished on Tue Mar 15 13:20:10 EDT 2022
ui system finished on Tue Mar 15 13:20:10 EDT 2022
```

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
