### PR TITLE
[GH-1639] Pin jinja2 version for mkdocks compatibility

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 pymdown-extensions==8.0.1
 markdown-include==0.6.0
 mkdocs-material==7.2.4
+jinja2==3.0.3


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1639

`jinja2` v3.1.0 was released today and included the removal of some deprecated code: https://jinja.palletsprojects.com/en/3.1.x/changes/#version-3-1-0

But `mkdocs` is incompatible with this latest version (and we pin it anyways).  They're working on it: https://github.com/mkdocs/mkdocs/issues/2794

The impact on `wfl` is that `make docs` fails:

```
AttributeError: module 'jinja2' has no attribute 'contextfilter'
```

So, I pinned the last good `jinja2` version and the build succeeds once more.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

A clean docs build should succeed:

```
cd /path/to/wfl
make distclean; make docs
```