### PR TITLE
[GH-1691] Deploy WFL 0.20.1 to pick up AoU and SG/GDC fixes.

### DIFF
--- a/api/deps.edn
+++ b/api/deps.edn
@@ -96,7 +96,7 @@
    :extra-paths ["test"]
    :main-opts   ["-m" "wfl.tools.parallel-runner"]}
 
-  :uberjar {:extra-deps {uberdeps/uberdeps {:mvn/version "1.1.4"}}}
+  :uberjar {:extra-deps {uberdeps/uberdeps {:mvn/version "1.0.4"}}}
 
   :prebuild {:extra-paths ["./build"] :exec-fn build/prebuild}
 

--- a/api/src/wfl/main.clj
+++ b/api/src/wfl/main.clj
@@ -4,7 +4,8 @@
             [clojure.pprint    :refer [pprint]]
             [clojure.string    :as str]
             [wfl.util          :as util]
-            [wfl.wfl           :as wfl]))
+            [wfl.wfl           :as wfl])
+  (:gen-class))
 
 (defn describe
   "Describe the purpose of this program."


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1692

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- [GH-1691] Fix the SG/GDC increment the add_bam version in Clio hack. ([#623](https://github.com/broadinstitute/wfl/pull/623))
- [Back up to uberdeps 1.0.4 because 1.1.4 doesn't work for WFL yet.](https://github.com/broadinstitute/wfl/commit/eac6b875c3c935577252719c1afec75907646bb1)

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- Note the changes over the already-merged `/tbl/release-0.20.1/` branch.
- `uberdeps/uberjar` fails silently, and none of our tests runs against the deployed jar.

[GH-1691]: https://broadinstitute.atlassian.net/browse/GH-1691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ