### PR TITLE
[GH-1645] Update wfl.module.wgs/workflow-wdl to allow overriding read_length in CollectRawWgsMetrics.

### DIFF
--- a/api/src/wfl/executor.clj
+++ b/api/src/wfl/executor.clj
@@ -5,7 +5,6 @@
             [clojure.string        :as str]
             [ring.util.codec       :refer [url-encode]]
             [wfl.api.workloads     :refer [defoverload] :as workloads]
-            [wfl.environment       :as env]
             [wfl.jdbc              :as jdbc]
             [wfl.log               :as log]
             [wfl.module.all        :as all]
@@ -16,7 +15,7 @@
             [wfl.service.postgres  :as postgres]
             [wfl.service.rawls     :as rawls]
             [wfl.service.slack     :as slack]
-            [wfl.stage             :as stage :refer [log-prefix]]
+            [wfl.stage             :as stage]
             [wfl.util              :as util :refer [map-keys utc-now]])
   (:import [wfl.util UserException]))
 
@@ -685,7 +684,7 @@
 (defn ^:private terra-executor-retry-workflows
   "Resubmit the snapshot references associated with `workflows` in `workspace`
   and update each original workflow record with the row ID of its retry."
-  [{{:keys [workspace] :as executor} :executor :as workload} workflows]
+  [{{:keys [workspace] :as _executor} :executor :as workload} workflows]
   (letfn [(submit-reference [reference-id]
             (let [reference (rawls/get-snapshot-reference workspace reference-id)]
               (->> reference

--- a/api/src/wfl/module/wgs.clj
+++ b/api/src/wfl/module/wgs.clj
@@ -20,7 +20,7 @@
 
 (def workflow-wdl
   "The top-level WDL file and its version."
-  {:release "c1f20c46ad61aa3b87ce9d88fd9facc871ae6d4b"
+  {:release "ExternalWholeGenomeReprocessing_v2.0.5"
    :path    "pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.wdl"})
 
 (def ^:private cromwell-label

--- a/api/src/wfl/stage.clj
+++ b/api/src/wfl/stage.clj
@@ -22,10 +22,3 @@
   "A `stage` context object for logs."
   [stage]
   (:type stage))
-
-;; Goal: deprecate in favor of attaching `workloads/to-log` to logs.
-;;
-(defn log-prefix
-  "Prefix string for `stage` logs indicating the `type` (table) and row `id`."
-  [{:keys [type id] :as _stage}]
-  (format "[%s id=%s]" type id))

--- a/api/src/wfl/util.clj
+++ b/api/src/wfl/util.clj
@@ -8,7 +8,7 @@
             [clojure.string     :as str]
             [wfl.log            :as log]
             [wfl.wfl            :as wfl])
-  (:import [java.io File IOException StringWriter Writer]
+  (:import [java.io IOException StringWriter Writer]
            [java.nio.file Files]
            [java.nio.file.attribute FileAttribute]
            [java.time OffsetDateTime ZoneId]
@@ -115,27 +115,6 @@
   `(if (~pred ~coll ~key)
      (assoc ~coll ~key ~value)
      ~coll))
-
-(defn delete-tree
-  "Recursively delete a sequence of FILES."
-  [& files]
-  (when (seq files)
-    (let [file (first files)
-          more (.listFiles file)]
-      (if (seq more)
-        (recur (concat more files))
-        (do (io/delete-file file :無)
-            (recur (rest files)))))))
-
-(defn copy-directory
-  "Copy files from SRC to under DEST."
-  [^File src ^File dest]
-  (let [prefix (str (.getParent src) "/")]
-    (doseq [file (file-seq src)]
-      (when-not (.isDirectory file)
-        (let [target (io/file dest (unprefix (.getPath file) prefix))]
-          (io/make-parents target)
-          (io/copy file target))))))
 
 (defn sleep-seconds
   "Sleep for N seconds."

--- a/api/test/wfl/integration/modules/staged_test.clj
+++ b/api/test/wfl/integration/modules/staged_test.clj
@@ -40,7 +40,6 @@
 (def ^:private testing-workspace (str testing-namespace "/" "CDC_Viral_Sequencing"))
 (def ^:private testing-method-name "sarscov2_illumina_full")
 (def ^:private testing-method-configuration (str testing-namespace "/" testing-method-name))
-(def ^:private testing-method-configuration-version 2)
 (def ^:private testing-table-name "flowcells")
 
 (let [new-env {"WFL_FIRECLOUD_URL" "https://api.firecloud.org"

--- a/api/test/wfl/system/v1_endpoint_test.clj
+++ b/api/test/wfl/system/v1_endpoint_test.clj
@@ -377,7 +377,7 @@
 
 (deftest ^:parallel test-workflows-by-filters
   (testing "Get workflows by status"
-    (let [{:keys [statuses workflows workload]}
+    (let [{:keys [statuses workload]}
           (->> (endpoints/get-workloads)
                (filter :finished)
                (take 7)                 ; Why not?

--- a/api/test/wfl/unit/logging_test.clj
+++ b/api/test/wfl/unit/logging_test.clj
@@ -1,11 +1,10 @@
 (ns wfl.unit.logging-test
   "Test that our overcomplicated logging works."
-  (:require [clojure.test        :refer [is deftest testing]]
-            [clojure.data.json   :as json]
-            [clojure.edn         :as edn]
-            [clojure.string      :as str]
-            [wfl.log             :as log]
-            [wfl.tools.endpoints :as endpoints])
+  (:require [clojure.test      :refer [is deftest testing]]
+            [clojure.data.json :as json]
+            [clojure.edn       :as edn]
+            [clojure.string    :as str]
+            [wfl.log           :as log])
   (:import [java.util.regex Pattern]))
 
 (defmulti check-message?


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1644
- https://broadinstitute.atlassian.net/browse/GH-1645

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Upgrade to `ExternalWholeGenomeReprocessing_v2.0.5`.
- Delete unused code from `wfl.util`.
- Clean up random cruft I noticed recently.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- The new WGS pipeline takes a while to run.