### PR TITLE
[GH-1623] workloads/update-workload! should define own transactions

### DIFF
--- a/api/src/wfl/api/workloads.clj
+++ b/api/src/wfl/api/workloads.clj
@@ -27,8 +27,8 @@
   (fn [_transaction workload] (:pipeline workload)))
 
 (defmulti update-workload!
-  "(transaction workload) -> workload"
-  (fn [_transaction workload] (:pipeline workload)))
+  "workload -> workload"
+  :pipeline)
 
 (defmulti workflows
   "Use db `transaction` to return the workflows managed by the `workload`."
@@ -148,7 +148,7 @@
 
 (defmethod update-workload!
   :default
-  [_ {:keys [pipeline] :as workload}]
+  [{:keys [pipeline] :as workload}]
   (throw
    (ex-info "Failed to update workload - no such pipeline"
             {:workload workload

--- a/api/src/wfl/api/workloads.clj
+++ b/api/src/wfl/api/workloads.clj
@@ -27,7 +27,7 @@
   (fn [_transaction workload] (:pipeline workload)))
 
 (defmulti update-workload!
-  "workload -> workload"
+  "workload-record -> workload"
   :pipeline)
 
 (defmulti workflows
@@ -148,10 +148,10 @@
 
 (defmethod update-workload!
   :default
-  [{:keys [pipeline] :as workload}]
+  [{:keys [pipeline] :as workload-record}]
   (throw
    (ex-info "Failed to update workload - no such pipeline"
-            {:workload workload
+            {:workload workload-record
              :pipeline pipeline
              :type     ::invalid-pipeline})))
 

--- a/api/src/wfl/module/staged.clj
+++ b/api/src/wfl/module/staged.clj
@@ -125,17 +125,18 @@
     (if-not started (start workload (utc-now)) workload)))
 
 (defn ^:private update-staged-workload
-  "Use transaction `tx` to update `workload` statuses."
-  [tx {:keys [started finished] :as workload}]
+  "Update `workload` stages."
+  [{:keys [started finished] :as workload}]
   (letfn [(update! [{:keys [id source executor sink] :as workload} now]
             (-> workload
                 (source/update-source!)
                 (executor/update-executor!)
                 (sink/update-sink!))
-            (patch-workload tx workload {:updated now})
-            (when (every? stage/done? [source executor sink])
-              (patch-workload tx workload {:finished now}))
-            (workloads/load-workload-for-id tx id))]
+            (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+              (patch-workload tx workload {:updated now})
+              (when (every? stage/done? [source executor sink])
+                (patch-workload tx workload {:finished now}))
+              (workloads/load-workload-for-id tx id)))]
     (if (and started (not finished)) (update! workload (utc-now)) workload)))
 
 (defn ^:private stop-staged-workload

--- a/api/src/wfl/module/staged.clj
+++ b/api/src/wfl/module/staged.clj
@@ -125,9 +125,11 @@
     (if-not started (start workload (utc-now)) workload)))
 
 (defn ^:private update-staged-workload
-  "Update `workload` stages."
-  [{:keys [started finished] :as workload}]
-  (letfn [(update! [{:keys [id source executor sink] :as workload} now]
+  "Update `workload-record` stages."
+  [{:keys [id started finished] :as _workload-record}]
+  (letfn [(load-workload [tx]
+            (workloads/load-workload-for-id tx id))
+          (update! [{:keys [source executor sink] :as workload} now]
             (-> workload
                 (source/update-source!)
                 (executor/update-executor!)
@@ -136,8 +138,12 @@
               (patch-workload tx workload {:updated now})
               (when (every? stage/done? [source executor sink])
                 (patch-workload tx workload {:finished now}))
-              (workloads/load-workload-for-id tx id)))]
-    (if (and started (not finished)) (update! workload (utc-now)) workload)))
+              (load-workload tx)))]
+    (let [workload (jdbc/with-db-transaction [tx (postgres/wfl-db-config)]
+                     (load-workload tx))]
+      (if (and started (not finished))
+        (update! workload (utc-now))
+        workload))))
 
 (defn ^:private stop-staged-workload
   "Use transaction `tx` to stop the `workload` looking for new data."

--- a/api/test/wfl/tools/workloads.clj
+++ b/api/test/wfl/tools/workloads.clj
@@ -285,7 +285,7 @@
 (def start-workload!      (evalT wfl.api.workloads/start-workload!))
 (def stop-workload!       (evalT wfl.api.workloads/stop-workload!))
 (def execute-workload!    (evalT wfl.api.workloads/execute-workload!))
-(def update-workload!     (evalT wfl.api.workloads/update-workload!))
+(def update-workload!     wfl.api.workloads/update-workload!)
 (def workflows            (evalT wfl.api.workloads/workflows))
 (def workflows-by-filters (evalT wfl.api.workloads/workflows-by-filters))
 


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1623

As a prerequisite to factoring out external calls from DB transactions, this PR forces `workloads/update-workload!` implementations to define their own transactions.

With these changes, this decoupling is complete for staged workloads.  Staged workloads can be updated in their own future in a separate PR.

Legacy workload update behavior otherwise remains the same.

### System Tests

Pass:
```
wm111-e35:wfl okotsopo$ make TARGET=system
export CPCACHE=/Users/okotsopo/wfl/api/.cpcache;            \
	export WFL_WFL_URL=http://localhost:3000; \
	clojure  -M:parallel-test wfl.system.v1-endpoint-test | \
	tee /Users/okotsopo/wfl/derived/api/system.log
WARNING: Use of :paths external to the project has been deprecated, please remove: ../derived/api/src
WARNING: Use of :paths external to the project has been deprecated, please remove: ../derived/api/resources

Ran 33 tests containing 374 assertions.
0 failures, 0 errors.
```

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

I recommend hiding whitespace when reviewing.  Wouldn't mind eyes on the code consolidation I did in `wfl.server.clj`.
