### PR TITLE
[GH-1678] When monitoring source load tags, match prefix instead of exact match. 

### DIFF
--- a/api/src/wfl/service/datarepo.clj
+++ b/api/src/wfl/service/datarepo.clj
@@ -322,7 +322,7 @@
                             (format "ingest_time BETWEEN '%s' AND '%s'"
                                     start end))
         where-load-tag    (when loadTag
-                            (format "load_tag = '%s'" loadTag))
+                            (format "load_tag LIKE '%s%%'" loadTag))
         where-clauses     (util/remove-empty-and-join
                            [where-ingest-time where-load-tag] " AND ")
         where             (if (empty? where-clauses) ""

--- a/api/src/wfl/service/datarepo.clj
+++ b/api/src/wfl/service/datarepo.clj
@@ -304,7 +304,7 @@
    (query-table-impl dataset table
                      (util/to-comma-separated-list (map name columns)))))
 
-(defn metadata
+(defn ^:private metadata
   "Return TDR row metadata table name corresponding to `table-name`."
   [table-name]
   (str "datarepo_row_metadata_" table-name))

--- a/api/src/wfl/service/datarepo.clj
+++ b/api/src/wfl/service/datarepo.clj
@@ -304,8 +304,7 @@
    (query-table-impl dataset table
                      (util/to-comma-separated-list (map name columns)))))
 
-;; Public for testing
-(def metadata-table-name-prefix "datarepo_row_metadata_")
+(def ^:private metadata-table-name-prefix "datarepo_row_metadata_")
 
 (defn metadata
   "Return TDR row metadata table name corresponding to `table-name`."

--- a/api/src/wfl/service/datarepo.clj
+++ b/api/src/wfl/service/datarepo.clj
@@ -304,12 +304,10 @@
    (query-table-impl dataset table
                      (util/to-comma-separated-list (map name columns)))))
 
-(def ^:private metadata-table-name-prefix "datarepo_row_metadata_")
-
 (defn metadata
   "Return TDR row metadata table name corresponding to `table-name`."
   [table-name]
-  (format "%s%s" metadata-table-name-prefix table-name))
+  (str "datarepo_row_metadata_" table-name))
 
 (defn ^:private query-metadata-table-impl
   "Return `col-spec` from rows from TDR `dataset`.`table` metadata

--- a/api/src/wfl/service/datarepo.clj
+++ b/api/src/wfl/service/datarepo.clj
@@ -328,9 +328,8 @@
                             (format "load_tag = '%s'" loadTag))
         where-clauses     (util/remove-empty-and-join
                            [where-ingest-time where-load-tag] " AND ")
-        where             (if-not (empty? where-clauses)
-                            (format "WHERE %s" where-clauses)
-                            "")]
+        where             (if (empty? where-clauses) ""
+                              (format "WHERE %s" where-clauses))]
     (-> "SELECT %s FROM `%s` %s"
         (format col-spec (bq-path dataset-or-snapshot meta-table) where)
         (->> (bigquery/query-sync dataProject)))))

--- a/api/test/wfl/integration/source_test.clj
+++ b/api/test/wfl/integration/source_test.clj
@@ -164,7 +164,7 @@
 
 (deftest test-create-tdr-source-with-invalid-dataset-metadata-table
   (with-redefs
-    [datarepo/metadata (partial str "wrong-metadata-table-name-")]
+   [datarepo/metadata (partial str "wrong-metadata-table-name-")]
     (is (thrown-with-msg?
          UserException #"TDR row metadata table not found in BigQuery"
          (source/datarepo-source-validate-request-or-throw

--- a/api/test/wfl/integration/source_test.clj
+++ b/api/test/wfl/integration/source_test.clj
@@ -164,7 +164,7 @@
 
 (deftest test-create-tdr-source-with-invalid-dataset-metadata-table
   (with-redefs
-   [datarepo/metadata-table-name-prefix "wrong-metadata-table-name-"]
+    [datarepo/metadata (partial str "wrong-metadata-table-name-")]
     (is (thrown-with-msg?
          UserException #"TDR row metadata table not found in BigQuery"
          (source/datarepo-source-validate-request-or-throw

--- a/api/test/wfl/system/v1_endpoint_test.clj
+++ b/api/test/wfl/system/v1_endpoint_test.clj
@@ -337,11 +337,13 @@
                                     {:submission submission :status status-unretriable}]
                 filters-valid      [{:submission submission}
                                     {:submission submission :status status-retriable}]]
-            (run! (partial should-throw-400
-                           executor/terra-executor-retry-filters-invalid-error-message)
+            (run! (partial
+                   should-throw-400
+                   executor/terra-executor-retry-filters-invalid-error-message)
                   filters-invalid)
-            (run! (partial should-throw-400
-                           handlers/retry-no-workflows-error-message)
+            (run! (partial
+                   should-throw-400
+                   @#'handlers/retry-no-workflows-error-message)
                   filters-valid))))
       (testing "/start staged workload"
         (let [{:keys [created started] :as response}

--- a/api/test/wfl/unit/executor_test.clj
+++ b/api/test/wfl/unit/executor_test.clj
@@ -6,35 +6,35 @@
   (:import [java.util UUID]
            [wfl.util UserException]))
 
-(deftest test-terra-executor-workflows-sql-params
+(deftest test-filter-query-for-unretried-workflows
   (let [executor {:details "TerraExecutor_00000001"}
         submission (str (UUID/randomUUID))
         status "Failed"
         filters {:submission submission :status status}]
     (letfn [(arg-count [sql] (-> sql frequencies (get \? 0)))]
       (testing "No filters"
-        (let [[sql & params] (#'executor/terra-executor-workflows-sql-params
+        (let [[sql & params] (#'executor/filter-query-for-unretried-workflows
                               executor {})]
           (is (== 0 (arg-count sql))
               "No filters should yield no query arguments")
           (is (empty? params)
               "No filters should yield no parameters")))
       (testing "Submission filter only"
-        (let [[sql & params] (#'executor/terra-executor-workflows-sql-params
+        (let [[sql & params] (#'executor/filter-query-for-unretried-workflows
                               executor (select-keys filters [:submission]))]
           (is (== 1 (arg-count sql))
               "Single filter (submission) should yield 1 query argument")
           (is (= [submission] params)
               "Submission filter should yield lone submission parameter")))
       (testing "Status filter only"
-        (let [[sql & params] (#'executor/terra-executor-workflows-sql-params
+        (let [[sql & params] (#'executor/filter-query-for-unretried-workflows
                               executor (select-keys filters [:status]))]
           (is (== 1 (arg-count sql))
               "Single filter (status) should yield 1 query argument")
           (is (= [status] params)
               "Status filter should yield lone status parameter")))
       (testing "Submission and status filters"
-        (let [[sql & params] (#'executor/terra-executor-workflows-sql-params
+        (let [[sql & params] (#'executor/filter-query-for-unretried-workflows
                               executor (select-keys filters [:submission :status]))]
           (is (== 2 (arg-count sql))
               "Two filters (submission and status) should yield 2 query arguments")

--- a/docs/md/staged-source.md
+++ b/docs/md/staged-source.md
@@ -47,14 +47,14 @@ like:
 ```
 The table below summarises the purpose of each attribute in the above request.
 
-| Attribute                | Description                                              |
-|--------------------------|----------------------------------------------------------|
-| `name`                   | Selects the `Terra DataRepo` source implementation.      |
-| `dataset`                | The `UUID` of dataset to monitor and read from.          |
-| `table`                  | The name of the `dataset` table to monitor and read from.|
-| `snapshotReaders`        | A list of email addresses to set as `readers` of all snapshots created in this workload.|
-| `pollingIntervalMinutes` | Optional.  Rate at which WFL will poll TDR for new rows to snapshot.|
-| `loadTag`                | Optional.  Only snapshot new rows ingested to TDR with `loadTag`.|
+| Attribute                | Description                                                                              |
+|--------------------------|------------------------------------------------------------------------------------------|
+| `name`                   | Selects the `Terra DataRepo` source implementation.                                      |
+| `dataset`                | The `UUID` of dataset to monitor and read from.                                          |
+| `table`                  | The name of the `dataset` table to monitor and read from.                                |
+| `snapshotReaders`        | A list of email addresses to set as `readers` of all snapshots created in this workload. |
+| `pollingIntervalMinutes` | Optional.  Rate at which WFL will poll TDR for new rows to snapshot.                     |
+| `loadTag`                | Optional.  Snapshot only new rows ingested with `loadTag`.                               |
 
 #### `dataset`
 
@@ -84,8 +84,25 @@ If not provided, the default interval is 20 minutes.
 
 #### Optional `loadTag`
 
-WFL will only snapshot new rows ingested to TDR with `loadTag`.
-If not provided, all new rows will be eligible for snapshotting.
+Specifying a `loadTag`
+restricts the set of new rows
+that WFL will include in a snapshot.
+The `loadTag` specifies
+a prefix to be matched
+against the `loadTag` used
+to ingest data to TDR.
+Thus `my-ingest-tag` matches
+all of the following load tags.
+
+    - `my-ingest-tag`
+    - `my-ingest-tag-`
+    - `my-ingest-tag-0`
+    - `my-ingest-tag-a`
+    - `my-ingest-tag-2022-07-14
+
+When not provided,
+all new rows will be eligible
+for snapshotting.
 
 !!! note
     When initiating a TDR ingest, one can optionally set a load tag.


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1678

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Factor out retry filter keys.
- Rename `terra-executor-workflows-sql-params` to `filter-query-for-unretried-workflows`.
- Privatize some "public for testing" vars.
- Prefix match `loadTag` with `LIKE` on snapshot queries.
- Document changes. 

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- Start with `datarepo.clj` and `staged-source.md`.
- Scan the rest while ignoring whitespace changes.
