### PR TITLE
[GH-1638] Disable link unfurling when Slacking watchers

### DIFF
--- a/api/src/wfl/service/slack.clj
+++ b/api/src/wfl/service/slack.clj
@@ -32,10 +32,13 @@
 ;; https://api.slack.com/methods/chat.postMessage#errors
 ;;
 (defn ^:private post-message
-  "Post `message` to `channel`."
+  "Post `message` to `channel` with link unfurling disabled."
   [channel message]
   (let [headers {:Authorization (str "Bearer " (env/getenv "WFL_SLACK_TOKEN"))}
-        body    (json/write-str {:channel channel :text message})]
+        body    (json/write-str {:channel      channel
+                                 :text         message
+                                 :unfurl_links false
+                                 :unfurl_media false})]
     (-> "https://slack.com/api/chat.postMessage"
         (http/post {:headers      headers
                     :content-type :application/json


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1638

@schaluva 's feedback on Slack notifications for Terra submission creation is that the TDR preview adds clutter.  I agree!

<img width="775" alt="Screen Shot 2022-03-22 at 3 12 45 PM" src="https://user-images.githubusercontent.com/79769153/159558125-6aebfb88-2102-448a-acea-4bfe7265d463.png">

So, I changed the Slacker to disable all manner of link previews.  More info: https://api.slack.com/reference/messaging/link-unfurling

<img width="787" alt="Screen Shot 2022-03-22 at 3 12 55 PM" src="https://user-images.githubusercontent.com/79769153/159559369-199ddc50-c809-4850-ba65-c91cd0e1c412.png">

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

If you'd like, you can try the following off of a local WFL:

```
cd /path/to/wfl/api
WFL_WFL_URL=http://localhost:3000 \
  clojure -M:test --focus \
  wfl.system.v1-endpoint-test/test-workload-sink-outputs-to-tdr
```

I did this, the test passed:
```
--- system (clojure.test) ---------------------------
wfl.system.v1-endpoint-test
  test-workload-sink-outputs-to-tdr

1 tests, 7 assertions, 0 failures.
```

And the following Slack messages were emitted (note no link previews):

https://broadinstitute.slack.com/archives/C026PTM4XPA/p1647975806215949
https://broadinstitute.slack.com/archives/C026PTM4XPA/p1647976085750169
