### PR TITLE
[GH-1640] Broken Terra Submission links in completed workflow Slack messages

### DIFF
--- a/api/src/wfl/executor.clj
+++ b/api/src/wfl/executor.clj
@@ -299,7 +299,7 @@
         workflow-link   (-> workflow
                             firecloud/workflow-url
                             (slack/link workflow))
-        submission-link (-> workspace
+        submission-link (-> submission
                             (firecloud/submission-url workspace)
                             (slack/link submission))]
     (str/join \newline


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1640

Whoops!

I broke Terra Submission links in completed workflow Slack messages when doing some light refactoring in https://github.com/broadinstitute/wfl/pull/591/files

### System Tests

Ran this test individually:
```
wm111-e35:api okotsopo$ WFL_WFL_URL=http://localhost:3000  clojure -M:test --focus   wfl.system.v1-endpoint-test/test-workload-sink-outputs-to-tdr
…
--- system (clojure.test) ---------------------------
wfl.system.v1-endpoint-test
  test-workload-sink-outputs-to-tdr

1 tests, 7 assertions, 0 failures.
```

Verified that the emitted Slack message links all worked as expected (they won't work now if you click on them since the resources have since been cleaned up):

https://broadinstitute.slack.com/archives/C026PTM4XPA/p1648234413929859
https://broadinstitute.slack.com/archives/C026PTM4XPA/p1648234694248259

Notably, the submission link which previously was broken:

<img width="1713" alt="Screen Shot 2022-03-25 at 2 58 41 PM" src="https://user-images.githubusercontent.com/79769153/160185233-0e360224-2000-4fde-a64f-bf739b447d02.png">
