### PR TITLE
WM-2582: Unset dedicated ingest SA flag

### DIFF
--- a/api/test/resources/datasets/illumina-genotyping-array.json
+++ b/api/test/resources/datasets/illumina-genotyping-array.json
@@ -125,5 +125,6 @@
         }
       }
     ]
-  }
+  },
+  "dedicatedIngestServiceAccount": false
 }

--- a/api/test/resources/datasets/testing-dataset.json
+++ b/api/test/resources/datasets/testing-dataset.json
@@ -50,5 +50,6 @@
         }
       }
     ]
-  }
+  },
+  "dedicatedIngestServiceAccount": false
 }


### PR DESCRIPTION
### Purpose
Resolve CI errors by unsetting the dedicated ingest service account flag in tests.

Ticket: https://broadworkbench.atlassian.net/browse/WM-2582

