### PR TITLE
[GH-1433] No TDR temporary snapshots in tests

### DIFF
--- a/api/test/wfl/integration/datarepo_test.clj
+++ b/api/test/wfl/integration/datarepo_test.clj
@@ -88,17 +88,18 @@
               (is (== 1 (count row-ids))
                   "Single input row should have been written to the dataset")
               (testing "creating snapshot after completed ingest"
-                (fixtures/with-temporary-snapshot
-                  (snapshots/unique-snapshot-request tdr-profile
-                                                     dataset
-                                                     table-name
-                                                     row-ids)
-                  #(let [snapshot        (datarepo/snapshot %)
-                         expected-prefix (str (:name dataset) "_" table-name)]
-                     (is (= % (:id snapshot)))
-                     (is (str/starts-with? (:name snapshot) expected-prefix)
-                         (str "Snapshot name should start with "
-                              "dataset name and table name"))))))))))))
+                (let [request         (snapshots/unique-snapshot-request
+                                       tdr-profile
+                                       dataset
+                                       table-name
+                                       row-ids)
+                      snapshot-id     (datarepo/create-snapshot request)
+                      snapshot        (datarepo/snapshot snapshot-id)
+                      expected-prefix (str (:name dataset) "_" table-name)]
+                  (is (= snapshot-id (:id snapshot)))
+                  (is (str/starts-with? (:name snapshot) expected-prefix)
+                      (str "Snapshot name should start with "
+                           "dataset name and table name")))))))))))
 
 (deftest test-flattened-query-result
   (let [samplesheets (-> (datarepo/snapshot (:id testing-snapshot))

--- a/api/test/wfl/tools/fixtures.clj
+++ b/api/test/wfl/tools/fixtures.clj
@@ -193,18 +193,6 @@
    datarepo/delete-snapshots-then-dataset
    f))
 
-;; Recommendation: only call this within a temporary dataset.
-;; If calling within a fixed dataset, running the same test concurrently
-;; may fail due to exclusive dataset locking on snapshot deletion.
-;;
-(defn with-temporary-snapshot
-  "Create a temporary Terra Data Repository Snapshot with `snapshot-request`"
-  [snapshot-request f]
-  (util/bracket
-   #(datarepo/create-snapshot snapshot-request)
-   datarepo/delete-snapshot
-   f))
-
 (defn with-temporary-workspace
   "Create and use a temporary Terra Workspace."
   ([workspace-prefix group f]


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1433

Previous work in this space: https://github.com/broadinstitute/wfl/pull/561

I found this new improvement in my "stash graveyard".

In integration tests which interact with TDR, we don't actually have to create temporary snapshots within temporary datasets (and cross our fingers that developers won't use temporary snapshots within fixed datasets).  You might remember that deleting a snapshot obtains an exclusive lock on the underlying dataset, which lead to flapping test failures on concurrent runs.

Instead, we can create snapshots as normal within temporary datasets: temporary datasets automatically delete any of their snapshots before the dataset.