### PR TITLE
[GH-1691] Fix the SG/GDC increment the add_bam version in Clio hack.

### DIFF
--- a/api/deps.edn
+++ b/api/deps.edn
@@ -53,7 +53,7 @@
    :main-opts  ["-m" "cljfmt.main" "fix"]}
 
   :kondo
-  {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2021.06.01"}}
+  {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2022.09.08"}}
    :main-opts ["-m" "clj-kondo.main"]}
 
   :kibit
@@ -61,16 +61,17 @@
    :main-opts   ["-e" "(use,'kibit.driver),(external-run,[\"src\"],nil)"]}
 
   :eastwood
-  {:extra-deps {jonase/eastwood {:mvn/version "0.4.3"}
+  {:extra-deps {jonase/eastwood {:mvn/version "1.3.0"}
                 org.liquibase/liquibase-core
                 {:mvn/version "4.3.5"
                  :exclusions  [ch.qos.logback/logback-classic]}}
    :extra-paths ["test"]
    :main-opts ["-m" "eastwood.lint"
-               {:add-linters    #{#_:keyword-typos :unused-fn-args}
-                :config-files   #{"resources/eastwood.clj"}
-                :source-paths   ["src" "test"]
-                :ignored-faults {:keyword-typos {wfl.api.routes [true]}}}]}
+               {:add-linters     #{#_:keyword-typos :unused-fn-args}
+                :config-files    #{"resources/eastwood.clj"}
+                :exclude-linters #{:reflection}
+                :source-paths    ["src" "test"]
+                :ignored-faults  {:keyword-typos {wfl.api.routes [true]}}}]}
 
   :liquibase
   {:extra-deps  {org.liquibase/liquibase-core  {:mvn/version "4.3.5"
@@ -95,7 +96,7 @@
    :extra-paths ["test"]
    :main-opts   ["-m" "wfl.tools.parallel-runner"]}
 
-  :uberjar {:extra-deps {uberdeps/uberdeps {:mvn/version "1.0.4"}}}
+  :uberjar {:extra-deps {uberdeps/uberdeps {:mvn/version "1.1.4"}}}
 
   :prebuild {:extra-paths ["./build"] :exec-fn build/prebuild}
 

--- a/api/deps.edn
+++ b/api/deps.edn
@@ -11,7 +11,6 @@
   org.clojure/data.xml                      {:mvn/version "0.2.0-alpha6"}
   org.clojure/data.zip                      {:mvn/version "1.0.0"}
   org.clojure/java.jdbc                     {:mvn/version "0.7.12"}
-  org.clojure/tools.logging                 {:mvn/version "1.1.0"}
   amperity/vault-clj                        {:mvn/version "1.0.3"}
   clj-http/clj-http                         {:mvn/version "3.9.1"}
   clj-time/clj-time                         {:mvn/version "0.15.2"}

--- a/api/deps.edn
+++ b/api/deps.edn
@@ -5,7 +5,7 @@
   "clojars" {:url "https://clojars.org/repo"}}
 
  :deps
- {org.clojure/clojure                       {:mvn/version "1.10.3"}
+ {org.clojure/clojure                       {:mvn/version "1.11.1"}
   org.clojure/data.csv                      {:mvn/version "1.0.0"}
   org.clojure/data.json                     {:mvn/version "2.3.0"}
   org.clojure/data.xml                      {:mvn/version "0.2.0-alpha6"}

--- a/api/src/wfl/api/handlers.clj
+++ b/api/src/wfl/api/handlers.clj
@@ -1,7 +1,6 @@
 (ns wfl.api.handlers
   "Define handlers for API endpoints."
   (:require [clojure.set                :refer [rename-keys]]
-            [wfl.wfl                    :as wfl]
             [ring.util.http-response    :as response]
             [wfl.api.workloads          :as workloads]
             [wfl.configuration          :as config]
@@ -11,7 +10,8 @@
             [wfl.module.aou             :as aou]
             [wfl.service.google.storage :as gcs]
             [wfl.service.postgres       :as postgres]
-            [wfl.util                   :as util])
+            [wfl.util                   :as util]
+            [wfl.wfl                    :as wfl])
   (:import  [wfl.util UserException]))
 
 (defn succeed

--- a/api/src/wfl/api/spec.clj
+++ b/api/src/wfl/api/spec.clj
@@ -1,17 +1,17 @@
 (ns wfl.api.spec
-  "Define specs used in routes"
-  (:require [clojure.spec.alpha   :as s]
-            [clojure.string       :as str]
-            [wfl.executor         :as executor]
-            [wfl.module.all       :as all]
-            [wfl.module.aou       :as aou]
-            [wfl.module.batch     :as batch]
-            [wfl.module.copyfile  :as copyfile]
-            [wfl.module.sg        :as sg]
-            [wfl.module.staged    :as staged]
-            [wfl.module.wgs       :as wgs]
-            [wfl.module.xx        :as xx]
-            [wfl.util             :as util]))
+  "Define the specs used in routes."
+  (:require [clojure.spec.alpha  :as s]
+            [clojure.string      :as str]
+            [wfl.executor        :as executor]
+            [wfl.module.all      :as all]
+            [wfl.module.aou      :as aou]
+            [wfl.module.batch    :as batch]
+            [wfl.module.copyfile :as copyfile]
+            [wfl.module.sg       :as sg]
+            [wfl.module.staged   :as staged]
+            [wfl.module.wgs      :as wgs]
+            [wfl.module.xx       :as xx]
+            [wfl.util            :as util]))
 
 (s/def ::workload-query (s/and (s/keys :opt-un [::all/uuid ::all/project])
                                #(not (and (:uuid %) (:project %)))))

--- a/api/src/wfl/api/workloads.clj
+++ b/api/src/wfl/api/workloads.clj
@@ -1,7 +1,8 @@
 (ns wfl.api.workloads
+  "An interface to workloads."
   (:require [clojure.string :as str]
-            [wfl.log        :as log]
             [wfl.jdbc       :as jdbc]
+            [wfl.log        :as log]
             [wfl.util       :as util])
   (:import [wfl.util UserException]))
 

--- a/api/src/wfl/auth.clj
+++ b/api/src/wfl/auth.clj
@@ -1,9 +1,9 @@
 (ns wfl.auth
   "Manage credentials and configurations."
-  (:require [clojure.java.io   :as io]
-            [clojure.string    :as str]
+  (:require [clojure.java.io :as io]
+            [clojure.string  :as str]
             [wfl.environment :as env]
-            [wfl.util         :as util])
+            [wfl.util        :as util])
   (:import [com.google.auth.oauth2 GoogleCredentials]))
 
 (defn ^:private authorization-header-with-bearer-token

--- a/api/src/wfl/configuration.clj
+++ b/api/src/wfl/configuration.clj
@@ -1,8 +1,7 @@
 (ns wfl.configuration
-  "Configuration for WFL. A configuration table exists as a simple key
-   value store for simple configuration."
-  (:require [clojure.string                 :as str]
-            [wfl.jdbc                       :as jdbc]))
+  "A simple key value store to configure WFL."
+  (:require [clojure.string :as str]
+            [wfl.jdbc       :as jdbc]))
 
 (def ^:private configuration-table "configuration")
 

--- a/api/src/wfl/debug.clj
+++ b/api/src/wfl/debug.clj
@@ -11,7 +11,7 @@
        x#)))
 
 (defmacro trace
-  "Like `dump` but include location metadata."
+  "Like `dump` but include location metadata in a map."
   [expression]
   (let [{:keys [line column]} (meta &form)]
     `(let [x# ~expression]

--- a/api/src/wfl/environment.clj
+++ b/api/src/wfl/environment.clj
@@ -1,10 +1,10 @@
 (ns wfl.environment
   "Map environment to various values here."
-  (:require [clojure.data.json :as json]
-            [clojure.string    :as str]
-            [wfl.log           :as log]
+  (:require [clojure.data.json  :as json]
+            [clojure.string     :as str]
             [vault.client.http] ; vault.core needs this
-            [vault.core        :as vault]))
+            [vault.core         :as vault]
+            [wfl.log            :as log]))
 
 (declare getenv)
 
@@ -20,7 +20,7 @@
        (vault/authenticate! :token token))
      path {})))
 
-;; Keep this map pure - defer any IO to the thunk returned by this map.
+;; Keep this map pure. Defer any IO to the thunk returned by this map.
 (def ^:private defaults
   "Default actions (thunks) for computing environment variables, mainly for
    development, testing and documentation purposes."
@@ -55,8 +55,9 @@
    (fn [] "https://dockstore.org")
    "WFL_SLACK_TOKEN"
    #(-> "secret/dsde/gotc/dev/wfl/slack" vault-secrets :bot-user-token)
-
+   ;;
    ;; -- variables used in test code below this line --
+   ;;
    "WFL_CROMWELL_URL"
    (fn [] "https://cromwell-gotc-auth.gotc-dev.broadinstitute.org")
    "WFL_TDR_DEFAULT_PROFILE"

--- a/api/src/wfl/executor.clj
+++ b/api/src/wfl/executor.clj
@@ -1,4 +1,5 @@
 (ns wfl.executor
+  "Execute a workflow somehow."
   (:require [clojure.edn           :as edn]
             [clojure.set           :as set :refer [rename-keys]]
             [clojure.spec.alpha    :as s]

--- a/api/src/wfl/main.clj
+++ b/api/src/wfl/main.clj
@@ -1,11 +1,10 @@
 (ns wfl.main
   "Run some demonstrations."
   (:require [clojure.data.json :as json]
-            [clojure.pprint :refer [pprint]]
-            [clojure.string :as str]
-            [wfl.util :as util]
-            [wfl.wfl :as wfl])
-  (:gen-class))
+            [clojure.pprint    :refer [pprint]]
+            [clojure.string    :as str]
+            [wfl.util          :as util]
+            [wfl.wfl           :as wfl]))
 
 (defn describe
   "Describe the purpose of this program."

--- a/api/src/wfl/mime_type.clj
+++ b/api/src/wfl/mime_type.clj
@@ -4,18 +4,16 @@
 
 (def ^:private mime-types
   "mime-types for file extensions commonly used in computational biology."
-  (let [extensions
-        {"bam"     "application/octet-stream"
-         "cram"    "application/octet-stream"
-         "fasta"   "application/octet-stream"
-         "genbank" "application/octet-stream"
-         "ready"   "text/plain"
-         "tsv"     "text/tab-separated-values"
-         "vcf"     "text/plain"}]
+  (let [extensions {"bam"     "application/octet-stream"
+                    "cram"    "application/octet-stream"
+                    "fasta"   "application/octet-stream"
+                    "genbank" "application/octet-stream"
+                    "ready"   "text/plain"
+                    "tsv"     "text/tab-separated-values"
+                    "vcf"     "text/plain"}]
     (merge mime-type/default-mime-types extensions)))
 
-;; visible for testing
-(defn ext-mime-type-no-default
+(defn ^:private ext-mime-type-no-default
   "Look up the mime-type of `filename` by file extension."
   [filename]
   (loop [filename (util/basename filename)]

--- a/api/src/wfl/module/all.clj
+++ b/api/src/wfl/module/all.clj
@@ -1,13 +1,12 @@
 (ns wfl.module.all
   "Some utilities shared across module namespaces."
-  (:require [clojure.spec.alpha         :as s]
-            [clojure.string             :as str]
-            [wfl.jdbc                   :as jdbc]
-            [wfl.service.cromwell       :as cromwell]
-            [wfl.service.google.storage :as gcs]
-            [wfl.service.slack          :as slack]
-            [wfl.util                   :as util]
-            [wfl.wfl                    :as wfl])
+  (:require [clojure.spec.alpha   :as s]
+            [clojure.string       :as str]
+            [wfl.jdbc             :as jdbc]
+            [wfl.service.cromwell :as cromwell]
+            [wfl.service.slack    :as slack]
+            [wfl.util             :as util]
+            [wfl.wfl              :as wfl])
   (:import [java.util UUID]))
 
 (defn add-workload-table!

--- a/api/src/wfl/module/all.clj
+++ b/api/src/wfl/module/all.clj
@@ -10,63 +10,6 @@
             [wfl.wfl                    :as wfl])
   (:import [java.util UUID]))
 
-(defn throw-when-output-exists-already!
-  "Throw when GS-OUTPUT-URL output exists already."
-  [gs-output-url]
-  (when (first (gcs/list-objects gs-output-url))
-    (throw
-     (IllegalArgumentException.
-      (format "%s: output already exists: %s"
-              wfl/the-name gs-output-url)))))
-
-(defn bam-or-cram?
-  "Nil or a vector with root of PATH and the matching suffix."
-  [path]
-  (or (let [bam (util/unsuffix path ".bam")]
-        (when (not= bam path)
-          [:input_bam bam ".bam"]))
-      (let [cram (util/unsuffix path ".cram")]
-        (when (not= cram path)
-          [:input_cram cram ".cram"]))))
-
-(defn readable!
-  "Throw or return the bucket for GS-URL when it is readable."
-  [gs-url]
-  (let [[result prefix] (gcs/parse-gs-url gs-url)]
-    (letfn [(ok? [bucket prefix]
-              (prn (format "%s: reading: %s" wfl/the-name gs-url))
-              (util/do-or-nil (gcs/list-objects bucket prefix)))]
-      (when-not (ok? result prefix)
-        (throw (IllegalArgumentException.
-                (format "%s must be readable" gs-url)))))
-    result))
-
-(defn processed-crams
-  "Root object names of CRAMs in OUT-GS."
-  [out-gs]
-  (let [[bucket prefix] (gcs/parse-gs-url out-gs)]
-    (letfn [(cram? [{:keys [name]}]
-              (when (str/ends-with? name ".cram")
-                (-> name
-                    (util/unsuffix ".cram")
-                    (subs (count prefix)))))]
-      (->> (gcs/list-objects bucket prefix)
-           (keep cram?)
-           set))))
-
-(defn count-files
-  "Count the BAM or CRAM files in IN-GS, and the BAM or CRAM files
-  in OUT-GS."
-  [in-gs out-gs]
-  (letfn [(crams [gs-url]
-            (prn (format "%s: reading: %s" wfl/the-name gs-url))
-            [gs-url (->> (gcs/list-objects gs-url)
-                         (keep (comp bam-or-cram? :name))
-                         count)])]
-    (let [gs-urls (into (array-map) (map crams [in-gs out-gs]))
-          remaining (apply - (map gs-urls [in-gs out-gs]))]
-      (into gs-urls [[:remaining remaining]]))))
-
 (defn add-workload-table!
   "Return ID and TABLE for _WORKFLOW-WDL in BODY under transaction TX."
   [tx {:keys [release path] :as _workflow-wdl} body]
@@ -91,14 +34,6 @@
     (jdbc/execute! tx ["UPDATE workload SET pipeline = ?::pipeline WHERE id = ?" pipeline id])
     (jdbc/db-do-commands tx [work])
     [id table]))
-
-(defn has?
-  "Return a function that takes a map and returns the result of applying the
-   `predicate?` to the value at the `key` in `map`, if one exists."
-  [key predicate?]
-  (fn [map]
-    (when-let [value (get map key)]
-      (predicate? value))))
 
 ;; shared specs
 (s/def ::base_file_name string?)

--- a/api/src/wfl/module/all.clj
+++ b/api/src/wfl/module/all.clj
@@ -6,8 +6,7 @@
             [wfl.service.cromwell :as cromwell]
             [wfl.service.slack    :as slack]
             [wfl.util             :as util]
-            [wfl.wfl              :as wfl])
-  (:import [java.util UUID]))
+            [wfl.wfl              :as wfl]))
 
 (defn add-workload-table!
   "Return ID and TABLE for _WORKFLOW-WDL in BODY under transaction TX."
@@ -22,7 +21,7 @@
                                     :output   output
                                     :project  project
                                     :release  release
-                                    :uuid     (UUID/randomUUID)
+                                    :uuid     (random-uuid)
                                     :version  version
                                     :watchers (pr-str watchers)
                                     :wdl      path})

--- a/api/src/wfl/module/aou.clj
+++ b/api/src/wfl/module/aou.clj
@@ -13,8 +13,7 @@
             [wfl.util             :as util]
             [wfl.wfl              :as wfl])
   (:import [java.sql Timestamp]
-           [java.time Instant]
-           [java.util UUID]))
+           [java.time Instant]))
 
 ;; This must agree with the AoU cloud function.
 ;;
@@ -217,7 +216,7 @@
                                     :output   slashified
                                     :project  project
                                     :release  release
-                                    :uuid     (UUID/randomUUID)
+                                    :uuid     (random-uuid)
                                     :version  version
                                     :watchers (pr-str watchers)
                                     :wdl      path})))))

--- a/api/src/wfl/module/batch.clj
+++ b/api/src/wfl/module/batch.clj
@@ -15,7 +15,6 @@
             [wfl.util             :as util]
             [wfl.wfl              :as wfl])
   (:import [java.time OffsetDateTime]
-           [java.util UUID]
            [wfl.util UserException]))
 
 ;;specs
@@ -136,7 +135,7 @@
             (update :executor util/de-slashify)
             (update :watchers pr-str)
             (merge (select-keys (wfl/get-the-version) [:commit :version]))
-            (assoc :release release :wdl path :uuid (UUID/randomUUID))
+            (assoc :release release :wdl path :uuid (random-uuid))
             (->> (jdbc/insert! tx :workload)))
         table (format "%s_%09d" pipeline id)]
     (jdbc/execute!       tx [setter pipeline id])

--- a/api/src/wfl/module/sg.clj
+++ b/api/src/wfl/module/sg.clj
@@ -153,6 +153,13 @@
         (log/warn "Need output files for Clio.")
         (log/error {:need need}))))
 
+(def ^:private clio-force=true-error-message-starts
+  "How a Clio force=true error message starts."
+  "\"Adding this document will overwrite the following existing metadata:")
+(def ^:private clio-force=true-error-message-ends
+  "How a Clio force=true error message ends."
+  "Use 'force=true' to overwrite the existing data.\"")
+
 ;; This hack depends on how Clio spells error messages.
 ;;
 (defn ^:private hack-try-increment-version-in-clio-add-bam?
@@ -163,12 +170,8 @@
     (and
      (== 400 status)
      (= "Bad Request" reason-phrase)
-     (str/starts-with?
-      body
-      "Adding this document will overwrite the following existing metadata:")
-     (str/ends-with?
-      body
-      "Use 'force=true' to overwrite the existing data."))))
+     (str/starts-with? body clio-force=true-error-message-starts)
+     (str/ends-with?   body clio-force=true-error-message-ends))))
 
 (defn ^:private hack-clio-add-bam-with-version-incremented
   "Attempt to add `bam` record to `clio` with version `increment`ed."

--- a/api/src/wfl/module/sg.clj
+++ b/api/src/wfl/module/sg.clj
@@ -158,10 +158,6 @@
 
 ;; This hack depends on how Clio spells error messages.
 ;;
-(defn ^:private hack-clio-add-bam-again
-  "Add `bam` record to `clio` without retries."
-  [clio bam]
-  (clio/add-bam clio bam))
 (def ^:private clio-force=true-error-message-starts
   "How a Clio force=true error message starts."
   "\"Adding this document will overwrite the following existing metadata:")
@@ -184,8 +180,8 @@
   [clio bam]
   (try (clio/add-bam clio bam)
        (catch Throwable x
-         (log/warning {:bam bam :x x})
-         (hack-clio-add-bam-again
+         (log/error {:bam bam :x x})
+         (clio/add-bam
           clio (if (hack-try-increment-version-in-clio-add-bam? x)
                  (-> bam (select-keys clio-key-no-version)
                      (->> (clio/query-bam clio)

--- a/api/src/wfl/module/sg.clj
+++ b/api/src/wfl/module/sg.clj
@@ -166,7 +166,11 @@
   "True when `exception` suggests that `clio-add-bam` might succeed
   with the version incremented."
   [exception]
+  (wfl.debug/trace exception)
   (let [{:keys [body reason-phrase status]} (ex-data exception)]
+    (wfl.debug/trace status)
+    (wfl.debug/trace reason-phrase)
+    (wfl.debug/trace body)
     (and
      (== 400 status)
      (= "Bad Request" reason-phrase)

--- a/api/src/wfl/module/sg.clj
+++ b/api/src/wfl/module/sg.clj
@@ -115,6 +115,18 @@
       (log/error "More than 1 Clio BAM record" :bam bam :count n))
     (first records)))
 
+(def ^:private clio-key-no-version
+  "The Clio metadata fields in a BAM or CRAM record key without `:version`."
+  [:data_type :location :project :sample_alias])
+
+(def ^:private clio-cram-keys
+  "The Clio CRAM fields to promote to new BAM records."
+  (concat clio-key-no-version [:billing_project
+                               :document_status
+                               :insert_size_metrics_path
+                               :notes
+                               :version]))
+
 (defn ^:private clio-cram-record
   "Return the useful part of the `clio` record for `input_cram` or throw."
   [clio input_cram]
@@ -123,15 +135,7 @@
     (when (not= 1 n)
       (log/error "Expected 1 Clio record with cram_path"
                  :count n :cram_path input_cram))
-    (-> records first (select-keys [:billing_project
-                                    :data_type
-                                    :document_status
-                                    :insert_size_metrics_path
-                                    :location
-                                    :notes
-                                    :project
-                                    :sample_alias
-                                    :version]))))
+    (-> records first (select-keys clio-cram-keys))))
 
 (defn ^:private final_workflow_outputs_dir_hack
   "Do to `file` what Cromwell's `{:final_workflow_outputs_dir output}` does."
@@ -154,6 +158,11 @@
 
 ;; This hack depends on how Clio spells error messages.
 ;;
+(defn ^:private hack-clio-add-bam-again
+  "Add `bam` record to `clio` without retries."
+  [clio bam]
+  (wfl.debug/trace ['hack-clio-add-bam-again bam])
+  (clio/add-bam clio bam))
 (def ^:private clio-force=true-error-message-starts
   "How a Clio force=true error message starts."
   "\"Adding this document will overwrite the following existing metadata:")
@@ -175,24 +184,22 @@
      (str/starts-with? body clio-force=true-error-message-starts)
      (str/ends-with?   body clio-force=true-error-message-ends))))
 
-(defn ^:private hack-clio-add-bam-with-version-incremented
-  "Attempt to add `bam` record to `clio` with version `increment`ed."
-  [clio bam increment]
-  (wfl.debug/trace increment)
-  (wfl.debug/trace bam)
-  (when (> increment 2)
-    (throw (ex-info "Cannot update Clio" {:bam bam :clio clio})))
-  (try (clio/add-bam clio (update bam :version + increment))
+(defn ^:private clio-add-bam
+  "Add `bam` to `clio`, and maybe retry once with a new :version."
+  [clio bam]
+  (wfl.debug/trace ['clio-add-bam bam])
+  (try (clio/add-bam clio bam)
        (catch Throwable x
          (log/warning {:bam bam :x x})
-         (if (hack-try-increment-version-in-clio-add-bam? x)
-           (hack-clio-add-bam-with-version-incremented clio bam (inc increment))
-           (throw x)))))
-
-(defn ^:private clio-add-bam
-  "Add `bam` record to `clio`, and maybe retry after incrementing :version."
-  [clio bam]
-  (hack-clio-add-bam-with-version-incremented clio bam 0))
+         (hack-clio-add-bam-again
+          clio (if (hack-try-increment-version-in-clio-add-bam? x)
+                 (-> bam (select-keys clio-key-no-version)
+                     (->> (clio/query-bam clio)
+                          (sort-by :version)
+                          wfl.debug/trace
+                          last :version inc
+                          (assoc bam :version)))
+                 bam)))))
 
 (defn ^:private maybe-update-clio-and-write-final-files
   "Maybe update `clio-url` with `final` and write files and `metadata`."

--- a/api/src/wfl/module/staged.clj
+++ b/api/src/wfl/module/staged.clj
@@ -12,8 +12,7 @@
             [wfl.stage            :as stage]
             [wfl.util             :as util :refer [utc-now]]
             [wfl.wfl              :as wfl])
-  (:import [java.util UUID]
-           [wfl.util UserException]))
+  (:import [wfl.util UserException]))
 
 (def pipeline nil)
 
@@ -79,7 +78,7 @@
                :output   ""
                :release  ""
                :wdl      ""
-               :uuid     (UUID/randomUUID))
+               :uuid     (random-uuid))
         (->> (jdbc/insert! tx :workload) first :id))))
 
 (def ^:private update-workload-query

--- a/api/src/wfl/server.clj
+++ b/api/src/wfl/server.clj
@@ -1,7 +1,7 @@
 (ns wfl.server
   "An HTTP API server."
-  (:require [clojure.string                 :as str]
-            [clj-time.coerce                :as tc]
+  (:require [clj-time.coerce                :as tc]
+            [clojure.string                 :as str]
             [ring.adapter.jetty             :as jetty]
             [ring.middleware.defaults       :as defaults]
             [ring.middleware.json           :refer [wrap-json-response]]

--- a/api/src/wfl/service/firecloud.clj
+++ b/api/src/wfl/service/firecloud.clj
@@ -8,7 +8,6 @@
             [wfl.log           :as log]
             [wfl.util          :as util])
   (:import [clojure.lang ExceptionInfo]
-           [java.util UUID]
            [wfl.util UserException]))
 
 (defn terra-ui-url
@@ -273,7 +272,7 @@
           (array-map :expression)
           (create-submission workspace methodconfig [entity-set-type entity-set-name]))))
   ([workspace methodconfig entities]
-   (create-submission-for-entity-set workspace methodconfig entities (str (UUID/randomUUID)))))
+   (create-submission-for-entity-set workspace methodconfig entities (str (random-uuid)))))
 
 (defn list-method-configurations
   "List all method configurations in the `workspace`."

--- a/api/src/wfl/sink.clj
+++ b/api/src/wfl/sink.clj
@@ -75,7 +75,7 @@
 
 ;; reitit coercion spec
 (s/def ::terra-workspace-sink
-  (s/and (all/has? :name #(= terra-workspace-sink-name %))
+  (s/and #(= terra-workspace-sink-name (:name %))
          (s/keys :req-un [::all/workspace
                           ::all/entityType
                           ::identifier
@@ -234,7 +234,7 @@
 
 ;; reitit coercion spec
 (s/def ::terra-datarepo-sink
-  (s/and (all/has? :name #(= datarepo-sink-name %))
+  (s/and #(= datarepo-sink-name (:name %))
          (s/keys :req-un [::all/dataset ::all/table ::fromOutputs])))
 
 (defn ^:private write-datarepo-sink [tx id request]

--- a/api/src/wfl/source.clj
+++ b/api/src/wfl/source.clj
@@ -1,8 +1,9 @@
 (ns wfl.source
+  "Workload source interface and its implementations."
   (:require [clojure.edn          :as edn]
             [clojure.instant      :as instant]
-            [clojure.spec.alpha   :as s]
             [clojure.set          :as set]
+            [clojure.spec.alpha   :as s]
             [clojure.string       :as str]
             [wfl.api.workloads    :refer [defoverload] :as workloads]
             [wfl.jdbc             :as jdbc]

--- a/api/src/wfl/util.clj
+++ b/api/src/wfl/util.clj
@@ -350,7 +350,7 @@
 (defn randomize
   "Append a random suffix to `string`."
   [string]
-  (str string (str/replace (UUID/randomUUID) "-" "")))
+  (str string (str/replace (random-uuid) "-" "")))
 
 (defn curry
   "Curry the function `f` such that its arguments may be supplied across two

--- a/api/src/wfl/util.clj
+++ b/api/src/wfl/util.clj
@@ -4,7 +4,6 @@
             [clojure.data.json  :as json]
             [clojure.java.io    :as io]
             [clojure.java.shell :as shell]
-            [clojure.spec.alpha :as s]
             [clojure.string     :as str]
             [wfl.log            :as log]
             [wfl.wfl            :as wfl])
@@ -360,26 +359,26 @@
   (fn [x & xs] (apply partial f x xs)))
 
 (defn poll
-  "Call `task!` every `seconds` [default: 1] while it returns `nil`, up
-  to `max-attempts` times [default: 3].  Return the non-nil result or
-  throw."
+  "Call `task!` every `seconds` [default: 30] while it returns `nil`.
+  Throw after `max-attempts` [default: 30] or return the result."
   ([task! seconds max-attempts]
    (loop [attempt 1]
      (if-some [result (task!)]
        result
        (do (when (<= max-attempts attempt)
-             (throw (TimeoutException. "Max number of attempts exceeded")))
+             (throw (TimeoutException. (format "Tried %s times" max-attempts))))
            (log/debug
             (format "Sleeping - attempt #%s of %s" attempt max-attempts))
            (.sleep TimeUnit/SECONDS seconds)
            (recur (inc attempt))))))
   ([task seconds]
-   (poll task seconds 3))
+   (poll task seconds 30))
   ([task]
-   (poll task 1)))
+   (poll task 30)))
 
-"A set of all mutually supported TSV file types (by FireCloud and WFL)"
-(s/def ::tsv-type #{:entity :membership})
+(def ^:private tsv-type?
+  "The TSV file types supported by FireCloud and WFL."
+  #{:entity :membership})
 
 (defn terra-id
   "
@@ -405,7 +404,7 @@
 
   Parameters
   ----------
-    tsv-type - A member of ::tsv-type
+    tsv-type - One of tsv-type?
     col      - Entity name or primary key column base
 
   Examples
@@ -414,7 +413,7 @@
     (terra_id :membership \"flowcell\")
   "
   [tsv-type col]
-  {:pre [(s/valid? ::tsv-type tsv-type)]}
+  {:pre [(tsv-type? tsv-type)]}
   (str/join [(name tsv-type)
              ":"
              (-> col (unsuffix "_id") (unsuffix "_set"))
@@ -445,7 +444,7 @@
 
   Parameters
   ----------
-    tsv-type - A member of ::tsv-type
+    tsv-type - One of tsv-type?
     columns  - Column names (first will be formatted as primary key identifier)
     rows     - Rows with element counts matching the column count
     file     - [optional] TSV file name to dump
@@ -456,7 +455,7 @@
     (columns-rows->terra-tsv :membership [c1 c2 c3] [[x1 x2 x3] [y1 y2 y3] ...] \"dest.tsv\")
   "
   ([tsv-type columns rows file]
-   {:pre [(s/valid? ::tsv-type tsv-type)]}
+   {:pre [(tsv-type? tsv-type)]}
    (letfn [(format-entity-type [[head & rest]]
              (cons (terra-id tsv-type head) rest))]
      (columns-rows->tsv [(format-entity-type columns)] rows file)))

--- a/api/src/wfl/wfl.clj
+++ b/api/src/wfl/wfl.clj
@@ -1,8 +1,8 @@
 (ns wfl.wfl
   "Stuff specific to WFL."
-  (:require [clojure.edn :as edn]
+  (:require [clojure.edn     :as edn]
             [clojure.java.io :as io]
-            [clojure.string :as str]))
+            [clojure.string  :as str]))
 
 (def the-name
   "Use this name to refer to this program."
@@ -34,7 +34,7 @@
        :commit "aaaaabbbbbcccccdddddeeeeefffffggggghhhhh"}))
 
 (defn get-wfl-resource
-  "Return a wfl resource."
+  "Return the wfl resource at `path`."
   [path]
   (or (some-> (str/join "/" ["wfl" path])
               io/resource

--- a/api/test/wfl/integration/datarepo_test.clj
+++ b/api/test/wfl/integration/datarepo_test.clj
@@ -13,8 +13,7 @@
             [wfl.tools.resources         :as resources]
             [wfl.tools.snapshots         :as snapshots]
             [wfl.tools.workflows         :as workflows]
-            [wfl.util                    :as util])
-  (:import [java.util UUID]))
+            [wfl.util                    :as util]))
 
 (def ^:private testing-dataset {:id   "4a5d30fe-1f99-42cd-998b-a979885dea00"
                                 :name "workflow_launcher_testing_dataset"})
@@ -64,7 +63,7 @@
          (datasets/unique-dataset-request tdr-profile dataset-json))]
       (fn [[temp-bucket dataset-id]]
         (let [table-url        (str temp-bucket "table.json")
-              workflow-id      (UUID/randomUUID)
+              workflow-id      (random-uuid)
               dataset          (datarepo/datasets dataset-id)
               [_bucket object] (gcs/parse-gs-url temp-bucket)]
           (-> (#'sink/rename-gather-bulk workflow-id

--- a/api/test/wfl/integration/executor_test.clj
+++ b/api/test/wfl/integration/executor_test.clj
@@ -12,8 +12,7 @@
             [wfl.tools.fixtures    :as fixtures]
             [wfl.tools.queues      :refer [make-queue-from-list]]
             [wfl.util              :as util])
-  (:import [java.util UUID]
-           [wfl.util UserException]))
+  (:import [wfl.util UserException]))
 
 (def ^:private testing-namespace
   "wfl-dev")
@@ -80,10 +79,10 @@
 (def ^:private snapshot-table-name "snapshot-table")
 (defn ^:private mock-datarepo-snapshot [& _]
   {:name   snapshot-name
-   :id     (str (UUID/randomUUID))
+   :id     (str (random-uuid))
    :tables [{:name snapshot-table-name}]})
 
-(def ^:private snapshot-reference-id (str (UUID/randomUUID)))
+(def ^:private snapshot-reference-id (str (random-uuid)))
 (defn ^:private mock-rawls-snapshot-reference [& _]
   {:metadata {:name            snapshot-name
               :resourceId      snapshot-reference-id
@@ -122,7 +121,7 @@
 
 (defn ^:private workflow-base [entity status]
   {:entity      entity
-   :workflow-id (str (UUID/randomUUID))
+   :workflow-id (str (random-uuid))
    :status      status})
 
 (def ^:private init-submission-id  "init-submission-id")
@@ -235,7 +234,7 @@
 (deftest test-update-terra-executor
   (let [source        (make-queue-from-list [[:datarepo/snapshot (mock-datarepo-snapshot)]])
         executor      (create-terra-executor (rand-int 1000000))
-        workload-uuid (UUID/randomUUID)
+        workload-uuid (random-uuid)
         workload      {:uuid workload-uuid :source source :executor executor}]
     (letfn [(verify-record-against-workflow [record workflow idx]
               (is (= idx (:id record))
@@ -282,7 +281,7 @@
   (let [succeeded?    #{"Succeeded"}
         source        (make-queue-from-list [[:datarepo/snapshot (mock-datarepo-snapshot)]])
         executor      (create-terra-executor (rand-int 1000000))
-        workload-uuid (UUID/randomUUID)
+        workload-uuid (random-uuid)
         workload      {:uuid workload-uuid :source source :executor executor}]
     (with-redefs
      [rawls/create-or-get-snapshot-reference mock-rawls-snapshot-reference
@@ -313,7 +312,7 @@
 (deftest test-terra-executor-retry-workflows
   (let [source        (make-queue-from-list [[:datarepo/snapshot (mock-datarepo-snapshot)]])
         executor      (create-terra-executor (rand-int 1000000))
-        workload-uuid (UUID/randomUUID)
+        workload-uuid (random-uuid)
         workload      {:uuid workload-uuid :source source :executor executor}]
     (with-redefs
      [rawls/create-or-get-snapshot-reference mock-rawls-snapshot-reference
@@ -329,7 +328,7 @@
       (is (== 2 (stage/queue-length executor))
           "Two workflows should be enqueued prior to retry.")
       (let [executor      (reload-terra-executor executor)
-            workload-uuid (UUID/randomUUID)
+            workload-uuid (random-uuid)
             workload      {:uuid workload-uuid :source source :executor executor}]
         (is (== 2 (:methodConfigurationVersion executor))
             "Reloaded executor's method config should have version 2 post-update.")
@@ -397,7 +396,7 @@
     firecloud/get-workflow-outputs         mock-firecloud-get-workflow-outputs]
     (let [source        (make-queue-from-list [[:datarepo/snapshot (mock-datarepo-snapshot)]])
           executor      (create-terra-executor (rand-int 1000000))
-          workload-uuid (UUID/randomUUID)
+          workload-uuid (random-uuid)
           workload      {:uuid workload-uuid :source source :executor executor}]
       (with-redefs
        [workloads/load-workload-for-uuid (mock-load-workload-for-uuid source executor)]
@@ -423,7 +422,7 @@
     firecloud/get-workflow-outputs         mock-firecloud-get-workflow-outputs]
     (let [source        (make-queue-from-list [[:datarepo/snapshot (mock-datarepo-snapshot)]])
           executor      (create-terra-executor (rand-int 1000000))
-          workload-uuid (UUID/randomUUID)
+          workload-uuid (random-uuid)
           workload      {:uuid workload-uuid :source source :executor executor}]
       (with-redefs
        [workloads/load-workload-for-uuid (mock-load-workload-for-uuid source executor)]
@@ -461,7 +460,7 @@
      [rawls/create-snapshot-reference        throw-if-called
       rawls/create-or-get-snapshot-reference mock-rawls-snapshot-reference]
       (let [executor  (create-terra-executor (rand-int 1000000))
-            workload  {:uuid (UUID/randomUUID) :executor executor}
+            workload  {:uuid (random-uuid) :executor executor}
             reference (#'executor/entity-from-snapshot workload (mock-datarepo-snapshot))]
         (is (= snapshot-reference-id (get-in reference [:metadata :resourceId])))
         (is (= snapshot-name (get-in reference [:metadata :name])))))))
@@ -469,7 +468,7 @@
 (deftest test-update-method-configuration-with-version-mismatch
   (let [id                    (rand-int 1000000)
         executor              (create-terra-executor id)
-        workload              {:uuid (UUID/randomUUID) :executor executor}
+        workload              {:uuid (random-uuid) :executor executor}
         dataReferenceNamePre  "snapshotReferenceNamePreUpdate"
         dataReferenceNamePost "snapshotReferenceNamePostUpdate"
         reference             {:metadata {:name dataReferenceNamePost}}

--- a/api/test/wfl/integration/firecloud_test.clj
+++ b/api/test/wfl/integration/firecloud_test.clj
@@ -3,8 +3,7 @@
             [clojure.test          :refer [deftest is testing]]
             [wfl.service.cromwell  :as cromwell]
             [wfl.service.firecloud :as firecloud]
-            [wfl.util              :as util])
-  (:import [java.util UUID]))
+            [wfl.util              :as util]))
 
 ;; Of the form NAMESPACE/NAME
 (def workspace "wfl-dev/Illumina-Genotyping-Array")
@@ -46,7 +45,7 @@
                                                              []))))
   (doseq [entity-count (range 1 4)]
     (testing (str "Submission with " entity-count " matching entit(ies) yields 1 workflow")
-      (let [entity-set-name (str (UUID/randomUUID))]
+      (let [entity-set-name (str (random-uuid))]
         (util/bracket
          (comp :submissionId
                #(firecloud/create-submission-for-entity-set
@@ -74,7 +73,7 @@
 (deftest test-import-entity-set
   (doseq [entity-count (range 1 4)]
     (testing (str "Import entity set with " entity-count " matching entit(ies)")
-      (let [entity-set-name (str (UUID/randomUUID))]
+      (let [entity-set-name (str (random-uuid))]
         (util/bracket
          #(-> (firecloud/import-entity-set workspace entity-set-name (repeat entity-count entity))
               :body)

--- a/api/test/wfl/integration/google/storage_test.clj
+++ b/api/test/wfl/integration/google/storage_test.clj
@@ -5,8 +5,7 @@
             [clojure.test :refer [deftest is testing]]
             [wfl.auth :as auth]
             [wfl.service.google.storage :as gcs]
-            [wfl.tools.fixtures :as fixtures])
-  (:import [java.util UUID]))
+            [wfl.tools.fixtures :as fixtures]))
 
 (deftest object-test
   (fixtures/with-temporary-cloud-storage-folder
@@ -29,7 +28,7 @@
           (is (gcs/copy-object bucket (str src-folder  "test")
                                bucket (str dest-folder "test"))))
         (testing "download"
-          (let [local-file-name (str/join "-" ["wfl" "test" (UUID/randomUUID)])]
+          (let [local-file-name (str/join "-" ["wfl" "test" (random-uuid)])]
             (gcs/download-file local-file-name bucket (str dest-folder "test"))
             (try
               (is (= (slurp dockerfile) (slurp local-file-name)))

--- a/api/test/wfl/integration/modules/aou_test.clj
+++ b/api/test/wfl/integration/modules/aou_test.clj
@@ -7,19 +7,18 @@
             [wfl.module.batch               :as batch]
             [wfl.tools.fixtures             :as fixtures]
             [wfl.tools.workloads            :as workloads]
-            [wfl.util                       :as util])
-  (:import [java.util UUID]))
+            [wfl.util                       :as util]))
 
 (clojure.test/use-fixtures :once fixtures/temporary-postgresql-database)
 
-(defn mock-submit-workload [& _] (UUID/randomUUID))
+(defn mock-submit-workload [& _] (random-uuid))
 (defn mock-update-statuses! [tx {:keys [items] :as workload}]
   (letfn [(f [{:keys [id]}]
             (jdbc/update! tx items {:status "Succeeded"} ["id = ?" id]))]
     (run! f (workloads/workflows workload))))
 
 (defn ^:private make-aou-workload-request []
-  (-> (workloads/aou-workload-request (UUID/randomUUID))
+  (-> (workloads/aou-workload-request (random-uuid))
       (assoc :creator @workloads/email)))
 
 (defn ^:private inc-version [sample]

--- a/api/test/wfl/integration/modules/copyfile_test.clj
+++ b/api/test/wfl/integration/modules/copyfile_test.clj
@@ -11,8 +11,7 @@
             [wfl.tools.fixtures             :as fixtures]
             [wfl.tools.workloads            :as workloads]
             [wfl.util                       :as util])
-  (:import [java.util UUID]
-           [java.time OffsetDateTime]))
+  (:import [java.time OffsetDateTime]))
 
 (use-fixtures :once fixtures/temporary-postgresql-database)
 
@@ -45,7 +44,7 @@
             (let [defaults (copyfile/make-workflow-options url)]
               (verify-workflow-options options)
               (is (= defaults (select-keys options (keys defaults))))
-              (UUID/randomUUID)))]
+              (random-uuid)))]
     (with-redefs-fn {#'cromwell/submit-workflow verify-submitted-options}
       (fn []
         (->
@@ -71,7 +70,7 @@
           (verify-submitted-inputs [_ _ inputs _ _]
             (is (every? #(prefixed? :copyfile %) (keys inputs)))
             (verify-workflow-inputs (into {} (map strip-prefix inputs)))
-            (UUID/randomUUID))]
+            (random-uuid))]
     (with-redefs-fn {#'cromwell/submit-workflow verify-submitted-inputs}
       (fn []
         (->
@@ -102,7 +101,7 @@
 
 (deftest test-workload-state-transition
   (with-redefs-fn
-    {#'cromwell/submit-workflow              (fn [& _] (UUID/randomUUID))
+    {#'cromwell/submit-workflow              (fn [& _] (random-uuid))
      #'batch/batch-update-workflow-statuses! (partial mock-batch-update-workflow-statuses! "Succeeded")}
     #(shared/run-workload-state-transition-test!
       (make-copyfile-workload-request "gs://b/in" "gs://b/out"))))
@@ -113,7 +112,7 @@
 
 (deftest test-retry-failed-workflows
   (with-redefs-fn
-    {#'cromwell/submit-workflow              (fn [& _] (UUID/randomUUID))
+    {#'cromwell/submit-workflow              (fn [& _] (random-uuid))
      #'batch/batch-update-workflow-statuses! (partial mock-batch-update-workflow-statuses! "Failed")}
     #(shared/run-retry-is-not-supported-test!
       (make-copyfile-workload-request "gs://b/in" "gs://b/out"))))

--- a/api/test/wfl/integration/modules/sg_test.clj
+++ b/api/test/wfl/integration/modules/sg_test.clj
@@ -367,10 +367,6 @@
                   gcs/upload-content        mock-gcs-upload-content]
       (is (thrown-with-msg? Exception #"clj-http: status 500" (test-clio-updates))))))
 
-(comment
-  (clojure.test/test-vars [#'test-handle-add-bam-force=true-for-real])
-  (clojure.test/test-vars [#'test-handle-add-bam-force=true-mocked]))
-
 (deftest test-handle-add-bam-force=true-for-real
   (let [bug     "GH-1691"
         clio    "https://clio.gotc-dev.broadinstitute.org"

--- a/api/test/wfl/integration/modules/sg_test.clj
+++ b/api/test/wfl/integration/modules/sg_test.clj
@@ -320,22 +320,23 @@
                 (is (= (count items)
                        (-> workload workloads/workflows count))))))))
 
+;; The `body` below is only an approximation of what Scala generates
+;; for Clio's error message.
+;;
 (defn ^:private mock-add-bam-suggest-force=true
-  "Throw rejecting the `_md` update to `_clio` and suggesting force=true."
+  "Reject the `_md` update to `_clio` and suggest force=true."
   [_clio {:keys [bam_path version] :as _md}]
   (if (= 23 version)
-    (let [adding  (str/join \space   ["Adding this document will overwrite"
-                                      "the following existing metadata:"])
-          field   "Field: Chain(Left(bam_path)),"
+    (let [field   "Field: Chain(Left(bam_path)),"
           oldval  "Old value: \"gs://bam/oldval.bam\","
           newval  (format "New value: \"%s\"." bam_path)
-          force   "Use 'force=true' to overwrite the existing data."
-          message (str/join \space   [field oldval newval force])
-          stuff   (str/join \newline [adding message])
-          body    (str \" stuff \")]
-      (throw (ex-info "clj-http: status 400" {:body          body
-                                              :reason-phrase "Bad Request"
-                                              :status        400})))
+          body    (str @#'sg/clio-force=true-error-message-starts
+                       \newline field \space oldval \space newval \space
+                       @#'sg/clio-force=true-error-message-ends)]
+      (throw (ex-info "clj-http: status 400"
+                      {:body          body
+                       :reason-phrase "Bad Request"
+                       :status        400})))
     (is (= 24 version) "-Is-A-Clio-Record-Id")))
 
 (defn ^:private mock-add-bam-throw-something-else

--- a/api/test/wfl/integration/modules/sg_test.clj
+++ b/api/test/wfl/integration/modules/sg_test.clj
@@ -315,11 +315,11 @@
   (let [{:keys [items] :as request} (make-sg-workload-request)]
     (-> request workloads/execute-workload! workloads/update-workload!
         (as-> workload
-            (let [{:keys [finished pipeline]} workload]
-              (is finished)
-              (is (= sg/pipeline pipeline))
-              (is (= (count items)
-                     (-> workload workloads/workflows count))))))))
+              (let [{:keys [finished pipeline]} workload]
+                (is finished)
+                (is (= sg/pipeline pipeline))
+                (is (= (count items)
+                       (-> workload workloads/workflows count))))))))
 
 ;; The `body` below is only an approximation of what Scala generates
 ;; for Clio's error message.
@@ -369,8 +369,7 @@
 
 (comment
   (clojure.test/test-vars [#'test-handle-add-bam-force=true-for-real])
-  (clojure.test/test-vars [#'test-handle-add-bam-force=true-mocked])
-  )
+  (clojure.test/test-vars [#'test-handle-add-bam-force=true-mocked]))
 
 (deftest test-handle-add-bam-force=true-for-real
   (let [bug     "GH-1691"
@@ -497,6 +496,6 @@
 (deftest test-retry-workflows-supported
   (let [fail (partial mock-batch-update-workflow-statuses! "Failed")]
     (with-redefs
-      [cromwell/submit-workflows             mock-cromwell-submit-workflows
-       batch/batch-update-workflow-statuses! fail]
+     [cromwell/submit-workflows             mock-cromwell-submit-workflows
+      batch/batch-update-workflow-statuses! fail]
       (shared/run-workload-state-transition-test! (make-sg-workload-request)))))

--- a/api/test/wfl/integration/modules/sg_test.clj
+++ b/api/test/wfl/integration/modules/sg_test.clj
@@ -331,7 +331,8 @@
           newval  (format "New value: \"%s\"." bam_path)
           force   "Use 'force=true' to overwrite the existing data."
           message (str/join \space   [field oldval newval force])
-          body    (str/join \newline [adding message])]
+          stuff   (str/join \newline [adding message])
+          body    (str \" stuff \")]
       (throw (ex-info "clj-http: status 400" {:body          body
                                               :reason-phrase "Bad Request"
                                               :status        400})))

--- a/api/test/wfl/integration/modules/sg_test.clj
+++ b/api/test/wfl/integration/modules/sg_test.clj
@@ -385,7 +385,7 @@
                  :pipeline "GDCWholeGenomeSomaticSingleSample"
                  :project  @workloads/project
                  :items    [{:inputs inputs}]}]
-    (testing "That the `common` keys agree with `sg/clio-key-no-version`"
+    (testing "That the `common` keys agree with `sg/clio-key-no-version`."
       (is (= (set (keys common)) (set @#'sg/clio-key-no-version))))
     (letfn [(path [id suffix] (str (:output request) \/ id \/ bug \. suffix))
             (make-bam-path [id]

--- a/api/test/wfl/integration/modules/staged_test.clj
+++ b/api/test/wfl/integration/modules/staged_test.clj
@@ -42,13 +42,12 @@
 (def ^:private testing-method-configuration (str testing-namespace "/" testing-method-name))
 (def ^:private testing-table-name "flowcells")
 
-(let [new-env {"WFL_FIRECLOUD_URL" "https://api.firecloud.org"
-               "WFL_TDR_URL"       "https://data.terra.bio"
-               "WFL_RAWLS_URL"     "https://rawls.dsde-prod.broadinstitute.org"}]
-
-  (use-fixtures :once
-    (fixtures/temporary-environment new-env)
-    fixtures/temporary-postgresql-database))
+(use-fixtures :once
+  (fixtures/temporary-environment
+   {"WFL_FIRECLOUD_URL" "https://api.firecloud.org"
+    "WFL_RAWLS_URL"     "https://rawls.dsde-prod.broadinstitute.org"
+    "WFL_TDR_URL"       "https://data.terra.bio"})
+  fixtures/temporary-postgresql-database)
 
 (deftest test-create-workload
   (letfn [(verify-source [{:keys [type last_checked details]}]

--- a/api/test/wfl/integration/modules/staged_test.clj
+++ b/api/test/wfl/integration/modules/staged_test.clj
@@ -14,7 +14,6 @@
             [wfl.tools.workloads            :as workloads]
             [wfl.util                       :as util])
   (:import [java.time LocalDateTime]
-           [java.util UUID]
            [wfl.util UserException]))
 
 ;; Snapshot creation mock
@@ -30,7 +29,7 @@
 
 ;; Note this mock only covers happy paths of TDR jobs
 (defn ^:private mock-check-tdr-job [job-id _workload]
-  {:snapshot_id (str (UUID/randomUUID))
+  {:snapshot_id (str (random-uuid))
    :job_status "succeeded"
    :id job-id})
 
@@ -146,9 +145,9 @@
 (def ^:private fake-method-name "method-name")
 ;; Snapshot and snapshot reference mocks
 (def ^:private snapshot
-  {:name "test-snapshot-name" :id (str (UUID/randomUUID))})
+  {:name "test-snapshot-name" :id (str (random-uuid))})
 
-(def ^:private snapshot-reference-id (str (UUID/randomUUID)))
+(def ^:private snapshot-reference-id (str (random-uuid)))
 (def ^:private snapshot-reference-name (str (:name snapshot) "-ref"))
 (defn ^:private mock-rawls-snapshot-reference [& _]
   {:referenceId snapshot-reference-id
@@ -167,18 +166,18 @@
       "Incremented version should be passed to method config update")
   nil)
 
-(def ^:private submission-id-mock (str (UUID/randomUUID)))
+(def ^:private submission-id-mock (str (random-uuid)))
 
 (def ^:private running-workflow-mock
   {:entityName   "entity"
-   :id           (str (UUID/randomUUID))
+   :id           (str (random-uuid))
    :inputs       {:input "value"}
    :status       "Running"
    :workflowName fake-method-name})
 
 (def ^:private succeeded-workflow-mock
   {:entityName   "entity"
-   :id           (str (UUID/randomUUID))
+   :id           (str (random-uuid))
    :inputs       {:input "value"}
    :status       "Succeeded"
    :workflowName fake-method-name})

--- a/api/test/wfl/integration/modules/wgs_test.clj
+++ b/api/test/wfl/integration/modules/wgs_test.clj
@@ -14,16 +14,15 @@
             [wfl.tools.fixtures             :as fixtures]
             [wfl.tools.workloads            :as workloads]
             [wfl.util                       :as util])
-  (:import [java.util UUID]
-           [java.time OffsetDateTime]))
+  (:import [java.time OffsetDateTime]))
 
 (use-fixtures :once fixtures/temporary-postgresql-database)
 
 (defn ^:private mock-submit-workflows [_ _ inputs _ _]
-  (map (fn [_] (UUID/randomUUID)) inputs))
+  (map (fn [_] (random-uuid)) inputs))
 
 (defn ^:private make-wgs-workload-request []
-  (-> (UUID/randomUUID)
+  (-> (random-uuid)
       workloads/wgs-workload-request
       (assoc :creator @workloads/email)))
 
@@ -109,7 +108,7 @@
             (map
              (fn [in]
                (verify-use_input_bam! (into {} (map strip-prefix in)) labels)
-               (UUID/randomUUID))
+               (random-uuid))
              inputs))]
     (with-redefs-fn
       {#'cromwell/submit-workflows verify-inputs}
@@ -132,7 +131,7 @@
              (fn [in]
                (is (every? #(prefixed? :ExternalWholeGenomeReprocessing %) (keys in)))
                (verify-workflow-inputs (into {} (map strip-prefix in)))
-               (UUID/randomUUID))
+               (random-uuid))
              inputs))]
     (with-redefs-fn {#'cromwell/submit-workflows verify-submitted-inputs}
       (fn []
@@ -158,7 +157,7 @@
             (map
              (fn [in]
                (verify-workflow-inputs (into {} (map strip-prefix in)))
-               (UUID/randomUUID))
+               (random-uuid))
              inputs))
           (test-with-input [key value]
             (let [request (-> (make-wgs-workload-request)
@@ -178,7 +177,7 @@
             (let [defaults (wgs/make-workflow-options url)]
               (verify-workflow-options options)
               (is (= defaults (select-keys options (keys defaults))))
-              (map (fn [_] (UUID/randomUUID)) inputs)))]
+              (map (fn [_] (random-uuid)) inputs)))]
     (with-redefs-fn {#'cromwell/submit-workflows verify-submitted-options}
       (fn []
         (->
@@ -219,6 +218,6 @@
 
 (deftest test-retry-failed-workflows
   (with-redefs-fn
-    {#'cromwell/submit-workflow              (fn [& _] (UUID/randomUUID))
+    {#'cromwell/submit-workflow              (fn [& _] (random-uuid))
      #'batch/batch-update-workflow-statuses! (partial mock-batch-update-workflow-statuses! "Failed")}
     #(shared/run-retry-is-not-supported-test! (make-wgs-workload-request))))

--- a/api/test/wfl/integration/sinks/datarepo_sink_test.clj
+++ b/api/test/wfl/integration/sinks/datarepo_sink_test.clj
@@ -12,9 +12,8 @@
             [wfl.tools.resources  :as resources]
             [wfl.tools.workloads  :refer [evalT]]
             [wfl.util             :as util])
-  (:import [java.util UUID]
-           [wfl.util UserException]
-           [java.util.concurrent TimeUnit]))
+  (:import [java.util.concurrent TimeUnit]
+           [wfl.util UserException]))
 
 (def ^:private ^:dynamic *dataset*)
 
@@ -146,9 +145,9 @@
 (deftest test-update-datarepo-sink
   (let [outfile          "gs://not-a-real-bucket/not-a-real.unmapped.bam"
         description      (resources/read-resource "primitive.edn")
-        workflow         {:uuid (UUID/randomUUID) :outputs outputs}
+        workflow         {:uuid (random-uuid) :outputs outputs}
         upstream         (make-queue-from-list [[description workflow]])
-        failing-workflow {:uuid (UUID/randomUUID)
+        failing-workflow {:uuid (random-uuid)
                           :outputs {:outbool   true
                                     :outfile   outfile
                                     :outfloat  1.23

--- a/api/test/wfl/integration/source_test.clj
+++ b/api/test/wfl/integration/source_test.clj
@@ -11,8 +11,7 @@
             [wfl.tools.fixtures   :as fixtures]
             [wfl.util             :as util])
   (:import [java.time Instant LocalDateTime]
-           [java.util UUID]
-           [wfl.util  UserException]))
+           [wfl.util UserException]))
 
 (def ^:private testing-dataset "cd25d59e-1451-44d0-8a24-7669edb9a8f8")
 (def ^:private testing-snapshot "e8f1675e-1e7c-48b4-92ab-3598425c149d")
@@ -39,7 +38,7 @@
 
 ;; Note this mock only covers happy paths of TDR jobs
 (defn ^:private mock-check-tdr-job [job-id _workload]
-  {:snapshot_id (str (UUID/randomUUID))
+  {:snapshot_id (str (random-uuid))
    :job_status  "succeeded"
    :id          job-id})
 
@@ -64,7 +63,7 @@
 ;; A stable vector of TDR row IDs.
 ;;
 (defonce all-rows
-  (delay (vec (repeatedly mock-new-rows-size #(str (UUID/randomUUID))))))
+  (delay (vec (repeatedly mock-new-rows-size #(str (random-uuid))))))
 
 (defn ^:private mock-query-metadata-table-all
   "Mock datarepo/query-metadata-table to find all rows."
@@ -107,7 +106,7 @@
                          [:datarepo_row_id]]
           record-count  (int (Math/ceil (/ mock-new-rows-size 500)))
           source        (create-tdr-source)
-          workload-uuid (UUID/randomUUID)]
+          workload-uuid (random-uuid)]
       (testing "update-source! loads snapshots"
         (with-redefs
          [source/tdr-source-should-poll?             (constantly true)
@@ -183,7 +182,7 @@
 (deftest test-update-tdr-source
   (let [source               (create-tdr-source)
         expected-num-records (int (Math/ceil (/ mock-new-rows-size 500)))
-        workload-uuid        (UUID/randomUUID)]
+        workload-uuid        (random-uuid)]
     (with-redefs
      [source/tdr-source-should-poll?             (constantly true)
       source/create-snapshots                    mock-create-snapshots
@@ -222,7 +221,7 @@
         ex-message      (str "source/find-and-snapshot-new-rows "
                              "should not be called when ineligible "
                              "to poll TDR for new rows.")
-        workload-uuid   (UUID/randomUUID)
+        workload-uuid   (random-uuid)
         throw-if-called (fn [& args] (throw (ex-info ex-message
                                                      {:called-with args})))]
     (with-redefs
@@ -261,7 +260,7 @@
          (source/load-source! tx))))
 
 (deftest test-tdr-snapshot-list-to-edn
-  (let [snapshot {:name "test-snapshot-name" :id (str (UUID/randomUUID))}
+  (let [snapshot {:name "test-snapshot-name" :id (str (random-uuid))}
         source   (util/to-edn (create-tdr-snapshot-list [snapshot]))]
     (is (not-any? source [:id :type]))
     (is (= (:snapshots source) [(:id snapshot)]))

--- a/api/test/wfl/system/v1_endpoint_test.clj
+++ b/api/test/wfl/system/v1_endpoint_test.clj
@@ -23,11 +23,10 @@
             [wfl.tools.workflows        :as workflows]
             [wfl.tools.workloads        :as workloads]
             [wfl.util                   :as util])
-  (:import [clojure.lang ExceptionInfo]
-           [java.util UUID]))
+  (:import [clojure.lang ExceptionInfo]))
 
 (defn make-create-workload [make-request]
-  (fn [] (endpoints/create-workload (make-request (UUID/randomUUID)))))
+  (fn [] (endpoints/create-workload (make-request (random-uuid)))))
 
 (def create-aou-workload (make-create-workload workloads/aou-workload-request))
 (def create-sg-workload  (make-create-workload workloads/sg-workload-request))
@@ -90,14 +89,14 @@
       (test! (set/rename-keys request {:executor :cromwell})))))
 
 (deftest test-create-wgs-workload
-  (test-create-workload (workloads/wgs-workload-request (UUID/randomUUID))))
+  (test-create-workload (workloads/wgs-workload-request (random-uuid))))
 (deftest test-create-aou-workload
-  (test-create-workload (workloads/aou-workload-request (UUID/randomUUID))))
+  (test-create-workload (workloads/aou-workload-request (random-uuid))))
 
 (deftest test-create-xx-workload
-  (test-create-workload (workloads/xx-workload-request (UUID/randomUUID))))
+  (test-create-workload (workloads/xx-workload-request (random-uuid))))
 (deftest test-create-sg-workload
-  (test-create-workload (workloads/sg-workload-request (UUID/randomUUID))))
+  (test-create-workload (workloads/sg-workload-request (random-uuid))))
 (deftest test-create-copyfile-workload
   (test-create-workload (workloads/copyfile-workload-request
                          "gs://fake-inputs/lolcats.txt"
@@ -181,17 +180,17 @@
           (endpoints/stop-workload workload))))))
 
 (deftest ^:parallel test-exec-wgs-workload
-  (test-exec-workload (workloads/wgs-workload-request (UUID/randomUUID))))
+  (test-exec-workload (workloads/wgs-workload-request (random-uuid))))
 (deftest ^:parallel test-exec-wgs-workload-specifying-cromwell
   ;; All modules make use of the same code/behavior here, no need to spam Cromwell
-  (test-exec-workload (-> (workloads/wgs-workload-request (UUID/randomUUID))
+  (test-exec-workload (-> (workloads/wgs-workload-request (random-uuid))
                           (set/rename-keys {:executor :cromwell}))))
 (deftest ^:parallel test-exec-aou-workload
-  (test-exec-workload (workloads/aou-workload-request (UUID/randomUUID))))
+  (test-exec-workload (workloads/aou-workload-request (random-uuid))))
 (deftest ^:parallel test-exec-xx-workload
-  (test-exec-workload (workloads/xx-workload-request (UUID/randomUUID))))
+  (test-exec-workload (workloads/xx-workload-request (random-uuid))))
 (deftest ^:parallel test-exec-sg-workload
-  (test-exec-workload (workloads/sg-workload-request (UUID/randomUUID))))
+  (test-exec-workload (workloads/sg-workload-request (random-uuid))))
 
 (deftest ^:parallel test-exec-copyfile-workload
   (fixtures/with-temporary-cloud-storage-folder
@@ -231,19 +230,19 @@
             cromwell/status?))))
 
 (deftest ^:parallel test-retry-wgs-workload
-  (test-retry-legacy-workload-fails (workloads/wgs-workload-request (UUID/randomUUID))))
+  (test-retry-legacy-workload-fails (workloads/wgs-workload-request (random-uuid))))
 (deftest ^:parallel test-retry-aou-workload
-  (test-retry-legacy-workload-fails (workloads/aou-workload-request (UUID/randomUUID))))
+  (test-retry-legacy-workload-fails (workloads/aou-workload-request (random-uuid))))
 (deftest ^:parallel test-retry-xx-workload
-  (test-retry-legacy-workload-fails (workloads/xx-workload-request (UUID/randomUUID))))
+  (test-retry-legacy-workload-fails (workloads/xx-workload-request (random-uuid))))
 (deftest ^:parallel test-retry-sg-workload
-  (test-retry-legacy-workload-fails (workloads/sg-workload-request (UUID/randomUUID))))
+  (test-retry-legacy-workload-fails (workloads/sg-workload-request (random-uuid))))
 
 (deftest ^:parallel test-append-to-aou-workload
   (let [await    (partial cromwell/wait-for-workflow-complete
                           @workloads/cromwell-url)
         workload (endpoints/exec-workload
-                  (workloads/aou-workload-request (UUID/randomUUID)))]
+                  (workloads/aou-workload-request (random-uuid)))]
     (try
       (testing "appending sample successfully launches an aou workflow"
         (is (->> workload
@@ -330,7 +329,7 @@
                       (str "Expecting 400 error for retry with filters " filters)))]
           (let [status-unretriable "Running"
                 status-retriable   "Failed"
-                submission         (str (UUID/randomUUID))
+                submission         (str (random-uuid))
                 filters-invalid    [{}
                                     {:status status-unretriable}
                                     {:status status-retriable}

--- a/api/test/wfl/tools/fixtures.clj
+++ b/api/test/wfl/tools/fixtures.clj
@@ -12,7 +12,6 @@
             [wfl.util                   :as util])
   (:import [java.nio.file.attribute FileAttribute]
            [java.nio.file Files]
-           [java.util UUID]
            [org.apache.commons.io FileUtils]))
 
 (defn with-temporary-overload
@@ -144,7 +143,7 @@
         (fn [url] #_(use temporary folder at url)))"
   [bucket use-folder]
   (util/bracket
-   #(gcs/gs-url bucket (str "wfl-test-" (UUID/randomUUID) "/"))
+   #(gcs/gs-url bucket (str "wfl-test-" (random-uuid) "/"))
    #(run! (comp (partial gcs/delete-object bucket) :name) (gcs/list-objects %))
    use-folder))
 
@@ -152,7 +151,7 @@
   "Create a temporary Google Cloud Storage Pub/Sub topic."
   [project f]
   (util/bracket
-   #(pubsub/create-topic project (str "wfl-test-" (UUID/randomUUID)))
+   #(pubsub/create-topic project (str "wfl-test-" (random-uuid)))
    pubsub/delete-topic
    f))
 
@@ -168,7 +167,8 @@
   "Create a temporary Google Cloud Storage Pub/Sub subscription"
   [topic f]
   (util/bracket
-   #(pubsub/create-subscription topic (str "wfl-test-subscription-" (UUID/randomUUID)))
+   #(pubsub/create-subscription
+     topic (str "wfl-test-subscription-" (random-uuid)))
    pubsub/delete-subscription
    f))
 

--- a/api/test/wfl/tools/workloads.clj
+++ b/api/test/wfl/tools/workloads.clj
@@ -15,8 +15,7 @@
             [wfl.service.postgres           :as postgres]
             [wfl.tools.endpoints            :as endpoints]
             [wfl.util                       :as util])
-  (:import [java.time OffsetDateTime]
-           [java.util UUID]))
+  (:import [java.time OffsetDateTime]))
 
 (def clio-url (delay (env/getenv "WFL_CLIO_URL")))
 
@@ -188,7 +187,7 @@
     (clio/add-cram
      @clio-url
      (merge query tos
-            {:cromwell_id         (str (UUID/randomUUID))
+            {:cromwell_id         (str (random-uuid))
              :workflow_start_date (str (OffsetDateTime/now))}))
     (dorun (map (fn [k] (gcs/copy-object (k froms) (k tos))) (keys suffix))))
   (first (clio/query-cram @clio-url query)))

--- a/api/test/wfl/unit/executor_test.clj
+++ b/api/test/wfl/unit/executor_test.clj
@@ -3,12 +3,11 @@
             [wfl.executor         :as executor]
             [wfl.service.cromwell :as cromwell]
             [wfl.service.slack    :as slack])
-  (:import [java.util UUID]
-           [wfl.util UserException]))
+  (:import [wfl.util UserException]))
 
 (deftest test-filter-query-for-unretried-workflows
   (let [executor {:details "TerraExecutor_00000001"}
-        submission (str (UUID/randomUUID))
+        submission (str (random-uuid))
         status "Failed"
         filters {:submission submission :status status}]
     (letfn [(arg-count [sql] (-> sql frequencies (get \? 0)))]
@@ -50,7 +49,7 @@
                     "Submission ID is a required argument")
     (matches-error? (#'executor/retry-submission-validation-error "not-a-uuid")
                     "Submission ID must be a valid UUID")
-    (is (nil? (#'executor/retry-submission-validation-error (str (UUID/randomUUID))))
+    (is (nil? (#'executor/retry-submission-validation-error (str (random-uuid))))
         "No error expected when submission ID is a valid UUID")))
 
 (deftest test-retry-status-validation-error
@@ -68,9 +67,9 @@
         "No error expected for retriable Cromwell status")))
 
 (deftest test-terra-executor-throw-if-invalid-retry-filters
-  (let [workload-uuid (str (UUID/randomUUID))
+  (let [workload-uuid (str (random-uuid))
         workload {:uuid workload-uuid}
-        submission-valid (str (UUID/randomUUID))
+        submission-valid (str (random-uuid))
         submission-invalid nil
         status-valid "Failed"
         status-invalid "Running"]

--- a/api/test/wfl/unit/sink_test.clj
+++ b/api/test/wfl/unit/sink_test.clj
@@ -3,9 +3,8 @@
             [wfl.sink             :as sink]
             [wfl.tools.endpoints  :as endpoints]
             [wfl.tools.resources  :as resources]
-            [wfl.util             :refer [uuid-nil]])
-  (:import [java.util UUID]
-           [clojure.lang ExceptionInfo]))
+            [wfl.util             :as util])
+  (:import [clojure.lang ExceptionInfo]))
 
 (deftest test-rename-gather
   (let [inputs (resources/read-resource "sarscov2_illumina_full/inputs.edn")]
@@ -25,7 +24,7 @@
   (let [inputs  (resources/read-resource "sarscov2_illumina_full/inputs.edn")
         dataset (resources/read-resource "sarscov2-illumina-full-inputs.json")
         result  (#'sink/rename-gather-bulk
-                 (UUID/randomUUID) dataset "flowcell"
+                 (random-uuid) dataset "flowcell"
                  inputs {:flowcell_tgz      "flowcell_tgz"
                          :flowcell_id       "flowcell_id"
                          :sample_rename_map "sample_rename_map"})]
@@ -44,7 +43,7 @@
 
 (def ^:private datarepo-sink-request
   {:name        @#'sink/datarepo-sink-name
-   :dataset     (str uuid-nil)
+   :dataset     (str util/uuid-nil)
    :table       "tablename"
    :fromOutputs {}})
 

--- a/api/test/wfl/unit/spec_test.clj
+++ b/api/test/wfl/unit/spec_test.clj
@@ -3,21 +3,19 @@
             [clojure.test        :refer [deftest testing is]]
             [wfl.api.spec        :as spec]
             [wfl.tools.workloads :as workloads]
-            [wfl.module.all      :as all])
-  (:import [java.util UUID]))
+            [wfl.module.all      :as all]))
 
 (deftest request-spec-test
   (testing "Requests are valid"
     (letfn [(valid? [req] (is (s/valid? ::spec/workload-request req)))]
-      (run! valid? (map #(% (UUID/randomUUID))
-                        [workloads/wgs-workload-request
-                         workloads/aou-workload-request
-                         workloads/xx-workload-request])))))
+      (run! valid? (map #(% (random-uuid)) [workloads/aou-workload-request
+                                            workloads/wgs-workload-request
+                                            workloads/xx-workload-request])))))
 
 (deftest workload-query-spec-test
   (letfn [(invalid? [req] (is (not (s/valid? ::spec/workload-query req))))
           (valid? [req] (is (s/valid? ::spec/workload-query req)))]
-    (let [uuid (str (UUID/randomUUID))
+    (let [uuid    (str (random-uuid))
           project "bogus-project"]
       (testing "Workload UUID and project cannot be specified together"
         (let [request {:uuid uuid :project project}]

--- a/api/test/wfl/unit/tsv_test.clj
+++ b/api/test/wfl/unit/tsv_test.clj
@@ -5,8 +5,7 @@
             [clojure.set         :as set]
             [clojure.walk        :as walk]
             [wfl.tools.resources :as resources]
-            [wfl.tsv             :as tsv])
-  (:import [java.util UUID]))
+            [wfl.tsv             :as tsv]))
 
 (def ^:private the-edn
   "More EDN than can be represented in a Terra (.tsv) file."
@@ -82,7 +81,7 @@
 
 (deftest round-trip-file
   (testing "Round-trip THE-EDN to file.tsv and back."
-    (let [file (io/file (str (UUID/randomUUID) ".tsv"))]
+    (let [file (io/file (str (random-uuid) ".tsv"))]
       (try (is (= (-> the-edn hack-terrafy hack-unterrafy)
                   (do (-> the-edn tsv/tabulate (tsv/write-file file))
                       (-> file tsv/read-file tsv/mapulate hack-unterrafy))))


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1691

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Fixed Clio error message matching code to include bounding `"`s from Scala-=> JSON.
- Added code to reconcile `force=true` test code with `wfl.module.sg` code.
- Added test for SG/GDC `force=true` workaround that runs against the real dev Clio.
- Fixed the hack to allow a SG/GDC CRAM to be reprocessed multiple times.
- Updated Clojure to 1.11.1
- Increased polling timeouts and retries to work around flaky tests against TDR.
- `java.util.UUID/randomUUID` -=> `clojure.core/random-uuid`
- Updated dependencies to reduce build and linter noise.
- Deleted unused code.
- Removed more obscuring abstractions.
- Made a few more vars `:private`.
- Cleaned up, sorted, and added docstrings to some `ns` forms.
- Fixed format inconsistencies.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- Review new code in `api/test/wfl/integration/modules/sg_test.clj`.
- Review bug fixes in `api/src/wfl/module/sg.clj`.
- Review build and dependency changes in `api/deps.edn`.
- Review test workarounds in `api/src/wfl/util.clj` and other tweex there.
- Review changes elsewhere if you want.
- I don't like the `catch`-all in `wfl.module.sg/clio-add-bam` and welcome suggestions.
- I don't understand why the PR build fails yet: GitHub has issues.
- And now `dockstore.org` is offline. Nothing works™
- Woo hoo. The PR smoke test succeeded this morning!