### PR TITLE
[GH-1653] TDR snapshot direct links have changed

### DIFF
--- a/api/src/wfl/service/datarepo.clj
+++ b/api/src/wfl/service/datarepo.clj
@@ -239,7 +239,7 @@
 (defn snapshot-url
   "Return a link to `snapshot` in TDR UI."
   [{:keys [id] :as _snapshot}]
-  (datarepo-url "snapshots/details" id))
+  (datarepo-url "snapshots" id))
 
 (defn delete-dataset-snapshots
   "Delete snapshots on dataset with `dataset-id`."


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1653

Previously, one navigated directly to a TDR snapshot via the following path:

`https://<tdr-host>/snapshots/details/<snapshot-id>`

Recent changes in TDR have updated the path thusly (ticket: https://broadworkbench.atlassian.net/browse/DR-2436):

`https://<tdr-host>/snapshots/<snapshot-id>`

The impact of this change is that WFL’s “submission launched” Slack messages have broken links to the source snapshots.  Example:

https://broadinstitute.slack.com/archives/C031GKEHCKF/p1650995030978519
https://data.terra.bio/snapshots/details/1dea8d26-0e26-4816-b9d1-ce6d93e3756d

This fix would update the above link as follows:

https://data.terra.bio/snapshots/1dea8d26-0e26-4816-b9d1-ce6d93e3756d